### PR TITLE
Introduce Column struct and ColumnType trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Ying Tong Lai <yingtong@electriccoin.co>",
+    "Daira Hopwood <daira@electriccoin.co>",
 ]
 edition = "2018"
 description = """

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -117,25 +117,25 @@ fn test_proving() {
     use std::marker::PhantomData;
     const K: u32 = 5;
 
-    /// This represents an advice wire at a certain row in the ConstraintSystem
+    /// This represents an advice column at a certain row in the ConstraintSystem
     #[derive(Copy, Clone, Debug)]
-    pub struct Variable(AdviceWire, usize);
+    pub struct Variable(AdviceColumn, usize);
 
     // Initialize the polynomial commitment parameters
     let params: Params<EqAffine> = Params::new::<DummyHash<Fq>>(K);
 
     struct PLONKConfig {
-        a: AdviceWire,
-        b: AdviceWire,
-        c: AdviceWire,
-        d: AdviceWire,
-        e: AdviceWire,
+        a: AdviceColumn,
+        b: AdviceColumn,
+        c: AdviceColumn,
+        d: AdviceColumn,
+        e: AdviceColumn,
 
-        sa: FixedWire,
-        sb: FixedWire,
-        sc: FixedWire,
-        sm: FixedWire,
-        sp: FixedWire,
+        sa: FixedColumn,
+        sb: FixedColumn,
+        sc: FixedColumn,
+        sm: FixedColumn,
+        sp: FixedColumn,
 
         perm: usize,
         perm2: usize,
@@ -254,13 +254,13 @@ fn test_proving() {
             ))
         }
         fn copy(&mut self, left: Variable, right: Variable) -> Result<(), Error> {
-            let left_wire = match left.0 {
+            let left_column = match left.0 {
                 x if x == self.config.a => 0,
                 x if x == self.config.b => 1,
                 x if x == self.config.c => 2,
                 _ => unreachable!(),
             };
-            let right_wire = match right.0 {
+            let right_column = match right.0 {
                 x if x == self.config.a => 0,
                 x if x == self.config.b => 1,
                 x if x == self.config.c => 2,
@@ -268,9 +268,14 @@ fn test_proving() {
             };
 
             self.cs
-                .copy(self.config.perm, left_wire, left.1, right_wire, right.1)?;
-            self.cs
-                .copy(self.config.perm2, left_wire, left.1, right_wire, right.1)
+                .copy(self.config.perm, left_column, left.1, right_column, right.1)?;
+            self.cs.copy(
+                self.config.perm2,
+                left_column,
+                left.1,
+                right_column,
+                right.1,
+            )
         }
         fn public_input<F>(&mut self, f: F) -> Result<Variable, Error>
         where
@@ -290,22 +295,22 @@ fn test_proving() {
         type Config = PLONKConfig;
 
         fn configure(meta: &mut ConstraintSystem<F>) -> PLONKConfig {
-            let e = meta.advice_wire();
-            let a = meta.advice_wire();
-            let b = meta.advice_wire();
-            let sf = meta.fixed_wire();
-            let c = meta.advice_wire();
-            let d = meta.advice_wire();
-            let p = meta.aux_wire();
+            let e = meta.advice_column();
+            let a = meta.advice_column();
+            let b = meta.advice_column();
+            let sf = meta.fixed_column();
+            let c = meta.advice_column();
+            let d = meta.advice_column();
+            let p = meta.aux_column();
 
             let perm = meta.permutation(&[a, b, c]);
             let perm2 = meta.permutation(&[a, b, c]);
 
-            let sm = meta.fixed_wire();
-            let sa = meta.fixed_wire();
-            let sb = meta.fixed_wire();
-            let sc = meta.fixed_wire();
-            let sp = meta.fixed_wire();
+            let sm = meta.fixed_column();
+            let sa = meta.fixed_column();
+            let sb = meta.fixed_column();
+            let sc = meta.fixed_column();
+            let sp = meta.fixed_column();
 
             meta.create_gate(|meta| {
                 let d = meta.query_advice(d, 1);

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -114,28 +114,29 @@ fn test_proving() {
     use crate::arithmetic::{Curve, EqAffine, Field, Fp, Fq};
     use crate::poly::commitment::{Blind, Params};
     use crate::transcript::DummyHash;
+    use circuit::{Advice, Column, Fixed};
     use std::marker::PhantomData;
     const K: u32 = 5;
 
     /// This represents an advice column at a certain row in the ConstraintSystem
     #[derive(Copy, Clone, Debug)]
-    pub struct Variable(AdviceColumn, usize);
+    pub struct Variable(Column<Advice>, usize);
 
     // Initialize the polynomial commitment parameters
     let params: Params<EqAffine> = Params::new::<DummyHash<Fq>>(K);
 
     struct PLONKConfig {
-        a: AdviceColumn,
-        b: AdviceColumn,
-        c: AdviceColumn,
-        d: AdviceColumn,
-        e: AdviceColumn,
+        a: Column<Advice>,
+        b: Column<Advice>,
+        c: Column<Advice>,
+        d: Column<Advice>,
+        e: Column<Advice>,
 
-        sa: FixedColumn,
-        sb: FixedColumn,
-        sc: FixedColumn,
-        sm: FixedColumn,
-        sp: FixedColumn,
+        sa: Column<Fixed>,
+        sb: Column<Fixed>,
+        sc: Column<Fixed>,
+        sm: Column<Fixed>,
+        sp: Column<Fixed>,
 
         perm: usize,
         perm2: usize,

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -399,6 +399,17 @@ impl<F: Field> ConstraintSystem<F> {
         index
     }
 
+    /// Query an Any column at a relative position
+    fn query_any_index(&mut self, column: Column<Any>, at: i32) -> usize {
+        let index = match column.column_type {
+            Any::Advice => self.query_advice_index(Column::<Advice>::from(column), at),
+            Any::Fixed => self.query_fixed_index(Column::<Fixed>::from(column), at),
+            Any::Aux => self.query_aux_index(Column::<Aux>::from(column), at),
+        };
+
+        index
+    }
+
     /// Query an auxiliary column at a relative position
     pub fn query_aux(&mut self, column: Column<Aux>, at: i32) -> Expression<F> {
         Expression::Aux(self.query_aux_index(column, at))
@@ -412,7 +423,7 @@ impl<F: Field> ConstraintSystem<F> {
             }
         }
 
-        panic!("get_advice_query_index called for non-existant query");
+        panic!("get_advice_query_index called for non-existent query");
     }
 
     pub(crate) fn get_fixed_query_index(&self, column: Column<Fixed>, at: i32) -> usize {
@@ -424,6 +435,27 @@ impl<F: Field> ConstraintSystem<F> {
         }
 
         panic!("get_fixed_query_index called for non-existent query");
+    }
+
+    pub(crate) fn get_aux_query_index(&self, column: Column<Aux>, at: i32) -> usize {
+        let at = Rotation(at);
+        for (index, aux_query) in self.aux_queries.iter().enumerate() {
+            if aux_query == &(column, at) {
+                return index;
+            }
+        }
+
+        panic!("get_aux_query_index called for non-existent query");
+    }
+
+    pub(crate) fn get_any_query_index(&self, column: Column<Any>, at: i32) -> usize {
+        let index = match column.column_type {
+            Any::Advice => self.get_advice_query_index(Column::<Advice>::from(column), at),
+            Any::Fixed => self.get_fixed_query_index(Column::<Fixed>::from(column), at),
+            Any::Aux => self.get_aux_query_index(Column::<Aux>::from(column), at),
+        };
+
+        index
     }
 
     /// Create a new gate

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -87,12 +87,10 @@ impl TryFrom<Column<Any>> for Column<Advice> {
 
     fn try_from(any: Column<Any>) -> Result<Self, Self::Error> {
         match any.column_type() {
-            Any::Advice => {
-                return Ok(Column {
-                    index: any.index(),
-                    column_type: Advice,
-                })
-            }
+            Any::Advice => Ok(Column {
+                index: any.index(),
+                column_type: Advice,
+            }),
             _ => Err("Cannot convert into Column<Advice>"),
         }
     }
@@ -103,12 +101,10 @@ impl TryFrom<Column<Any>> for Column<Fixed> {
 
     fn try_from(any: Column<Any>) -> Result<Self, Self::Error> {
         match any.column_type() {
-            Any::Fixed => {
-                return Ok(Column {
-                    index: any.index(),
-                    column_type: Fixed,
-                })
-            }
+            Any::Fixed => Ok(Column {
+                index: any.index(),
+                column_type: Fixed,
+            }),
             _ => Err("Cannot convert into Column<Fixed>"),
         }
     }
@@ -119,12 +115,10 @@ impl TryFrom<Column<Any>> for Column<Aux> {
 
     fn try_from(any: Column<Any>) -> Result<Self, Self::Error> {
         match any.column_type() {
-            Any::Aux => {
-                return Ok(Column {
-                    index: any.index(),
-                    column_type: Aux,
-                })
-            }
+            Any::Aux => Ok(Column {
+                index: any.index(),
+                column_type: Aux,
+            }),
             _ => Err("Cannot convert into Column<Aux>"),
         }
     }
@@ -495,7 +489,7 @@ impl<F: Field> ConstraintSystem<F> {
     }
 
     pub(crate) fn get_any_query_index(&self, column: Column<Any>, at: i32) -> usize {
-        let index = match column.column_type() {
+        match column.column_type() {
             Any::Advice => {
                 self.get_advice_query_index(Column::<Advice>::try_from(column).unwrap(), at)
             }
@@ -503,9 +497,7 @@ impl<F: Field> ConstraintSystem<F> {
                 self.get_fixed_query_index(Column::<Fixed>::try_from(column).unwrap(), at)
             }
             Any::Aux => self.get_aux_query_index(Column::<Aux>::try_from(column).unwrap(), at),
-        };
-
-        index
+        }
     }
 
     /// Create a new gate

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -1,5 +1,5 @@
 use super::{
-    circuit::{AdviceColumn, Assignment, Circuit, ConstraintSystem, FixedColumn},
+    circuit::{Advice, Assignment, Circuit, Column, ConstraintSystem, Fixed},
     Error, ProvingKey, VerifyingKey,
 };
 use crate::arithmetic::{Curve, CurveAffine, Field};
@@ -28,7 +28,7 @@ where
     impl<F: Field> Assignment<F> for Assembly<F> {
         fn assign_advice(
             &mut self,
-            _: AdviceColumn,
+            _: Column<Advice>,
             _: usize,
             _: impl FnOnce() -> Result<F, Error>,
         ) -> Result<(), Error> {
@@ -38,13 +38,13 @@ where
 
         fn assign_fixed(
             &mut self,
-            column: FixedColumn,
+            column: Column<Fixed>,
             row: usize,
             to: impl FnOnce() -> Result<F, Error>,
         ) -> Result<(), Error> {
             *self
                 .fixed
-                .get_mut(column.0)
+                .get_mut(column.index)
                 .and_then(|v| v.get_mut(row))
                 .ok_or(Error::BoundsFailure)? = to()?;
 
@@ -230,7 +230,7 @@ where
         .fixed_queries
         .iter()
         .map(|&(column, at)| {
-            let poly = fixed_polys[column.0].clone();
+            let poly = fixed_polys[column.index].clone();
             domain.coeff_to_extended(poly, at)
         })
         .collect();

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -44,7 +44,7 @@ where
         ) -> Result<(), Error> {
             *self
                 .fixed
-                .get_mut(column.index)
+                .get_mut(column.index())
                 .and_then(|v| v.get_mut(row))
                 .ok_or(Error::BoundsFailure)? = to()?;
 
@@ -230,7 +230,7 @@ where
         .fixed_queries
         .iter()
         .map(|&(column, at)| {
-            let poly = fixed_polys[column.index].clone();
+            let poly = fixed_polys[column.index()].clone();
             domain.coeff_to_extended(poly, at)
         })
         .collect();

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -1,5 +1,5 @@
 use super::{
-    circuit::{AdviceWire, Assignment, Circuit, ConstraintSystem, FixedWire},
+    circuit::{AdviceColumn, Assignment, Circuit, ConstraintSystem, FixedColumn},
     Error, ProvingKey, VerifyingKey,
 };
 use crate::arithmetic::{Curve, CurveAffine, Field};
@@ -28,23 +28,23 @@ where
     impl<F: Field> Assignment<F> for Assembly<F> {
         fn assign_advice(
             &mut self,
-            _: AdviceWire,
+            _: AdviceColumn,
             _: usize,
             _: impl FnOnce() -> Result<F, Error>,
         ) -> Result<(), Error> {
-            // We only care about fixed wires here
+            // We only care about fixed columns here
             Ok(())
         }
 
         fn assign_fixed(
             &mut self,
-            wire: FixedWire,
+            column: FixedColumn,
             row: usize,
             to: impl FnOnce() -> Result<F, Error>,
         ) -> Result<(), Error> {
             *self
                 .fixed
-                .get_mut(wire.0)
+                .get_mut(column.0)
                 .and_then(|v| v.get_mut(row))
                 .ok_or(Error::BoundsFailure)? = to()?;
 
@@ -54,23 +54,23 @@ where
         fn copy(
             &mut self,
             permutation: usize,
-            left_wire: usize,
+            left_column: usize,
             left_row: usize,
-            right_wire: usize,
+            right_column: usize,
             right_row: usize,
         ) -> Result<(), Error> {
             // Check bounds first
             if permutation >= self.mapping.len()
-                || left_wire >= self.mapping[permutation].len()
-                || left_row >= self.mapping[permutation][left_wire].len()
-                || right_wire >= self.mapping[permutation].len()
-                || right_row >= self.mapping[permutation][right_wire].len()
+                || left_column >= self.mapping[permutation].len()
+                || left_row >= self.mapping[permutation][left_column].len()
+                || right_column >= self.mapping[permutation].len()
+                || right_row >= self.mapping[permutation][right_column].len()
             {
                 return Err(Error::BoundsFailure);
             }
 
-            let mut left_cycle = self.aux[permutation][left_wire][left_row];
-            let mut right_cycle = self.aux[permutation][right_wire][right_row];
+            let mut left_cycle = self.aux[permutation][left_column][left_row];
+            let mut right_cycle = self.aux[permutation][right_column][right_row];
 
             if left_cycle == right_cycle {
                 return Ok(());
@@ -93,10 +93,10 @@ where
                 }
             }
 
-            let tmp = self.mapping[permutation][left_wire][left_row];
-            self.mapping[permutation][left_wire][left_row] =
-                self.mapping[permutation][right_wire][right_row];
-            self.mapping[permutation][right_wire][right_row] = tmp;
+            let tmp = self.mapping[permutation][left_column][left_row];
+            self.mapping[permutation][left_column][left_row] =
+                self.mapping[permutation][right_column][right_row];
+            self.mapping[permutation][right_column][right_row] = tmp;
 
             Ok(())
         }
@@ -106,7 +106,7 @@ where
     let config = ConcreteCircuit::configure(&mut cs);
 
     // Get the largest permutation argument length in terms of the number of
-    // advice wires involved.
+    // advice columns involved.
     let mut largest_permutation_length = 0;
     for permutation in &cs.permutations {
         largest_permutation_length = std::cmp::max(permutation.len(), largest_permutation_length);
@@ -151,7 +151,7 @@ where
     }
 
     let mut assembly: Assembly<C::Scalar> = Assembly {
-        fixed: vec![domain.empty_lagrange(); cs.num_fixed_wires],
+        fixed: vec![domain.empty_lagrange(); cs.num_fixed_columns],
         mapping: vec![],
         aux: vec![],
         sizes: vec![],
@@ -161,13 +161,13 @@ where
     // Initialize the copy vector to keep track of copy constraints in all
     // the permutation arguments.
     for permutation in &cs.permutations {
-        let mut wires = vec![];
+        let mut columns = vec![];
         for i in 0..permutation.len() {
             // Computes [(i, 0), (i, 1), ..., (i, n - 1)]
-            wires.push((0..params.n).map(|j| (i, j as usize)).collect());
+            columns.push((0..params.n).map(|j| (i, j as usize)).collect());
         }
-        assembly.mapping.push(wires.clone());
-        assembly.aux.push(wires);
+        assembly.mapping.push(columns.clone());
+        assembly.aux.push(columns);
         assembly
             .sizes
             .push(vec![vec![1usize; params.n as usize]; permutation.len()]);
@@ -229,8 +229,8 @@ where
     let fixed_cosets = cs
         .fixed_queries
         .iter()
-        .map(|&(wire, at)| {
-            let poly = fixed_polys[wire.0].clone();
+        .map(|&(column, at)| {
+            let poly = fixed_polys[column.0].clone();
             domain.coeff_to_extended(poly, at)
         })
         .collect();

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -45,7 +45,7 @@ impl<C: CurveAffine> Proof<C> {
             ) -> Result<(), Error> {
                 *self
                     .advice
-                    .get_mut(column.index)
+                    .get_mut(column.index())
                     .and_then(|v| v.get_mut(row))
                     .ok_or(Error::BoundsFailure)? = to()?;
 
@@ -120,7 +120,7 @@ impl<C: CurveAffine> Proof<C> {
             .aux_queries
             .iter()
             .map(|&(column, at)| {
-                let poly = aux_polys[column.index].clone();
+                let poly = aux_polys[column.index()].clone();
                 domain.coeff_to_extended(poly, at)
             })
             .collect();
@@ -157,7 +157,7 @@ impl<C: CurveAffine> Proof<C> {
             .advice_queries
             .iter()
             .map(|&(column, at)| {
-                let poly = advice_polys[column.index].clone();
+                let poly = advice_polys[column.index()].clone();
                 domain.coeff_to_extended(poly, at)
             })
             .collect();
@@ -192,7 +192,7 @@ impl<C: CurveAffine> Proof<C> {
                 parallelize(&mut modified_advice, |modified_advice, start| {
                     for ((modified_advice, advice_value), permuted_advice_value) in modified_advice
                         .iter_mut()
-                        .zip(witness.advice[column.index][start..].iter())
+                        .zip(witness.advice[column.index()][start..].iter())
                         .zip(permuted_column_values[start..].iter())
                     {
                         *modified_advice *= &(x_0 * permuted_advice_value + &x_1 + advice_value);
@@ -226,7 +226,7 @@ impl<C: CurveAffine> Proof<C> {
                     let mut deltaomega = deltaomega * &omega.pow_vartime(&[start as u64, 0, 0, 0]);
                     for (modified_advice, advice_value) in modified_advice
                         .iter_mut()
-                        .zip(witness.advice[column.index][start..].iter())
+                        .zip(witness.advice[column.index()][start..].iter())
                     {
                         // Multiply by p_j(\omega^i) + \delta^j \omega^i \beta
                         *modified_advice *= &(deltaomega * &x_0 + &x_1 + advice_value);
@@ -395,7 +395,7 @@ impl<C: CurveAffine> Proof<C> {
             .advice_queries
             .iter()
             .map(|&(column, at)| {
-                eval_polynomial(&advice_polys[column.index], domain.rotate_omega(x_3, at))
+                eval_polynomial(&advice_polys[column.index()], domain.rotate_omega(x_3, at))
             })
             .collect();
 
@@ -403,7 +403,7 @@ impl<C: CurveAffine> Proof<C> {
             .aux_queries
             .iter()
             .map(|&(column, at)| {
-                eval_polynomial(&aux_polys[column.index], domain.rotate_omega(x_3, at))
+                eval_polynomial(&aux_polys[column.index()], domain.rotate_omega(x_3, at))
             })
             .collect();
 
@@ -411,7 +411,10 @@ impl<C: CurveAffine> Proof<C> {
             .fixed_queries
             .iter()
             .map(|&(column, at)| {
-                eval_polynomial(&pk.fixed_polys[column.index], domain.rotate_omega(x_3, at))
+                eval_polynomial(
+                    &pk.fixed_polys[column.index()],
+                    domain.rotate_omega(x_3, at),
+                )
             })
             .collect();
 
@@ -469,8 +472,8 @@ impl<C: CurveAffine> Proof<C> {
 
             instances.push(ProverQuery {
                 point,
-                poly: &advice_polys[column.index],
-                blind: advice_blinds[column.index],
+                poly: &advice_polys[column.index()],
+                blind: advice_blinds[column.index()],
                 eval: advice_evals[query_index],
             });
         }
@@ -480,7 +483,7 @@ impl<C: CurveAffine> Proof<C> {
 
             instances.push(ProverQuery {
                 point,
-                poly: &aux_polys[column.index],
+                poly: &aux_polys[column.index()],
                 blind: Blind::default(),
                 eval: aux_evals[query_index],
             });
@@ -491,7 +494,7 @@ impl<C: CurveAffine> Proof<C> {
 
             instances.push(ProverQuery {
                 point,
-                poly: &pk.fixed_polys[column.index],
+                poly: &pk.fixed_polys[column.index()],
                 blind: Blind::default(),
                 eval: fixed_evals[query_index],
             });

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -93,7 +93,7 @@ impl<'a, C: CurveAffine> Proof<C> {
             let point = vk.domain.rotate_omega(x_3, at);
             queries.push(VerifierQuery {
                 point,
-                commitment: &self.advice_commitments[column.0],
+                commitment: &self.advice_commitments[column.index],
                 eval: self.advice_evals[query_index],
             });
         }
@@ -102,7 +102,7 @@ impl<'a, C: CurveAffine> Proof<C> {
             let point = vk.domain.rotate_omega(x_3, at);
             queries.push(VerifierQuery {
                 point,
-                commitment: &aux_commitments[column.0],
+                commitment: &aux_commitments[column.index],
                 eval: self.aux_evals[query_index],
             });
         }
@@ -111,7 +111,7 @@ impl<'a, C: CurveAffine> Proof<C> {
             let point = vk.domain.rotate_omega(x_3, at);
             queries.push(VerifierQuery {
                 point,
-                commitment: &vk.fixed_commitments[column.0],
+                commitment: &vk.fixed_commitments[column.index],
                 eval: self.fixed_evals[query_index],
             });
         }

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -93,7 +93,7 @@ impl<'a, C: CurveAffine> Proof<C> {
             let point = vk.domain.rotate_omega(x_3, at);
             queries.push(VerifierQuery {
                 point,
-                commitment: &self.advice_commitments[column.index],
+                commitment: &self.advice_commitments[column.index()],
                 eval: self.advice_evals[query_index],
             });
         }
@@ -102,7 +102,7 @@ impl<'a, C: CurveAffine> Proof<C> {
             let point = vk.domain.rotate_omega(x_3, at);
             queries.push(VerifierQuery {
                 point,
-                commitment: &aux_commitments[column.index],
+                commitment: &aux_commitments[column.index()],
                 eval: self.aux_evals[query_index],
             });
         }
@@ -111,7 +111,7 @@ impl<'a, C: CurveAffine> Proof<C> {
             let point = vk.domain.rotate_omega(x_3, at);
             queries.push(VerifierQuery {
                 point,
-                commitment: &vk.fixed_commitments[column.index],
+                commitment: &vk.fixed_commitments[column.index()],
                 eval: self.fixed_evals[query_index],
             });
         }


### PR DESCRIPTION
The `Column` struct is generic over any type which implements the `ColumnType` trait.

The `ColumnType` trait is implemented for `Advice`, `Fixed`, and `Aux` structs, and the `Any` enum (which has `Advice`, `Fixed`, `Aux` variants).