### PR TITLE
Remove redundancy in type parameters.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Ying Tong Lai <yingtong@electriccoin.co>",
+    "Daira Hopwood <daira@electriccoin.co>",
 ]
 edition = "2018"
 description = """

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -29,7 +29,7 @@ pub struct VerifyingKey<C: CurveAffine> {
     domain: EvaluationDomain<C::Scalar>,
     fixed_commitments: Vec<C>,
     permutation_commitments: Vec<Vec<C>>,
-    cs: ConstraintSystem<C, C::Scalar>,
+    cs: ConstraintSystem<C>,
 }
 
 /// This is a proving key which allows for the creation of proofs for a

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -15,7 +15,7 @@ pub fn keygen<C, ConcreteCircuit>(
 ) -> Result<ProvingKey<C>, Error>
 where
     C: CurveAffine,
-    ConcreteCircuit: Circuit<C, C::Scalar>,
+    ConcreteCircuit: Circuit<C>,
 {
     struct Assembly<F: Field> {
         fixed: Vec<Polynomial<F, LagrangeCoeff>>,

--- a/src/plonk/lookup/verifier.rs
+++ b/src/plonk/lookup/verifier.rs
@@ -5,7 +5,7 @@ use crate::arithmetic::{CurveAffine, Field};
 impl<C: CurveAffine> Proof<C> {
     pub fn check_lookup_constraints(
         &self,
-        cs: &ConstraintSystem<C, C::Scalar>,
+        cs: &ConstraintSystem<C>,
         beta: C::Scalar,
         gamma: C::Scalar,
         theta: C::Scalar,

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -20,7 +20,7 @@ impl<C: CurveAffine> Proof<C> {
     pub fn create<
         HBase: Hasher<C::Base>,
         HScalar: Hasher<C::Scalar>,
-        ConcreteCircuit: Circuit<C, C::Scalar>,
+        ConcreteCircuit: Circuit<C>,
     >(
         params: &Params<C>,
         pk: &ProvingKey<C>,


### PR DESCRIPTION
Signed-off-by: Daira Hopwood <daira@jacaranda.org>