### PR TITLE
Remove rotations from ConstraintSystem & use Rotation instead of i32 for circuit methods.

### DIFF
--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -5,7 +5,7 @@ extern crate halo2;
 use halo2::arithmetic::FieldExt;
 use halo2::pasta::{EqAffine, Fp, Fq};
 use halo2::plonk::*;
-use halo2::poly::commitment::Params;
+use halo2::poly::{commitment::Params, Rotation};
 use halo2::transcript::{DummyHashRead, DummyHashWrite};
 
 use std::marker::PhantomData;
@@ -166,14 +166,14 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
             let sc = meta.fixed_column();
 
             meta.create_gate(|meta| {
-                let a = meta.query_advice(a, 0);
-                let b = meta.query_advice(b, 0);
-                let c = meta.query_advice(c, 0);
+                let a = meta.query_advice(a, Rotation::cur());
+                let b = meta.query_advice(b, Rotation::cur());
+                let c = meta.query_advice(c, Rotation::cur());
 
-                let sa = meta.query_fixed(sa, 0);
-                let sb = meta.query_fixed(sb, 0);
-                let sc = meta.query_fixed(sc, 0);
-                let sm = meta.query_fixed(sm, 0);
+                let sa = meta.query_fixed(sa, Rotation::cur());
+                let sb = meta.query_fixed(sb, Rotation::cur());
+                let sc = meta.query_fixed(sc, Rotation::cur());
+                let sm = meta.query_fixed(sm, Rotation::cur());
 
                 a.clone() * sa + b.clone() * sb + a * b * sm + (c * sc * (-F::one()))
             });

--- a/examples/performance_model.rs
+++ b/examples/performance_model.rs
@@ -3,7 +3,10 @@ use halo2::{
     model::ModelRecorder,
     pasta::{EqAffine, Fp, Fq},
     plonk::*,
-    poly::commitment::{Blind, Params},
+    poly::{
+        commitment::{Blind, Params},
+        Rotation,
+    },
     transcript::{DummyHashRead, DummyHashWrite},
 };
 
@@ -177,22 +180,22 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
         let sp = meta.fixed_column();
 
         meta.create_gate(|meta| {
-            let a = meta.query_advice(a, 0);
-            let b = meta.query_advice(b, 0);
-            let c = meta.query_advice(c, 0);
+            let a = meta.query_advice(a, Rotation::cur());
+            let b = meta.query_advice(b, Rotation::cur());
+            let c = meta.query_advice(c, Rotation::cur());
 
-            let sa = meta.query_fixed(sa, 0);
-            let sb = meta.query_fixed(sb, 0);
-            let sc = meta.query_fixed(sc, 0);
-            let sm = meta.query_fixed(sm, 0);
+            let sa = meta.query_fixed(sa, Rotation::cur());
+            let sb = meta.query_fixed(sb, Rotation::cur());
+            let sc = meta.query_fixed(sc, Rotation::cur());
+            let sm = meta.query_fixed(sm, Rotation::cur());
 
             a.clone() * sa + b.clone() * sb + a * b * sm + (c * sc * (-F::one()))
         });
 
         meta.create_gate(|meta| {
-            let a = meta.query_advice(a, 0);
-            let p = meta.query_aux(p, 0);
-            let sp = meta.query_fixed(sp, 0);
+            let a = meta.query_advice(a, Rotation::cur());
+            let p = meta.query_aux(p, Rotation::cur());
+            let sp = meta.query_fixed(sp, Rotation::cur());
 
             sp * (a + p * (-F::one()))
         });

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -58,6 +58,7 @@ pub enum VerifyFailure {
 ///     dev::{MockProver, VerifyFailure},
 ///     pasta::Fp,
 ///     plonk::{Advice, Assignment, Circuit, Column, ConstraintSystem, Error},
+///     poly::Rotation,
 /// };
 /// const K: u32 = 5;
 ///
@@ -81,9 +82,9 @@ pub enum VerifyFailure {
 ///         let c = meta.advice_column();
 ///
 ///         meta.create_gate(|meta| {
-///             let a = meta.query_advice(a, 0);
-///             let b = meta.query_advice(b, 0);
-///             let c = meta.query_advice(c, 0);
+///             let a = meta.query_advice(a, Rotation::cur());
+///             let b = meta.query_advice(b, Rotation::cur());
+///             let c = meta.query_advice(c, Rotation::cur());
 ///
 ///             // BUG: Should be a * b - c
 ///             a * b + c

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -105,7 +105,10 @@ fn test_proving() {
     use crate::arithmetic::{Curve, FieldExt};
     use crate::dev::MockProver;
     use crate::pasta::{EqAffine, Fp, Fq};
-    use crate::poly::commitment::{Blind, Params};
+    use crate::poly::{
+        commitment::{Blind, Params},
+        Rotation,
+    };
     use crate::transcript::{DummyHashRead, DummyHashWrite};
     use circuit::{Advice, Column, Fixed};
     use std::marker::PhantomData;
@@ -344,25 +347,25 @@ fn test_proving() {
             meta.lookup(&[a.into(), b.into()], &[sl.into(), sl2.into()]);
 
             meta.create_gate(|meta| {
-                let d = meta.query_advice(d, 1);
-                let a = meta.query_advice(a, 0);
-                let sf = meta.query_fixed(sf, 0);
-                let e = meta.query_advice(e, -1);
-                let b = meta.query_advice(b, 0);
-                let c = meta.query_advice(c, 0);
+                let d = meta.query_advice(d, Rotation::next());
+                let a = meta.query_advice(a, Rotation::cur());
+                let sf = meta.query_fixed(sf, Rotation::cur());
+                let e = meta.query_advice(e, Rotation::prev());
+                let b = meta.query_advice(b, Rotation::cur());
+                let c = meta.query_advice(c, Rotation::cur());
 
-                let sa = meta.query_fixed(sa, 0);
-                let sb = meta.query_fixed(sb, 0);
-                let sc = meta.query_fixed(sc, 0);
-                let sm = meta.query_fixed(sm, 0);
+                let sa = meta.query_fixed(sa, Rotation::cur());
+                let sb = meta.query_fixed(sb, Rotation::cur());
+                let sc = meta.query_fixed(sc, Rotation::cur());
+                let sm = meta.query_fixed(sm, Rotation::cur());
 
                 a.clone() * sa + b.clone() * sb + a * b * sm + (c * sc * (-F::one())) + sf * (d * e)
             });
 
             meta.create_gate(|meta| {
-                let a = meta.query_advice(a, 0);
-                let p = meta.query_aux(p, 0);
-                let sp = meta.query_fixed(sp, 0);
+                let a = meta.query_advice(a, Rotation::cur());
+                let p = meta.query_aux(p, Rotation::cur());
+                let sp = meta.query_fixed(sp, Rotation::cur());
 
                 sp * (a + p * (-F::one()))
             });

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -147,7 +147,7 @@ where
     let mut l0 = domain.empty_lagrange();
     l0[0] = C::Scalar::one();
     let l0 = domain.lagrange_to_coeff(l0);
-    let l0 = domain.coeff_to_extended(l0, Rotation::default());
+    let l0 = domain.coeff_to_extended(l0, Rotation::cur());
 
     Ok(ProvingKey {
         vk: VerifyingKey {

--- a/src/plonk/lookup/prover.rs
+++ b/src/plonk/lookup/prover.rs
@@ -94,7 +94,7 @@ impl Argument {
                     };
                     (
                         &values[column.index()],
-                        &cosets[pk.vk.cs.get_any_query_index(column, 0)],
+                        &cosets[pk.vk.cs.get_any_query_index(column, Rotation::cur())],
                     )
                 })
                 .unzip();
@@ -148,7 +148,7 @@ impl Argument {
         let permuted_input_coset = pk
             .vk
             .domain
-            .coeff_to_extended(permuted_input_poly.clone(), Rotation::default());
+            .coeff_to_extended(permuted_input_poly.clone(), Rotation::cur());
         let permuted_input_inv_coset = pk
             .vk
             .domain
@@ -156,7 +156,7 @@ impl Argument {
         let permuted_table_coset = pk
             .vk
             .domain
-            .coeff_to_extended(permuted_table_poly.clone(), Rotation::default());
+            .coeff_to_extended(permuted_table_poly.clone(), Rotation::cur());
 
         Ok(Permuted {
             unpermuted_input_columns,
@@ -310,11 +310,8 @@ impl<'a, C: CurveAffine> Permuted<'a, C> {
         let product_blind = Blind(C::Scalar::rand());
         let product_commitment = params.commit_lagrange(&z, product_blind).to_affine();
         let z = pk.vk.domain.lagrange_to_coeff(z);
-        let product_coset = pk
-            .vk
-            .domain
-            .coeff_to_extended(z.clone(), Rotation::default());
-        let product_inv_coset = pk.vk.domain.coeff_to_extended(z.clone(), Rotation(-1));
+        let product_coset = pk.vk.domain.coeff_to_extended(z.clone(), Rotation::cur());
+        let product_inv_coset = pk.vk.domain.coeff_to_extended(z.clone(), Rotation::prev());
 
         // Hash product commitment
         transcript

--- a/src/plonk/lookup/verifier.rs
+++ b/src/plonk/lookup/verifier.rs
@@ -120,7 +120,7 @@ impl<C: CurveAffine> Evaluated<C> {
                 columns
                     .iter()
                     .map(|column| {
-                        let index = vk.cs.get_any_query_index(*column, 0);
+                        let index = vk.cs.get_any_query_index(*column, Rotation::cur());
                         match column.column_type() {
                             Any::Advice => advice_evals[index],
                             Any::Fixed => fixed_evals[index],

--- a/src/plonk/permutation/keygen.rs
+++ b/src/plonk/permutation/keygen.rs
@@ -164,7 +164,7 @@ impl Assembly {
             permutations.push(permutation_poly.clone());
             let poly = domain.lagrange_to_coeff(permutation_poly);
             polys.push(poly.clone());
-            cosets.push(domain.coeff_to_extended(poly, Rotation::default()));
+            cosets.push(domain.coeff_to_extended(poly, Rotation::cur()));
         }
         (
             ProvingKey {

--- a/src/plonk/permutation/verifier.rs
+++ b/src/plonk/permutation/verifier.rs
@@ -88,7 +88,9 @@ impl<C: CurveAffine> Evaluated<C> {
                 for (advice_eval, permutation_eval) in p
                     .columns
                     .iter()
-                    .map(|&column| advice_evals[vk.cs.get_advice_query_index(column, 0)])
+                    .map(|&column| {
+                        advice_evals[vk.cs.get_advice_query_index(column, Rotation::cur())]
+                    })
                     .zip(self.permutation_evals.iter())
                 {
                     left *= &(advice_eval + &(*beta * permutation_eval) + &*gamma);
@@ -96,11 +98,9 @@ impl<C: CurveAffine> Evaluated<C> {
 
                 let mut right = self.permutation_product_inv_eval;
                 let mut current_delta = *beta * &*x;
-                for advice_eval in p
-                    .columns
-                    .iter()
-                    .map(|&column| advice_evals[vk.cs.get_advice_query_index(column, 0)])
-                {
+                for advice_eval in p.columns.iter().map(|&column| {
+                    advice_evals[vk.cs.get_advice_query_index(column, Rotation::cur())]
+                }) {
                     right *= &(advice_eval + &current_delta + &*gamma);
                     current_delta *= &C::Scalar::DELTA;
                 }

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -200,3 +200,32 @@ impl<'a, F: Field, B: Basis> Mul<F> for Polynomial<F, B> {
         self
     }
 }
+
+/// Describes the relative rotation of a vector. Negative numbers represent
+/// reverse (leftmost) rotations and positive numbers represent forward (rightmost)
+/// rotations. Zero represents no rotation.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct Rotation(pub i32);
+
+impl Default for Rotation {
+    fn default() -> Rotation {
+        Rotation(0)
+    }
+}
+
+impl Rotation {
+    /// The current location in the evaluation domain
+    pub fn cur() -> Rotation {
+        Rotation(0)
+    }
+
+    /// The previous location in the evaluation domain
+    pub fn prev() -> Rotation {
+        Rotation(-1)
+    }
+
+    /// The next location in the evaluation domain
+    pub fn next() -> Rotation {
+        Rotation(1)
+    }
+}

--- a/src/poly/domain.rs
+++ b/src/poly/domain.rs
@@ -3,21 +3,10 @@
 
 use crate::arithmetic::{best_fft, parallelize, BatchInvert, FieldExt, Group};
 
-use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial};
+use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation};
 
 use ff::{Field, PrimeField};
 use std::marker::PhantomData;
-
-/// Describes a relative location in the evaluation domain; applying a rotation
-/// by i will rotate the vector in the evaluation domain by i.
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Ord, PartialOrd)]
-pub struct Rotation(pub i32);
-
-impl Default for Rotation {
-    fn default() -> Rotation {
-        Rotation(0)
-    }
-}
 
 /// This structure contains precomputed constants and other details needed for
 /// performing operations on an evaluation domain of size $2^k$ and an extended


### PR DESCRIPTION
The first commit of this branch just removes the unused `rotations` field from ConstraintSystem.
The second commit switches to using Rotation in the circuit interface rather than i32; it can be dropped if folks don't care for it.