### PR TITLE
Remove fork hack from OpeningProof::create()

### DIFF
--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -578,18 +578,11 @@ impl<C: CurveAffine> Proof<C> {
                     }
                 });
             }
+            let opening = OpeningProof::create(&params, &mut transcript, &f_poly, f_blind_dup, x_6);
 
-            // Check U
-            let u_x = transcript.clone().squeeze();
-            // y^2 = x^3 + B
-            let u_y2 = u_x.square() * &u_x + &C::b();
-
-            if let Some(_) = u_y2.deterministic_sqrt() {
+            if opening.is_ok() {
                 final_q_evals = q_evals;
-                let opening =
-                    OpeningProof::create(&params, &mut transcript, &f_poly, f_blind_dup, x_6)
-                        .unwrap();
-                break opening;
+                break opening.unwrap();
             } else {
                 f_blind += C::Scalar::one();
                 f_commitment = (f_commitment + params.h).to_affine();

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -534,9 +534,7 @@ impl<C: CurveAffine> Proof<C> {
         let mut f_blind = Blind(C::Scalar::random());
         let mut f_commitment = params.commit(&f_poly, f_blind).to_affine();
 
-        let final_q_evals;
-
-        let opening = loop {
+        let (opening, q_evals) = loop {
             let mut transcript = transcript.clone();
             let mut transcript_scalar = transcript_scalar.clone();
             hash_point(&mut transcript, &f_commitment)?;
@@ -581,8 +579,7 @@ impl<C: CurveAffine> Proof<C> {
             let opening = OpeningProof::create(&params, &mut transcript, &f_poly, f_blind_dup, x_6);
 
             if opening.is_ok() {
-                final_q_evals = q_evals;
-                break opening.unwrap();
+                break (opening.unwrap(), q_evals);
             } else {
                 f_blind += C::Scalar::one();
                 f_commitment = (f_commitment + params.h).to_affine();
@@ -600,7 +597,7 @@ impl<C: CurveAffine> Proof<C> {
             fixed_evals,
             h_evals,
             f_commitment,
-            q_evals: final_q_evals,
+            q_evals,
             opening,
         })
     }

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -19,6 +19,8 @@ pub use domain::*;
 pub enum Error {
     /// OpeningProof is not well-formed
     OpeningError,
+    /// Caller needs to re-sample a point
+    SamplingError,
 }
 
 /// The basis over which a polynomial is described.

--- a/src/poly/commitment.rs
+++ b/src/poly/commitment.rs
@@ -16,7 +16,6 @@ mod verifier;
 /// This is a proof object for the polynomial commitment scheme opening.
 #[derive(Debug, Clone)]
 pub struct OpeningProof<C: CurveAffine> {
-    fork: u8,
     rounds: Vec<(C, C)>,
     delta: C,
     z1: C::Scalar,

--- a/src/poly/commitment/verifier.rs
+++ b/src/poly/commitment/verifier.rs
@@ -22,8 +22,6 @@ impl<C: CurveAffine> OpeningProof<C> {
             return Err(Error::OpeningError);
         }
 
-        transcript.absorb(C::Base::from_u64(self.fork as u64));
-
         // Compute U
         let u = {
             let u_x = transcript.squeeze();


### PR DESCRIPTION
Add loop in PLONK prover to repeatedly call `OpeningProof::create()`, each time incrementing blinding factor `f_blind`, until correct value is sampled.

Closes #8