### PR TITLE
Faux blinded accumulator

### DIFF
--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -375,7 +375,7 @@ fn test_proving() {
     pubinputs[0] = Fp::one();
     pubinputs[0] += Fp::one();
     let pubinput = params
-        .commit_lagrange(&pubinputs, Blind(Field::one()))
+        .commit_lagrange(&pubinputs, Blind::default())
         .to_affine();
 
     for _ in 0..100 {

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -375,7 +375,7 @@ fn test_proving() {
     pubinputs[0] = Fp::one();
     pubinputs[0] += Fp::one();
     let pubinput = params
-        .commit_lagrange(&pubinputs, Blind(Field::zero()))
+        .commit_lagrange(&pubinputs, Blind(Field::one()))
         .to_affine();
 
     for _ in 0..100 {

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -96,7 +96,7 @@ impl<C: CurveAffine> Proof<C> {
         // Compute commitments to aux wire polynomials
         let aux_commitments_projective: Vec<_> = aux
             .iter()
-            .map(|poly| params.commit_lagrange(poly, Blind(C::Scalar::zero()))) // TODO: bad blind?
+            .map(|poly| params.commit_lagrange(poly, Blind::default()))
             .collect();
         let mut aux_commitments = vec![C::zero(); aux_commitments_projective.len()];
         C::Projective::batch_to_affine(&aux_commitments_projective, &mut aux_commitments);
@@ -501,7 +501,7 @@ impl<C: CurveAffine> Proof<C> {
                 accumulate(
                     point_index,
                     &aux_polys[wire.0],
-                    Blind(C::Scalar::zero()),
+                    Blind::default(),
                     aux_evals[query_index],
                 );
             }

--- a/src/poly/commitment.rs
+++ b/src/poly/commitment.rs
@@ -4,14 +4,14 @@
 //! [halo]: https://eprint.iacr.org/2019/1021
 
 use super::{Coeff, LagrangeCoeff, Polynomial};
-use crate::arithmetic::{
-    best_fft, best_multiexp, parallelize, Challenge, Curve, CurveAffine, Field,
-};
+use crate::arithmetic::{best_fft, best_multiexp, parallelize, Curve, CurveAffine, Field};
 use crate::transcript::Hasher;
 use std::ops::{Add, AddAssign, Mul, MulAssign};
 
 mod prover;
 mod verifier;
+
+pub use verifier::{Accumulator, Guard};
 
 /// This is a proof object for the polynomial commitment scheme opening.
 #[derive(Debug, Clone)]
@@ -20,17 +20,6 @@ pub struct Proof<C: CurveAffine> {
     delta: C,
     z1: C::Scalar,
     z2: C::Scalar,
-}
-
-/// An accumulator instance consisting of an evaluation claim and a proof.
-#[derive(Debug, Clone)]
-pub struct Accumulator<C: CurveAffine> {
-    /// The claimed output of the linear-time polycommit opening protocol
-    pub g: C,
-
-    /// A vector of 128-bit challenges sampled by the verifier, to be used in
-    /// computing g.
-    pub challenges_sq_packed: Vec<Challenge>,
 }
 
 /// A multiscalar multiplication in the polynomial commitment scheme
@@ -281,46 +270,6 @@ impl<C: CurveAffine> Params<C> {
     }
 }
 
-/// A guard returned by the verifier
-#[derive(Debug, Clone)]
-pub struct Guard<'a, C: CurveAffine> {
-    msm: MSM<'a, C>,
-    neg_z1: C::Scalar,
-    allinv: C::Scalar,
-    challenges_sq: Vec<C::Scalar>,
-    challenges_sq_packed: Vec<Challenge>,
-}
-
-impl<'a, C: CurveAffine> Guard<'a, C> {
-    /// Lets caller supply the challenges and obtain an MSM with updated
-    /// scalars and points.
-    pub fn use_challenges(mut self) -> MSM<'a, C> {
-        let s = compute_s(&self.challenges_sq, self.allinv * &self.neg_z1);
-        self.msm.add_to_g(&s);
-
-        self.msm
-    }
-
-    /// Lets caller supply the purported G point and simply appends it to
-    /// return an updated MSM.
-    pub fn use_g(mut self, g: C) -> (MSM<'a, C>, Accumulator<C>) {
-        self.msm.add_term(self.neg_z1, g);
-
-        let accumulator = Accumulator {
-            g,
-            challenges_sq_packed: self.challenges_sq_packed,
-        };
-
-        (self.msm, accumulator)
-    }
-
-    /// Computes the g value when given a potential scalar as input.
-    pub fn compute_g(&self) -> C {
-        let s = compute_s(&self.challenges_sq, self.allinv);
-        best_multiexp(&s, &self.msm.params.g).to_affine()
-    }
-}
-
 /// Wrapper type around a blinding factor.
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct Blind<F>(pub F);
@@ -493,21 +442,4 @@ fn test_opening_proof() {
             break;
         }
     }
-}
-
-// TODO: parallelize
-fn compute_s<F: Field>(challenges_sq: &[F], allinv: F) -> Vec<F> {
-    let lg_n = challenges_sq.len();
-    let n = 1 << lg_n;
-
-    let mut s = Vec::with_capacity(n);
-    s.push(allinv);
-    for i in 1..n {
-        let lg_i = (32 - 1 - (i as u32).leading_zeros()) as usize;
-        let k = 1 << lg_i;
-        let u_lg_i_sq = challenges_sq[(lg_n - 1) - lg_i];
-        s.push(s[i - k] * u_lg_i_sq);
-    }
-
-    s
 }

--- a/src/poly/commitment/verifier.rs
+++ b/src/poly/commitment/verifier.rs
@@ -1,5 +1,5 @@
 use super::super::Error;
-use super::{Proof, Params, MSM};
+use super::{Params, Proof, MSM};
 use crate::transcript::Hasher;
 
 use crate::arithmetic::{


### PR DESCRIPTION
This makes it so that the G element in the accumulator actually contains an H term from the parameters, which means we can make it so that aux wires in PLONK also contain this blind. This is to be consistent with fixed wires, which we "faux blind" to avoid points at infinity during recursive verification.

Closes #25