### PR TITLE
Introduce names for index fields

### DIFF
--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -139,14 +139,14 @@ fn test_proving() {
             let sm = meta.fixed_wire();
 
             meta.create_gate(|meta| {
-                let a = meta.query_advice(a, 0);
-                let b = meta.query_advice(b, 0);
-                let c = meta.query_advice(c, 0);
+                let a = meta.query_advice(a, RowOffset(0));
+                let b = meta.query_advice(b, RowOffset(0));
+                let c = meta.query_advice(c, RowOffset(0));
 
-                let sa = meta.query_fixed(sa, 0);
-                let sb = meta.query_fixed(sb, 0);
-                let sc = meta.query_fixed(sc, 0);
-                let sm = meta.query_fixed(sm, 0);
+                let sa = meta.query_fixed(sa, RowOffset(0));
+                let sb = meta.query_fixed(sb, RowOffset(0));
+                let sc = meta.query_fixed(sc, RowOffset(0));
+                let sm = meta.query_fixed(sm, RowOffset(0));
 
                 a.clone() * sa + b.clone() * sb + a * b * sm + (c * sc * (-F::one()))
             });

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -1,5 +1,7 @@
 use super::{
-    circuit::{AdviceWire, Circuit, ConstraintSystem, FixedWire, MetaCircuit, Variable, Wire},
+    circuit::{
+        AdviceWire, Circuit, ConstraintSystem, FixedWire, MetaCircuit, RowIdx, Variable, Wire,
+    },
     hash_point, Error, Proof, SRS,
 };
 use crate::arithmetic::{
@@ -43,7 +45,7 @@ impl<C: CurveAffine> Proof<C> {
             ) -> Result<(), Error> {
                 *self
                     .advice
-                    .get_mut(wire.0)
+                    .get_mut((wire.0).0)
                     .and_then(|v| v.get_mut(row))
                     .ok_or(Error::BoundsFailure)? = to()?;
 
@@ -72,10 +74,10 @@ impl<C: CurveAffine> Proof<C> {
             ) -> Result<(Variable, Variable, Variable, Variable), Error> {
                 let (a, b, c, d) = f()?;
                 let tmp = Ok((
-                    Variable(Wire::A, self.a.len()),
-                    Variable(Wire::B, self.a.len()),
-                    Variable(Wire::C, self.a.len()),
-                    Variable(Wire::D, self.a.len()),
+                    Variable(Wire::A, RowIdx(self.a.len())),
+                    Variable(Wire::B, RowIdx(self.a.len())),
+                    Variable(Wire::C, RowIdx(self.a.len())),
+                    Variable(Wire::D, RowIdx(self.a.len())),
                 ));
                 self.a.push(a);
                 self.b.push(b);

--- a/src/plonk/srs.rs
+++ b/src/plonk/srs.rs
@@ -1,5 +1,7 @@
 use super::{
-    circuit::{AdviceWire, Circuit, ConstraintSystem, FixedWire, MetaCircuit, Variable, Wire},
+    circuit::{
+        AdviceWire, Circuit, ConstraintSystem, FixedWire, MetaCircuit, RowIdx, Variable, Wire,
+    },
     domain::EvaluationDomain,
     Error, GATE_DEGREE, SRS,
 };
@@ -41,7 +43,7 @@ impl<C: CurveAffine> SRS<C> {
             ) -> Result<(), Error> {
                 *self
                     .fixed
-                    .get_mut(wire.0)
+                    .get_mut((wire.0).0)
                     .and_then(|v| v.get_mut(row))
                     .ok_or(Error::BoundsFailure)? = to()?;
 
@@ -58,10 +60,10 @@ impl<C: CurveAffine> SRS<C> {
                 _: impl Fn() -> Result<(F, F, F, F), Error>,
             ) -> Result<(Variable, Variable, Variable, Variable), Error> {
                 let tmp = Ok((
-                    Variable(Wire::A, self.sa.len()),
-                    Variable(Wire::B, self.sa.len()),
-                    Variable(Wire::C, self.sa.len()),
-                    Variable(Wire::D, self.sa.len()),
+                    Variable(Wire::A, RowIdx(self.sa.len())),
+                    Variable(Wire::B, RowIdx(self.sa.len())),
+                    Variable(Wire::C, RowIdx(self.sa.len())),
+                    Variable(Wire::D, RowIdx(self.sa.len())),
                 ));
                 self.sa.push(sa);
                 self.sb.push(sb);


### PR DESCRIPTION
We identify wires/variables by their indices relative to several different positions. To avoid conflating indices, we can introduce explicit names for each type of index:

- `RowIdx`: the row index in a `MetaCircuit`, 
- `WireIdx`: the index of a wire in a `MetaCircuit`; indexed separately for `FixedWire` and `AdviceWire`
- `RowOffset` offset of a wire query relative to a row in a `MetaCircuit` 
- `QueryIdx` the index of a query in the query `HashMap` of a `MetaCircuit`; indexed separately for `fixed_queries` and `advice_queries`