### PR TITLE
Use latest stable Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: stable
           override: true
       - name: Run tests
         uses: actions-rs/cargo@v1
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: stable
           override: true
       # Build benchmarks to prevent bitrot
       - name: Build benchmarks
@@ -42,7 +42,7 @@ jobs:
           args: --all --benches --all-features
 
   clippy:
-    name: Clippy (1.45.2)
+    name: Clippy (stable)
     timeout-minutes: 30
     runs-on: ubuntu-latest
 
@@ -50,13 +50,13 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.45.2
+          toolchain: stable
           components: clippy
           override: true
       - name: Run clippy
         uses: actions-rs/clippy-check@v1
         with:
-          name: Clippy (1.45.2)
+          name: Clippy (stable)
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,6 @@ harness = false
 [dependencies]
 subtle = "2.2.1"
 crossbeam-utils = "0.7"
-metrics = "0.13.0-alpha.8"
+metrics = "=0.13.0-alpha.11"
 num_cpus = "1.13"
 rand = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
     clippy::many_single_char_names,
     clippy::same_item_push
 )]
-#![deny(intra_doc_link_resolution_failure)]
+#![deny(broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -49,13 +49,13 @@ impl fmt::Display for ModelRecorder {
 
         counters.sort_by(|(k1, _), (k2, _)| {
             let key1 = (
-                k1.name(),
+                k1.name().to_string(),
                 k1.labels()
                     .map(|l| (l.key(), l.value()))
                     .collect::<Vec<_>>(),
             );
             let key2 = (
-                k2.name(),
+                k2.name().to_string(),
                 k2.labels()
                     .map(|l| (l.key(), l.value()))
                     .collect::<Vec<_>>(),


### PR DESCRIPTION
We don't need to commit to an MSRV yet, and this avoids the problem
where some of our in-flux dependencies bump their MSRV (or don't have
a defined MSRV and make changes to use more recent features) causing
our CI to break.