### PR TITLE
New Transcript API (and modified commitment scheme)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ metrics = "=0.13.0-alpha.13"
 metrics-macros = "=0.1.0-alpha.9"
 num_cpus = "1.13"
 rand = "0.7"
+blake2b_simd = "0.5"
 
 [features]
 sanity-checks = []

--- a/benches/arithmetic.rs
+++ b/benches/arithmetic.rs
@@ -3,9 +3,9 @@ extern crate criterion;
 
 extern crate halo2;
 use crate::arithmetic::{small_multiexp, FieldExt};
-use crate::pasta::{EqAffine, Fp, Fq};
+use crate::pasta::{EqAffine, Fp};
 use crate::poly::commitment::Params;
-use crate::transcript::DummyHash;
+use crate::transcript::DummyHashWriter;
 use halo2::*;
 
 use criterion::{black_box, Criterion};
@@ -13,7 +13,7 @@ use criterion::{black_box, Criterion};
 fn criterion_benchmark(c: &mut Criterion) {
     // small multiexp
     {
-        let params: Params<EqAffine> = Params::new::<DummyHash<Fq>>(5);
+        let params: Params<EqAffine> = Params::new::<DummyHashWriter<_, _>>(5);
         let g = &mut params.get_g();
         let len = g.len() / 2;
         let (g_lo, g_hi) = g.split_at_mut(len);

--- a/benches/arithmetic.rs
+++ b/benches/arithmetic.rs
@@ -5,7 +5,7 @@ extern crate halo2;
 use crate::arithmetic::{small_multiexp, FieldExt};
 use crate::pasta::{EqAffine, Fp};
 use crate::poly::commitment::Params;
-use crate::transcript::DummyHashWriter;
+use crate::transcript::DummyHashWrite;
 use halo2::*;
 
 use criterion::{black_box, Criterion};
@@ -13,7 +13,7 @@ use criterion::{black_box, Criterion};
 fn criterion_benchmark(c: &mut Criterion) {
     // small multiexp
     {
-        let params: Params<EqAffine> = Params::new::<DummyHashWriter<_, _>>(5);
+        let params: Params<EqAffine> = Params::new::<DummyHashWrite<_, _>>(5);
         let g = &mut params.get_g();
         let len = g.len() / 2;
         let (g_lo, g_hi) = g.split_at_mut(len);

--- a/benches/arithmetic.rs
+++ b/benches/arithmetic.rs
@@ -5,7 +5,6 @@ extern crate halo2;
 use crate::arithmetic::{small_multiexp, FieldExt};
 use crate::pasta::{EqAffine, Fp};
 use crate::poly::commitment::Params;
-use crate::transcript::DummyHashWrite;
 use halo2::*;
 
 use criterion::{black_box, Criterion};
@@ -13,7 +12,7 @@ use criterion::{black_box, Criterion};
 fn criterion_benchmark(c: &mut Criterion) {
     // small multiexp
     {
-        let params: Params<EqAffine> = Params::new::<DummyHashWrite<_, _>>(5);
+        let params: Params<EqAffine> = Params::new(5);
         let g = &mut params.get_g();
         let len = g.len() / 2;
         let (g_lo, g_hi) = g.split_at_mut(len);

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -6,7 +6,7 @@ use halo2::arithmetic::FieldExt;
 use halo2::pasta::{EqAffine, Fp, Fq};
 use halo2::plonk::*;
 use halo2::poly::commitment::Params;
-use halo2::transcript::{DummyHashReader, DummyHashWriter, TranscriptRead, TranscriptWrite};
+use halo2::transcript::{DummyHashRead, DummyHashWrite, TranscriptRead, TranscriptWrite};
 
 use std::marker::PhantomData;
 
@@ -18,7 +18,7 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
     pub struct Variable(Column<Advice>, usize);
 
     // Initialize the polynomial commitment parameters
-    let params: Params<EqAffine> = Params::new::<DummyHashWriter<_, _>>(k);
+    let params: Params<EqAffine> = Params::new::<DummyHashWrite<_, _>>(k);
 
     struct PLONKConfig {
         a: Column<Advice>,
@@ -239,7 +239,7 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
             };
 
             // Create a proof
-            let mut transcript = DummyHashWriter::init(vec![], Fq::one());
+            let mut transcript = DummyHashWrite::init(vec![], Fq::one());
             create_proof(&params, &pk, &circuit, &[], &mut transcript)
                 .expect("proof generation should not fail")
         });
@@ -251,7 +251,7 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
     };
 
     // Create a proof
-    let mut transcript = DummyHashWriter::init(vec![], Fq::one());
+    let mut transcript = DummyHashWrite::init(vec![], Fq::one());
     create_proof(&params, &pk, &circuit, &[], &mut transcript)
         .expect("proof generation should not fail");
     let proof = transcript.finalize();
@@ -259,7 +259,7 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
     c.bench_function(&verifier_name, |b| {
         b.iter(|| {
             let msm = params.empty_msm();
-            let mut transcript = DummyHashReader::init(&proof[..], Fq::one());
+            let mut transcript = DummyHashRead::init(&proof[..], Fq::one());
             let guard = verify_proof(&params, pk.get_vk(), msm, &[], &mut transcript).unwrap();
             let msm = guard.clone().use_challenges();
             assert!(msm.eval());

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -6,7 +6,7 @@ use halo2::arithmetic::FieldExt;
 use halo2::pasta::{EqAffine, Fp, Fq};
 use halo2::plonk::*;
 use halo2::poly::commitment::Params;
-use halo2::transcript::{DummyHashRead, DummyHashWrite, TranscriptRead, TranscriptWrite};
+use halo2::transcript::{DummyHashRead, DummyHashWrite};
 
 use std::marker::PhantomData;
 

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -6,7 +6,7 @@ use halo2::arithmetic::FieldExt;
 use halo2::pasta::{EqAffine, Fp, Fq};
 use halo2::plonk::*;
 use halo2::poly::commitment::Params;
-use halo2::transcript::DummyHash;
+use halo2::transcript::{DummyHashReader, DummyHashWriter, TranscriptRead, TranscriptWrite};
 
 use std::marker::PhantomData;
 
@@ -18,7 +18,7 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
     pub struct Variable(Column<Advice>, usize);
 
     // Initialize the polynomial commitment parameters
-    let params: Params<EqAffine> = Params::new::<DummyHash<Fq>>(k);
+    let params: Params<EqAffine> = Params::new::<DummyHashWriter<_, _>>(k);
 
     struct PLONKConfig {
         a: Column<Advice>,
@@ -239,7 +239,8 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
             };
 
             // Create a proof
-            Proof::create::<DummyHash<Fq>, DummyHash<Fp>, _>(&params, &pk, &circuit, &[])
+            let mut transcript = DummyHashWriter::init(vec![], Fq::one());
+            create_proof(&params, &pk, &circuit, &[], &mut transcript)
                 .expect("proof generation should not fail")
         });
     });
@@ -250,15 +251,16 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
     };
 
     // Create a proof
-    let proof = Proof::create::<DummyHash<Fq>, DummyHash<Fp>, _>(&params, &pk, &circuit, &[])
+    let mut transcript = DummyHashWriter::init(vec![], Fq::one());
+    create_proof(&params, &pk, &circuit, &[], &mut transcript)
         .expect("proof generation should not fail");
+    let proof = transcript.finalize();
 
     c.bench_function(&verifier_name, |b| {
         b.iter(|| {
             let msm = params.empty_msm();
-            let guard = proof
-                .verify::<DummyHash<Fq>, DummyHash<Fp>>(&params, pk.get_vk(), msm, &[])
-                .unwrap();
+            let mut transcript = DummyHashReader::init(&proof[..], Fq::one());
+            let guard = verify_proof(&params, pk.get_vk(), msm, &[], &mut transcript).unwrap();
             let msm = guard.clone().use_challenges();
             assert!(msm.eval());
         });

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -18,7 +18,7 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
     pub struct Variable(Column<Advice>, usize);
 
     // Initialize the polynomial commitment parameters
-    let params: Params<EqAffine> = Params::new::<DummyHashWrite<_, _>>(k);
+    let params: Params<EqAffine> = Params::new(k);
 
     struct PLONKConfig {
         a: Column<Advice>,

--- a/examples/performance_model.rs
+++ b/examples/performance_model.rs
@@ -4,7 +4,7 @@ use halo2::{
     pasta::{EqAffine, Fp, Fq},
     plonk::*,
     poly::commitment::{Blind, Params},
-    transcript::{DummyHashRead, DummyHashWrite, TranscriptRead, TranscriptWrite},
+    transcript::{DummyHashRead, DummyHashWrite},
 };
 
 use std::marker::PhantomData;

--- a/examples/performance_model.rs
+++ b/examples/performance_model.rs
@@ -4,9 +4,10 @@ use halo2::{
     pasta::{EqAffine, Fp, Fq},
     plonk::*,
     poly::commitment::{Blind, Params},
-    transcript::DummyHash,
+    transcript::{DummyHashReader, DummyHashWriter, TranscriptRead, TranscriptWrite},
 };
 
+use std::io;
 use std::marker::PhantomData;
 
 /// This represents an advice column at a certain row in the ConstraintSystem
@@ -249,7 +250,7 @@ fn main() {
     let k = 11;
 
     // Initialize the polynomial commitment parameters
-    let params: Params<EqAffine> = Params::new::<DummyHash<Fq>>(k);
+    let params: Params<EqAffine> = Params::new::<DummyHashWriter<io::Sink, _>>(k);
 
     let empty_circuit: MyCircuit<Fp> = MyCircuit { a: None, k };
 
@@ -273,18 +274,18 @@ fn main() {
     };
 
     // Create a proof
-    let proof =
-        Proof::create::<DummyHash<Fq>, DummyHash<Fp>, _>(&params, &pk, &circuit, &[pubinputs])
-            .expect("proof generation should not fail");
+    let mut transcript = DummyHashWriter::init(vec![], Fq::one());
+    create_proof(&params, &pk, &circuit, &[pubinputs], &mut transcript)
+        .expect("proof generation should not fail");
+    let proof: Vec<u8> = transcript.finalize();
 
     println!("[Prover] {}", recorder);
     recorder.clear();
 
     let pubinput_slice = &[pubinput];
     let msm = params.empty_msm();
-    let guard = proof
-        .verify::<DummyHash<Fq>, DummyHash<Fp>>(&params, pk.get_vk(), msm, pubinput_slice)
-        .unwrap();
+    let mut transcript = DummyHashReader::init(&proof[..], Fq::one());
+    let guard = verify_proof(&params, pk.get_vk(), msm, pubinput_slice, &mut transcript).unwrap();
     let msm = guard.clone().use_challenges();
     assert!(msm.eval());
 

--- a/examples/performance_model.rs
+++ b/examples/performance_model.rs
@@ -7,7 +7,6 @@ use halo2::{
     transcript::{DummyHashRead, DummyHashWrite, TranscriptRead, TranscriptWrite},
 };
 
-use std::io;
 use std::marker::PhantomData;
 
 /// This represents an advice column at a certain row in the ConstraintSystem
@@ -250,7 +249,7 @@ fn main() {
     let k = 11;
 
     // Initialize the polynomial commitment parameters
-    let params: Params<EqAffine> = Params::new::<DummyHashWrite<io::Sink, _>>(k);
+    let params: Params<EqAffine> = Params::new(k);
 
     let empty_circuit: MyCircuit<Fp> = MyCircuit { a: None, k };
 

--- a/examples/performance_model.rs
+++ b/examples/performance_model.rs
@@ -4,7 +4,7 @@ use halo2::{
     pasta::{EqAffine, Fp, Fq},
     plonk::*,
     poly::commitment::{Blind, Params},
-    transcript::{DummyHashReader, DummyHashWriter, TranscriptRead, TranscriptWrite},
+    transcript::{DummyHashRead, DummyHashWrite, TranscriptRead, TranscriptWrite},
 };
 
 use std::io;
@@ -250,7 +250,7 @@ fn main() {
     let k = 11;
 
     // Initialize the polynomial commitment parameters
-    let params: Params<EqAffine> = Params::new::<DummyHashWriter<io::Sink, _>>(k);
+    let params: Params<EqAffine> = Params::new::<DummyHashWrite<io::Sink, _>>(k);
 
     let empty_circuit: MyCircuit<Fp> = MyCircuit { a: None, k };
 
@@ -274,7 +274,7 @@ fn main() {
     };
 
     // Create a proof
-    let mut transcript = DummyHashWriter::init(vec![], Fq::one());
+    let mut transcript = DummyHashWrite::init(vec![], Fq::one());
     create_proof(&params, &pk, &circuit, &[pubinputs], &mut transcript)
         .expect("proof generation should not fail");
     let proof: Vec<u8> = transcript.finalize();
@@ -284,7 +284,7 @@ fn main() {
 
     let pubinput_slice = &[pubinput];
     let msm = params.empty_msm();
-    let mut transcript = DummyHashReader::init(&proof[..], Fq::one());
+    let mut transcript = DummyHashRead::init(&proof[..], Fq::one());
     let guard = verify_proof(&params, pk.get_vk(), msm, pubinput_slice, &mut transcript).unwrap();
     let msm = guard.clone().use_challenges();
     assert!(msm.eval());

--- a/src/arithmetic/curves.rs
+++ b/src/arithmetic/curves.rs
@@ -122,6 +122,10 @@ pub trait CurveAffine:
     /// The base field over which this elliptic curve is constructed.
     type Base: FieldExt;
 
+    /// Personalization of BLAKE2b hasher used to generate the uniform
+    /// random string.
+    const BLAKE2B_PERSONALIZATION: &'static [u8; 16];
+
     /// Obtains the additive identity.
     fn zero() -> Self;
 

--- a/src/pasta/curves.rs
+++ b/src/pasta/curves.rs
@@ -11,7 +11,7 @@ use super::{Fp, Fq};
 use crate::arithmetic::{Curve, CurveAffine, FieldExt, Group};
 
 macro_rules! new_curve_impl {
-    ($name:ident, $name_affine:ident, $base:ident, $scalar:ident) => {
+    ($name:ident, $name_affine:ident, $base:ident, $scalar:ident, $blake2b_personalization:literal) => {
         /// Represents a point in the projective coordinate space.
         #[derive(Copy, Clone, Debug)]
         pub struct $name {
@@ -497,6 +497,8 @@ macro_rules! new_curve_impl {
             type Scalar = $scalar;
             type Base = $base;
 
+            const BLAKE2B_PERSONALIZATION: &'static [u8; 16] = $blake2b_personalization;
+
             fn zero() -> Self {
                 Self {
                     x: $base::zero(),
@@ -700,5 +702,5 @@ macro_rules! new_curve_impl {
     };
 }
 
-new_curve_impl!(Ep, EpAffine, Fp, Fq);
-new_curve_impl!(Eq, EqAffine, Fq, Fp);
+new_curve_impl!(Ep, EpAffine, Fp, Fq, b"halo2_____pallas");
+new_curve_impl!(Eq, EqAffine, Fq, Fp, b"halo2______vesta");

--- a/src/pasta/fields.rs
+++ b/src/pasta/fields.rs
@@ -6,21 +6,3 @@ mod fq;
 
 pub use fp::*;
 pub use fq::*;
-
-#[cfg(test)]
-use ff::{Field, PrimeField};
-
-#[cfg(test)]
-use crate::arithmetic::FieldExt;
-
-#[test]
-fn test_extract() {
-    let a = Fq::rand();
-    let a = a.square();
-    let (t, s) = a.extract_radix2_vartime().unwrap();
-    assert_eq!(
-        t.pow_vartime(&[1 << Fq::S, 0, 0, 0]) * Fq::ROOT_OF_UNITY.pow_vartime(&[s, 0, 0, 0]),
-        a
-    );
-    assert_eq!(a.deterministic_sqrt().unwrap().square(), a);
-}

--- a/src/pasta/fields/fp.rs
+++ b/src/pasta/fields/fp.rs
@@ -643,20 +643,7 @@ impl FieldExt for Fp {
         0xb4ed8e647196dad1,
         0x2cd5282c53116b5c,
     ]);
-    const UNROLL_T_EXPONENT: [u64; 4] = [
-        0x955a0a417453113c,
-        0x0000000022016b89,
-        0xc000000000000000,
-        0x3f7ed4c6,
-    ];
-    const T_EXPONENT: [u64; 4] = [
-        0x094cf91b992d30ed,
-        0x00000000224698fc,
-        0x0000000000000000,
-        0x40000000,
-    ];
     const DELTA: Self = DELTA;
-    const UNROLL_S_EXPONENT: u64 = 0x204ace5;
     const TWO_INV: Self = Fp::from_raw([
         0xcc96987680000001,
         0x11234c7e04a67c8d,
@@ -788,13 +775,6 @@ fn test_rescue() {
 fn test_sqrt() {
     // NB: TWO_INV is standing in as a "random" field element
     let v = (Fp::TWO_INV).square().sqrt().unwrap();
-    assert!(v == Fp::TWO_INV || (-v) == Fp::TWO_INV);
-}
-
-#[test]
-fn test_deterministic_sqrt() {
-    // NB: TWO_INV is standing in as a "random" field element
-    let v = (Fp::TWO_INV).square().deterministic_sqrt().unwrap();
     assert!(v == Fp::TWO_INV || (-v) == Fp::TWO_INV);
 }
 

--- a/src/pasta/fields/fq.rs
+++ b/src/pasta/fields/fq.rs
@@ -643,20 +643,7 @@ impl FieldExt for Fq {
         0xf4c8f353124086c1,
         0x2235e1a7415bf936,
     ]);
-    const UNROLL_T_EXPONENT: [u64; 4] = [
-        0xcc771cc2ac1e1664,
-        0x00000000062dfe9e,
-        0xc000000000000000,
-        0xb89e9c7,
-    ];
-    const T_EXPONENT: [u64; 4] = [
-        0x0994a8dd8c46eb21,
-        0x00000000224698fc,
-        0x0000000000000000,
-        0x40000000,
-    ];
     const DELTA: Self = DELTA;
-    const UNROLL_S_EXPONENT: u64 = 0xd1d858e1;
     const TWO_INV: Self = Fq::from_raw([
         0xc623759080000001,
         0x11234c7e04ca546e,
@@ -788,13 +775,6 @@ fn test_rescue() {
 fn test_sqrt() {
     // NB: TWO_INV is standing in as a "random" field element
     let v = (Fq::TWO_INV).square().sqrt().unwrap();
-    assert!(v == Fq::TWO_INV || (-v) == Fq::TWO_INV);
-}
-
-#[test]
-fn test_deterministic_sqrt() {
-    // NB: TWO_INV is standing in as a "random" field element
-    let v = (Fq::TWO_INV).square().deterministic_sqrt().unwrap();
     assert!(v == Fq::TWO_INV || (-v) == Fq::TWO_INV);
 }
 

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -107,7 +107,6 @@ fn test_proving() {
     use crate::poly::commitment::{Blind, Params};
     use crate::transcript::{DummyHashRead, DummyHashWrite, TranscriptRead, TranscriptWrite};
     use circuit::{Advice, Column, Fixed};
-    use std::io;
     use std::marker::PhantomData;
     const K: u32 = 5;
 
@@ -116,7 +115,7 @@ fn test_proving() {
     pub struct Variable(Column<Advice>, usize);
 
     // Initialize the polynomial commitment parameters
-    let params: Params<EqAffine> = Params::new::<DummyHashWrite<io::Sink, _>>(K);
+    let params: Params<EqAffine> = Params::new(K);
 
     struct PLONKConfig {
         a: Column<Advice>,

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -105,7 +105,7 @@ fn test_proving() {
     use crate::arithmetic::{Curve, FieldExt};
     use crate::pasta::{EqAffine, Fp, Fq};
     use crate::poly::commitment::{Blind, Params};
-    use crate::transcript::{DummyHashReader, DummyHashWriter, TranscriptRead, TranscriptWrite};
+    use crate::transcript::{DummyHashRead, DummyHashWrite, TranscriptRead, TranscriptWrite};
     use circuit::{Advice, Column, Fixed};
     use std::io;
     use std::marker::PhantomData;
@@ -116,7 +116,7 @@ fn test_proving() {
     pub struct Variable(Column<Advice>, usize);
 
     // Initialize the polynomial commitment parameters
-    let params: Params<EqAffine> = Params::new::<DummyHashWriter<io::Sink, _>>(K);
+    let params: Params<EqAffine> = Params::new::<DummyHashWrite<io::Sink, _>>(K);
 
     struct PLONKConfig {
         a: Column<Advice>,
@@ -448,7 +448,7 @@ fn test_proving() {
         .to_affine();
 
     for _ in 0..100 {
-        let mut transcript = DummyHashWriter::init(vec![], Fq::one());
+        let mut transcript = DummyHashWrite::init(vec![], Fq::one());
         // Create a proof
         create_proof(
             &params,
@@ -462,7 +462,7 @@ fn test_proving() {
 
         let pubinput_slice = &[pubinput];
         let msm = params.empty_msm();
-        let mut transcript = DummyHashReader::init(&proof[..], Fq::one());
+        let mut transcript = DummyHashRead::init(&proof[..], Fq::one());
         let guard =
             verify_proof(&params, pk.get_vk(), msm, pubinput_slice, &mut transcript).unwrap();
         {
@@ -476,7 +476,7 @@ fn test_proving() {
         }
         let msm = guard.clone().use_challenges();
         assert!(msm.clone().eval());
-        let mut transcript = DummyHashReader::init(&proof[..], Fq::one());
+        let mut transcript = DummyHashRead::init(&proof[..], Fq::one());
         let guard =
             verify_proof(&params, pk.get_vk(), msm, pubinput_slice, &mut transcript).unwrap();
         {

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -105,7 +105,7 @@ fn test_proving() {
     use crate::arithmetic::{Curve, FieldExt};
     use crate::pasta::{EqAffine, Fp, Fq};
     use crate::poly::commitment::{Blind, Params};
-    use crate::transcript::{DummyHashRead, DummyHashWrite, TranscriptRead, TranscriptWrite};
+    use crate::transcript::{DummyHashRead, DummyHashWrite};
     use circuit::{Advice, Column, Fixed};
     use std::marker::PhantomData;
     const K: u32 = 5;

--- a/src/plonk/lookup.rs
+++ b/src/plonk/lookup.rs
@@ -1,5 +1,4 @@
 use super::circuit::{Any, Column};
-use crate::arithmetic::CurveAffine;
 
 mod prover;
 mod verifier;
@@ -36,16 +35,4 @@ impl Argument {
         // (a′(X)−s′(X))⋅(a′(X)−a′(\omega{-1} X)) = 0
         3
     }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct Proof<C: CurveAffine> {
-    product_commitment: C,
-    product_eval: C::Scalar,
-    product_inv_eval: C::Scalar,
-    permuted_input_commitment: C,
-    permuted_table_commitment: C,
-    permuted_input_eval: C::Scalar,
-    permuted_input_inv_eval: C::Scalar,
-    permuted_table_eval: C::Scalar,
 }

--- a/src/plonk/lookup/prover.rs
+++ b/src/plonk/lookup/prover.rs
@@ -13,7 +13,6 @@ use crate::{
     transcript::TranscriptWrite,
 };
 use ff::Field;
-use std::io::Write;
 use std::{collections::BTreeMap, iter};
 
 #[derive(Debug)]
@@ -73,12 +72,7 @@ impl Argument {
     /// - constructs Permuted<C> struct using permuted_input_value = A', and
     ///   permuted_table_column = S'.
     /// The Permuted<C> struct is used to update the Lookup, and is then returned.
-    pub(in crate::plonk) fn commit_permuted<
-        'a,
-        C: CurveAffine,
-        W: Write,
-        T: TranscriptWrite<W, C>,
-    >(
+    pub(in crate::plonk) fn commit_permuted<'a, C: CurveAffine, T: TranscriptWrite<C>>(
         &self,
         pk: &ProvingKey<C>,
         params: &Params<C>,
@@ -195,7 +189,7 @@ impl<'a, C: CurveAffine> Permuted<'a, C> {
     /// grand product polynomial over the lookup. The grand product polynomial
     /// is used to populate the Product<C> struct. The Product<C> struct is
     /// added to the Lookup and finally returned by the method.
-    pub(in crate::plonk) fn commit_product<W: Write, T: TranscriptWrite<W, C>>(
+    pub(in crate::plonk) fn commit_product<T: TranscriptWrite<C>>(
         self,
         pk: &ProvingKey<C>,
         params: &Params<C>,
@@ -443,7 +437,7 @@ impl<'a, C: CurveAffine> Committed<'a, C> {
 }
 
 impl<C: CurveAffine> Constructed<C> {
-    pub(in crate::plonk) fn evaluate<W: Write, T: TranscriptWrite<W, C>>(
+    pub(in crate::plonk) fn evaluate<T: TranscriptWrite<C>>(
         self,
         pk: &ProvingKey<C>,
         x: ChallengeX<C>,

--- a/src/plonk/lookup/prover.rs
+++ b/src/plonk/lookup/prover.rs
@@ -2,7 +2,7 @@ use super::super::{
     circuit::{Any, Column},
     ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, Error, ProvingKey,
 };
-use super::{Argument, Proof};
+use super::Argument;
 use crate::{
     arithmetic::{eval_polynomial, parallelize, BatchInvert, Curve, CurveAffine, FieldExt},
     poly::{
@@ -10,9 +10,10 @@ use crate::{
         multiopen::ProverQuery,
         Coeff, EvaluationDomain, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation,
     },
-    transcript::{Hasher, Transcript},
+    transcript::TranscriptWrite,
 };
 use ff::Field;
+use std::io::Write;
 use std::{collections::BTreeMap, iter};
 
 #[derive(Debug)]
@@ -47,13 +48,10 @@ pub(in crate::plonk) struct Committed<'a, C: CurveAffine> {
 pub(in crate::plonk) struct Constructed<C: CurveAffine> {
     permuted_input_poly: Polynomial<C::Scalar, Coeff>,
     permuted_input_blind: Blind<C::Scalar>,
-    permuted_input_commitment: C,
     permuted_table_poly: Polynomial<C::Scalar, Coeff>,
     permuted_table_blind: Blind<C::Scalar>,
-    permuted_table_commitment: C,
     product_poly: Polynomial<C::Scalar, Coeff>,
     product_blind: Blind<C::Scalar>,
-    product_commitment: C,
 }
 
 pub(in crate::plonk) struct Evaluated<C: CurveAffine> {
@@ -78,21 +76,21 @@ impl Argument {
     pub(in crate::plonk) fn commit_permuted<
         'a,
         C: CurveAffine,
-        HBase: Hasher<C::Base>,
-        HScalar: Hasher<C::Scalar>,
+        W: Write,
+        T: TranscriptWrite<W, C>,
     >(
         &self,
         pk: &ProvingKey<C>,
         params: &Params<C>,
         domain: &EvaluationDomain<C::Scalar>,
-        theta: ChallengeTheta<C::Scalar>,
+        theta: ChallengeTheta<C>,
         advice_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
         fixed_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
         aux_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
         advice_cosets: &'a [Polynomial<C::Scalar, ExtendedLagrangeCoeff>],
         fixed_cosets: &'a [Polynomial<C::Scalar, ExtendedLagrangeCoeff>],
         aux_cosets: &'a [Polynomial<C::Scalar, ExtendedLagrangeCoeff>],
-        transcript: &mut Transcript<C, HBase, HScalar>,
+        transcript: &mut T,
     ) -> Result<Permuted<'a, C>, Error> {
         // Closure to get values of columns and compress them
         let compress_columns = |columns: &[Column<Any>]| {
@@ -150,12 +148,12 @@ impl Argument {
 
         // Hash permuted input commitment
         transcript
-            .absorb_point(&permuted_input_commitment)
+            .write_point(permuted_input_commitment)
             .map_err(|_| Error::TranscriptError)?;
 
         // Hash permuted table commitment
         transcript
-            .absorb_point(&permuted_table_commitment)
+            .write_point(permuted_table_commitment)
             .map_err(|_| Error::TranscriptError)?;
 
         let permuted_input_coset = pk
@@ -197,14 +195,14 @@ impl<'a, C: CurveAffine> Permuted<'a, C> {
     /// grand product polynomial over the lookup. The grand product polynomial
     /// is used to populate the Product<C> struct. The Product<C> struct is
     /// added to the Lookup and finally returned by the method.
-    pub(in crate::plonk) fn commit_product<HBase: Hasher<C::Base>, HScalar: Hasher<C::Scalar>>(
+    pub(in crate::plonk) fn commit_product<W: Write, T: TranscriptWrite<W, C>>(
         self,
         pk: &ProvingKey<C>,
         params: &Params<C>,
-        theta: ChallengeTheta<C::Scalar>,
-        beta: ChallengeBeta<C::Scalar>,
-        gamma: ChallengeGamma<C::Scalar>,
-        transcript: &mut Transcript<C, HBase, HScalar>,
+        theta: ChallengeTheta<C>,
+        beta: ChallengeBeta<C>,
+        gamma: ChallengeGamma<C>,
+        transcript: &mut T,
     ) -> Result<Committed<'a, C>, Error> {
         // Goal is to compute the products of fractions
         //
@@ -331,7 +329,7 @@ impl<'a, C: CurveAffine> Permuted<'a, C> {
 
         // Hash product commitment
         transcript
-            .absorb_point(&product_commitment)
+            .write_point(product_commitment)
             .map_err(|_| Error::TranscriptError)?;
 
         Ok(Committed::<'a, C> {
@@ -354,9 +352,9 @@ impl<'a, C: CurveAffine> Committed<'a, C> {
     pub(in crate::plonk) fn construct(
         self,
         pk: &'a ProvingKey<C>,
-        theta: ChallengeTheta<C::Scalar>,
-        beta: ChallengeBeta<C::Scalar>,
-        gamma: ChallengeGamma<C::Scalar>,
+        theta: ChallengeTheta<C>,
+        beta: ChallengeBeta<C>,
+        gamma: ChallengeGamma<C>,
     ) -> Result<
         (
             Constructed<C>,
@@ -434,13 +432,10 @@ impl<'a, C: CurveAffine> Committed<'a, C> {
             Constructed {
                 permuted_input_poly: permuted.permuted_input_poly,
                 permuted_input_blind: permuted.permuted_input_blind,
-                permuted_input_commitment: permuted.permuted_input_commitment,
                 permuted_table_poly: permuted.permuted_table_poly,
                 permuted_table_blind: permuted.permuted_table_blind,
-                permuted_table_commitment: permuted.permuted_table_commitment,
                 product_poly: self.product_poly,
                 product_blind: self.product_blind,
-                product_commitment: self.product_commitment,
             },
             expressions,
         ))
@@ -448,12 +443,12 @@ impl<'a, C: CurveAffine> Committed<'a, C> {
 }
 
 impl<C: CurveAffine> Constructed<C> {
-    pub(in crate::plonk) fn evaluate<HBase: Hasher<C::Base>, HScalar: Hasher<C::Scalar>>(
+    pub(in crate::plonk) fn evaluate<W: Write, T: TranscriptWrite<W, C>>(
         self,
         pk: &ProvingKey<C>,
-        x: ChallengeX<C::Scalar>,
-        transcript: &mut Transcript<C, HBase, HScalar>,
-    ) -> Evaluated<C> {
+        x: ChallengeX<C>,
+        transcript: &mut T,
+    ) -> Result<Evaluated<C>, Error> {
         let domain = &pk.vk.domain;
         let x_inv = domain.rotate_omega(*x, Rotation(-1));
 
@@ -471,17 +466,19 @@ impl<C: CurveAffine> Constructed<C> {
             .chain(Some(permuted_input_inv_eval))
             .chain(Some(permuted_table_eval))
         {
-            transcript.absorb_scalar(eval);
+            transcript
+                .write_scalar(eval)
+                .map_err(|_| Error::TranscriptError)?;
         }
 
-        Evaluated {
+        Ok(Evaluated {
             constructed: self,
             product_eval,
             product_inv_eval,
             permuted_input_eval,
             permuted_input_inv_eval,
             permuted_table_eval,
-        }
+        })
     }
 }
 
@@ -489,7 +486,7 @@ impl<C: CurveAffine> Evaluated<C> {
     pub(in crate::plonk) fn open<'a>(
         &'a self,
         pk: &'a ProvingKey<C>,
-        x: ChallengeX<C::Scalar>,
+        x: ChallengeX<C>,
     ) -> impl Iterator<Item = ProverQuery<'a, C>> + Clone {
         let x_inv = pk.vk.domain.rotate_omega(*x, Rotation(-1));
 
@@ -520,28 +517,15 @@ impl<C: CurveAffine> Evaluated<C> {
                 point: x_inv,
                 poly: &self.constructed.permuted_input_poly,
                 blind: self.constructed.permuted_input_blind,
-                eval: self.permuted_input_eval,
+                eval: self.permuted_input_inv_eval,
             }))
             // Open lookup product commitments at x_inv
             .chain(Some(ProverQuery {
                 point: x_inv,
                 poly: &self.constructed.product_poly,
                 blind: self.constructed.product_blind,
-                eval: self.product_eval,
+                eval: self.product_inv_eval,
             }))
-    }
-
-    pub(crate) fn build(self) -> Proof<C> {
-        Proof {
-            product_commitment: self.constructed.product_commitment,
-            product_eval: self.product_eval,
-            product_inv_eval: self.product_inv_eval,
-            permuted_input_commitment: self.constructed.permuted_input_commitment,
-            permuted_table_commitment: self.constructed.permuted_table_commitment,
-            permuted_input_eval: self.permuted_input_eval,
-            permuted_input_inv_eval: self.permuted_input_inv_eval,
-            permuted_table_eval: self.permuted_table_eval,
-        }
     }
 }
 

--- a/src/plonk/lookup/verifier.rs
+++ b/src/plonk/lookup/verifier.rs
@@ -16,8 +16,7 @@ pub struct PermutationCommitments<C: CurveAffine> {
 }
 
 pub struct Committed<C: CurveAffine> {
-    permuted_input_commitment: C,
-    permuted_table_commitment: C,
+    permuted: PermutationCommitments<C>,
     product_commitment: C,
 }
 
@@ -59,8 +58,7 @@ impl<C: CurveAffine> PermutationCommitments<C> {
             .map_err(|_| Error::TranscriptError)?;
 
         Ok(Committed {
-            permuted_input_commitment: self.permuted_input_commitment,
-            permuted_table_commitment: self.permuted_table_commitment,
+            permuted: self,
             product_commitment,
         })
     }
@@ -176,19 +174,19 @@ impl<C: CurveAffine> Evaluated<C> {
             // Open lookup input commitments at x
             .chain(Some(VerifierQuery {
                 point: *x,
-                commitment: &self.committed.permuted_input_commitment,
+                commitment: &self.committed.permuted.permuted_input_commitment,
                 eval: self.permuted_input_eval,
             }))
             // Open lookup table commitments at x
             .chain(Some(VerifierQuery {
                 point: *x,
-                commitment: &self.committed.permuted_table_commitment,
+                commitment: &self.committed.permuted.permuted_table_commitment,
                 eval: self.permuted_table_eval,
             }))
             // Open lookup input commitments at \omega^{-1} x
             .chain(Some(VerifierQuery {
                 point: x_inv,
-                commitment: &self.committed.permuted_input_commitment,
+                commitment: &self.committed.permuted.permuted_input_commitment,
                 eval: self.permuted_input_inv_eval,
             }))
             // Open lookup product commitments at \omega^{-1} x

--- a/src/plonk/lookup/verifier.rs
+++ b/src/plonk/lookup/verifier.rs
@@ -30,7 +30,7 @@ pub struct Evaluated<C: CurveAffine> {
 }
 
 impl Argument {
-    pub(in crate::plonk) fn absorb_permuted_commitments<C: CurveAffine, T: TranscriptRead<C>>(
+    pub(in crate::plonk) fn read_permuted_commitments<C: CurveAffine, T: TranscriptRead<C>>(
         &self,
         transcript: &mut T,
     ) -> Result<PermutationCommitments<C>, Error> {
@@ -49,7 +49,7 @@ impl Argument {
 }
 
 impl<C: CurveAffine> PermutationCommitments<C> {
-    pub(in crate::plonk) fn absorb_product_commitment<T: TranscriptRead<C>>(
+    pub(in crate::plonk) fn read_product_commitment<T: TranscriptRead<C>>(
         self,
         transcript: &mut T,
     ) -> Result<Committed<C>, Error> {

--- a/src/plonk/lookup/verifier.rs
+++ b/src/plonk/lookup/verifier.rs
@@ -9,7 +9,6 @@ use crate::{
     transcript::TranscriptRead,
 };
 use ff::Field;
-use std::io::Read;
 
 pub struct PermutationCommitments<C: CurveAffine> {
     permuted_input_commitment: C,
@@ -32,11 +31,7 @@ pub struct Evaluated<C: CurveAffine> {
 }
 
 impl Argument {
-    pub(in crate::plonk) fn absorb_permuted_commitments<
-        C: CurveAffine,
-        R: Read,
-        T: TranscriptRead<R, C>,
-    >(
+    pub(in crate::plonk) fn absorb_permuted_commitments<C: CurveAffine, T: TranscriptRead<C>>(
         &self,
         transcript: &mut T,
     ) -> Result<PermutationCommitments<C>, Error> {
@@ -55,7 +50,7 @@ impl Argument {
 }
 
 impl<C: CurveAffine> PermutationCommitments<C> {
-    pub(in crate::plonk) fn absorb_product_commitment<R: Read, T: TranscriptRead<R, C>>(
+    pub(in crate::plonk) fn absorb_product_commitment<T: TranscriptRead<C>>(
         self,
         transcript: &mut T,
     ) -> Result<Committed<C>, Error> {
@@ -72,7 +67,7 @@ impl<C: CurveAffine> PermutationCommitments<C> {
 }
 
 impl<C: CurveAffine> Committed<C> {
-    pub(crate) fn evaluate<R: Read, T: TranscriptRead<R, C>>(
+    pub(crate) fn evaluate<T: TranscriptRead<C>>(
         self,
         transcript: &mut T,
     ) -> Result<Evaluated<C>, Error> {

--- a/src/plonk/lookup/verifier.rs
+++ b/src/plonk/lookup/verifier.rs
@@ -1,51 +1,117 @@
 use std::iter;
 
 use super::super::circuit::{Any, Column};
-use super::{Argument, Proof};
+use super::Argument;
 use crate::{
     arithmetic::CurveAffine,
     plonk::{ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, Error, VerifyingKey},
     poly::{multiopen::VerifierQuery, Rotation},
-    transcript::{Hasher, Transcript},
+    transcript::TranscriptRead,
 };
 use ff::Field;
+use std::io::Read;
 
-impl<C: CurveAffine> Proof<C> {
+pub struct PermutationCommitments<C: CurveAffine> {
+    permuted_input_commitment: C,
+    permuted_table_commitment: C,
+}
+
+pub struct Committed<C: CurveAffine> {
+    permuted_input_commitment: C,
+    permuted_table_commitment: C,
+    product_commitment: C,
+}
+
+pub struct Evaluated<C: CurveAffine> {
+    committed: Committed<C>,
+    product_eval: C::Scalar,
+    product_inv_eval: C::Scalar,
+    permuted_input_eval: C::Scalar,
+    permuted_input_inv_eval: C::Scalar,
+    permuted_table_eval: C::Scalar,
+}
+
+impl Argument {
     pub(in crate::plonk) fn absorb_permuted_commitments<
-        HBase: Hasher<C::Base>,
-        HScalar: Hasher<C::Scalar>,
+        C: CurveAffine,
+        R: Read,
+        T: TranscriptRead<R, C>,
     >(
         &self,
-        transcript: &mut Transcript<C, HBase, HScalar>,
-    ) -> Result<(), Error> {
-        transcript
-            .absorb_point(&self.permuted_input_commitment)
+        transcript: &mut T,
+    ) -> Result<PermutationCommitments<C>, Error> {
+        let permuted_input_commitment = transcript
+            .read_point()
             .map_err(|_| Error::TranscriptError)?;
-        transcript
-            .absorb_point(&self.permuted_table_commitment)
-            .map_err(|_| Error::TranscriptError)
-    }
+        let permuted_table_commitment = transcript
+            .read_point()
+            .map_err(|_| Error::TranscriptError)?;
 
-    pub(in crate::plonk) fn absorb_product_commitment<
-        HBase: Hasher<C::Base>,
-        HScalar: Hasher<C::Scalar>,
-    >(
-        &self,
-        transcript: &mut Transcript<C, HBase, HScalar>,
-    ) -> Result<(), Error> {
-        transcript
-            .absorb_point(&self.product_commitment)
-            .map_err(|_| Error::TranscriptError)
+        Ok(PermutationCommitments {
+            permuted_input_commitment,
+            permuted_table_commitment,
+        })
     }
+}
 
+impl<C: CurveAffine> PermutationCommitments<C> {
+    pub(in crate::plonk) fn absorb_product_commitment<R: Read, T: TranscriptRead<R, C>>(
+        self,
+        transcript: &mut T,
+    ) -> Result<Committed<C>, Error> {
+        let product_commitment = transcript
+            .read_point()
+            .map_err(|_| Error::TranscriptError)?;
+
+        Ok(Committed {
+            permuted_input_commitment: self.permuted_input_commitment,
+            permuted_table_commitment: self.permuted_table_commitment,
+            product_commitment,
+        })
+    }
+}
+
+impl<C: CurveAffine> Committed<C> {
+    pub(crate) fn evaluate<R: Read, T: TranscriptRead<R, C>>(
+        self,
+        transcript: &mut T,
+    ) -> Result<Evaluated<C>, Error> {
+        let product_eval = transcript
+            .read_scalar()
+            .map_err(|_| Error::TranscriptError)?;
+        let product_inv_eval = transcript
+            .read_scalar()
+            .map_err(|_| Error::TranscriptError)?;
+        let permuted_input_eval = transcript
+            .read_scalar()
+            .map_err(|_| Error::TranscriptError)?;
+        let permuted_input_inv_eval = transcript
+            .read_scalar()
+            .map_err(|_| Error::TranscriptError)?;
+        let permuted_table_eval = transcript
+            .read_scalar()
+            .map_err(|_| Error::TranscriptError)?;
+
+        Ok(Evaluated {
+            committed: self,
+            product_eval,
+            product_inv_eval,
+            permuted_input_eval,
+            permuted_input_inv_eval,
+            permuted_table_eval,
+        })
+    }
+}
+
+impl<C: CurveAffine> Evaluated<C> {
     pub(in crate::plonk) fn expressions<'a>(
         &'a self,
         vk: &'a VerifyingKey<C>,
         l_0: C::Scalar,
         argument: &'a Argument,
-        theta: ChallengeTheta<C::Scalar>,
-        beta: ChallengeBeta<C::Scalar>,
-        gamma: ChallengeGamma<C::Scalar>,
+        theta: ChallengeTheta<C>,
+        beta: ChallengeBeta<C>,
+        gamma: ChallengeGamma<C>,
         advice_evals: &[C::Scalar],
         fixed_evals: &[C::Scalar],
         aux_evals: &[C::Scalar],
@@ -98,19 +164,10 @@ impl<C: CurveAffine> Proof<C> {
             ))
     }
 
-    pub(in crate::plonk) fn evals(&self) -> impl Iterator<Item = &C::Scalar> {
-        iter::empty()
-            .chain(Some(&self.product_eval))
-            .chain(Some(&self.product_inv_eval))
-            .chain(Some(&self.permuted_input_eval))
-            .chain(Some(&self.permuted_input_inv_eval))
-            .chain(Some(&self.permuted_table_eval))
-    }
-
     pub(in crate::plonk) fn queries<'a>(
         &'a self,
         vk: &'a VerifyingKey<C>,
-        x: ChallengeX<C::Scalar>,
+        x: ChallengeX<C>,
     ) -> impl Iterator<Item = VerifierQuery<'a, C>> + Clone {
         let x_inv = vk.domain.rotate_omega(*x, Rotation(-1));
 
@@ -118,31 +175,31 @@ impl<C: CurveAffine> Proof<C> {
             // Open lookup product commitments at x
             .chain(Some(VerifierQuery {
                 point: *x,
-                commitment: &self.product_commitment,
+                commitment: &self.committed.product_commitment,
                 eval: self.product_eval,
             }))
             // Open lookup input commitments at x
             .chain(Some(VerifierQuery {
                 point: *x,
-                commitment: &self.permuted_input_commitment,
+                commitment: &self.committed.permuted_input_commitment,
                 eval: self.permuted_input_eval,
             }))
             // Open lookup table commitments at x
             .chain(Some(VerifierQuery {
                 point: *x,
-                commitment: &self.permuted_table_commitment,
+                commitment: &self.committed.permuted_table_commitment,
                 eval: self.permuted_table_eval,
             }))
             // Open lookup input commitments at \omega^{-1} x
             .chain(Some(VerifierQuery {
                 point: x_inv,
-                commitment: &self.permuted_input_commitment,
+                commitment: &self.committed.permuted_input_commitment,
                 eval: self.permuted_input_inv_eval,
             }))
             // Open lookup product commitments at \omega^{-1} x
             .chain(Some(VerifierQuery {
                 point: x_inv,
-                commitment: &self.product_commitment,
+                commitment: &self.committed.product_commitment,
                 eval: self.product_inv_eval,
             }))
     }

--- a/src/plonk/permutation.rs
+++ b/src/plonk/permutation.rs
@@ -52,11 +52,3 @@ pub(crate) struct ProvingKey<C: CurveAffine> {
     polys: Vec<Polynomial<C::Scalar, Coeff>>,
     cosets: Vec<Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,
 }
-
-#[derive(Debug, Clone)]
-pub(crate) struct Proof<C: CurveAffine> {
-    permutation_product_commitment: C,
-    permutation_product_eval: C::Scalar,
-    permutation_product_inv_eval: C::Scalar,
-    permutation_evals: Vec<C::Scalar>,
-}

--- a/src/plonk/permutation/prover.rs
+++ b/src/plonk/permutation/prover.rs
@@ -1,5 +1,4 @@
 use ff::Field;
-use std::io::Write;
 use std::iter;
 
 use super::{Argument, ProvingKey};
@@ -34,7 +33,7 @@ pub(crate) struct Evaluated<C: CurveAffine> {
 }
 
 impl Argument {
-    pub(in crate::plonk) fn commit<C: CurveAffine, W: Write, T: TranscriptWrite<W, C>>(
+    pub(in crate::plonk) fn commit<C: CurveAffine, T: TranscriptWrite<C>>(
         &self,
         params: &Params<C>,
         pk: &plonk::ProvingKey<C>,
@@ -237,7 +236,7 @@ impl<C: CurveAffine> super::ProvingKey<C> {
 }
 
 impl<C: CurveAffine> Constructed<C> {
-    pub(in crate::plonk) fn evaluate<W: Write, T: TranscriptWrite<W, C>>(
+    pub(in crate::plonk) fn evaluate<T: TranscriptWrite<C>>(
         self,
         pk: &plonk::ProvingKey<C>,
         pkey: &ProvingKey<C>,

--- a/src/plonk/permutation/verifier.rs
+++ b/src/plonk/permutation/verifier.rs
@@ -1,5 +1,4 @@
 use ff::Field;
-use std::io::Read;
 use std::iter;
 
 use super::{Argument, VerifyingKey};
@@ -22,7 +21,7 @@ pub struct Evaluated<C: CurveAffine> {
 }
 
 impl Argument {
-    pub(crate) fn absorb_product_commitment<C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
+    pub(crate) fn absorb_product_commitment<C: CurveAffine, T: TranscriptRead<C>>(
         &self,
         transcript: &mut T,
     ) -> Result<Committed<C>, Error> {
@@ -37,7 +36,7 @@ impl Argument {
 }
 
 impl<C: CurveAffine> Committed<C> {
-    pub(crate) fn evaluate<R: Read, T: TranscriptRead<R, C>>(
+    pub(crate) fn evaluate<T: TranscriptRead<C>>(
         self,
         vkey: &VerifyingKey<C>,
         transcript: &mut T,

--- a/src/plonk/permutation/verifier.rs
+++ b/src/plonk/permutation/verifier.rs
@@ -21,7 +21,7 @@ pub struct Evaluated<C: CurveAffine> {
 }
 
 impl Argument {
-    pub(crate) fn absorb_product_commitment<C: CurveAffine, T: TranscriptRead<C>>(
+    pub(crate) fn read_product_commitment<C: CurveAffine, T: TranscriptRead<C>>(
         &self,
         transcript: &mut T,
     ) -> Result<Committed<C>, Error> {

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -1,9 +1,10 @@
 use ff::Field;
+use std::io::Write;
 use std::iter;
 
 use super::{
     circuit::{Advice, Assignment, Circuit, Column, ConstraintSystem, Fixed},
-    vanishing, ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, ChallengeY, Error, Proof,
+    vanishing, ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, ChallengeY, Error,
     ProvingKey,
 };
 use crate::arithmetic::{eval_polynomial, Curve, CurveAffine, FieldExt};
@@ -12,371 +13,350 @@ use crate::poly::{
     multiopen::{self, ProverQuery},
     LagrangeCoeff, Polynomial,
 };
-use crate::transcript::{Hasher, Transcript};
+use crate::transcript::TranscriptWrite;
 
-impl<C: CurveAffine> Proof<C> {
-    /// This creates a proof for the provided `circuit` when given the public
-    /// parameters `params` and the proving key [`ProvingKey`] that was
-    /// generated previously for the same circuit.
-    pub fn create<
-        HBase: Hasher<C::Base>,
-        HScalar: Hasher<C::Scalar>,
-        ConcreteCircuit: Circuit<C::Scalar>,
-    >(
-        params: &Params<C>,
-        pk: &ProvingKey<C>,
-        circuit: &ConcreteCircuit,
-        aux: &[Polynomial<C::Scalar, LagrangeCoeff>],
-    ) -> Result<Self, Error> {
-        if aux.len() != pk.vk.cs.num_aux_columns {
-            return Err(Error::IncompatibleParams);
+/// This creates a proof for the provided `circuit` when given the public
+/// parameters `params` and the proving key [`ProvingKey`] that was
+/// generated previously for the same circuit.
+pub fn create_proof<
+    C: CurveAffine,
+    W: Write,
+    T: TranscriptWrite<W, C>,
+    ConcreteCircuit: Circuit<C::Scalar>,
+>(
+    params: &Params<C>,
+    pk: &ProvingKey<C>,
+    circuit: &ConcreteCircuit,
+    aux: &[Polynomial<C::Scalar, LagrangeCoeff>],
+    transcript: &mut T,
+) -> Result<(), Error> {
+    if aux.len() != pk.vk.cs.num_aux_columns {
+        return Err(Error::IncompatibleParams);
+    }
+
+    struct WitnessCollection<F: Field> {
+        advice: Vec<Polynomial<F, LagrangeCoeff>>,
+        _marker: std::marker::PhantomData<F>,
+    }
+
+    impl<F: Field> Assignment<F> for WitnessCollection<F> {
+        fn assign_advice(
+            &mut self,
+            column: Column<Advice>,
+            row: usize,
+            to: impl FnOnce() -> Result<F, Error>,
+        ) -> Result<(), Error> {
+            *self
+                .advice
+                .get_mut(column.index())
+                .and_then(|v| v.get_mut(row))
+                .ok_or(Error::BoundsFailure)? = to()?;
+
+            Ok(())
         }
 
-        struct WitnessCollection<F: Field> {
-            advice: Vec<Polynomial<F, LagrangeCoeff>>,
-            _marker: std::marker::PhantomData<F>,
+        fn assign_fixed(
+            &mut self,
+            _: Column<Fixed>,
+            _: usize,
+            _: impl FnOnce() -> Result<F, Error>,
+        ) -> Result<(), Error> {
+            // We only care about advice columns here
+
+            Ok(())
         }
 
-        impl<F: Field> Assignment<F> for WitnessCollection<F> {
-            fn assign_advice(
-                &mut self,
-                column: Column<Advice>,
-                row: usize,
-                to: impl FnOnce() -> Result<F, Error>,
-            ) -> Result<(), Error> {
-                *self
-                    .advice
-                    .get_mut(column.index())
-                    .and_then(|v| v.get_mut(row))
-                    .ok_or(Error::BoundsFailure)? = to()?;
+        fn copy(&mut self, _: usize, _: usize, _: usize, _: usize, _: usize) -> Result<(), Error> {
+            // We only care about advice columns here
 
-                Ok(())
-            }
-
-            fn assign_fixed(
-                &mut self,
-                _: Column<Fixed>,
-                _: usize,
-                _: impl FnOnce() -> Result<F, Error>,
-            ) -> Result<(), Error> {
-                // We only care about advice columns here
-
-                Ok(())
-            }
-
-            fn copy(
-                &mut self,
-                _: usize,
-                _: usize,
-                _: usize,
-                _: usize,
-                _: usize,
-            ) -> Result<(), Error> {
-                // We only care about advice columns here
-
-                Ok(())
-            }
+            Ok(())
         }
+    }
 
-        let domain = &pk.vk.domain;
-        let mut meta = ConstraintSystem::default();
-        let config = ConcreteCircuit::configure(&mut meta);
+    let domain = &pk.vk.domain;
+    let mut meta = ConstraintSystem::default();
+    let config = ConcreteCircuit::configure(&mut meta);
 
-        let mut witness = WitnessCollection {
-            advice: vec![domain.empty_lagrange(); meta.num_advice_columns],
-            _marker: std::marker::PhantomData,
-        };
+    let mut witness = WitnessCollection {
+        advice: vec![domain.empty_lagrange(); meta.num_advice_columns],
+        _marker: std::marker::PhantomData,
+    };
 
-        // Synthesize the circuit to obtain the witness and other information.
-        circuit.synthesize(&mut witness, config)?;
+    // Synthesize the circuit to obtain the witness and other information.
+    circuit.synthesize(&mut witness, config)?;
 
-        let witness = witness;
+    let witness = witness;
 
-        // Create a transcript for obtaining Fiat-Shamir challenges.
-        let mut transcript = Transcript::<C, HBase, HScalar>::new();
+    // Compute commitments to aux column polynomials
+    let aux_commitments_projective: Vec<_> = aux
+        .iter()
+        .map(|poly| params.commit_lagrange(poly, Blind::default()))
+        .collect();
+    let mut aux_commitments = vec![C::zero(); aux_commitments_projective.len()];
+    C::Projective::batch_to_affine(&aux_commitments_projective, &mut aux_commitments);
+    let aux_commitments = aux_commitments;
+    drop(aux_commitments_projective);
+    metrics::counter!("aux_commitments", aux_commitments.len() as u64);
 
-        // Compute commitments to aux column polynomials
-        let aux_commitments_projective: Vec<_> = aux
-            .iter()
-            .map(|poly| params.commit_lagrange(poly, Blind::default()))
-            .collect();
-        let mut aux_commitments = vec![C::zero(); aux_commitments_projective.len()];
-        C::Projective::batch_to_affine(&aux_commitments_projective, &mut aux_commitments);
-        let aux_commitments = aux_commitments;
-        drop(aux_commitments_projective);
-        metrics::counter!("aux_commitments", aux_commitments.len() as u64);
+    for commitment in &aux_commitments {
+        transcript
+            .common_point(*commitment)
+            .map_err(|_| Error::TranscriptError)?;
+    }
 
-        for commitment in &aux_commitments {
-            transcript
-                .absorb_point(commitment)
-                .map_err(|_| Error::TranscriptError)?;
-        }
+    let aux_polys: Vec<_> = aux
+        .iter()
+        .map(|poly| {
+            let lagrange_vec = domain.lagrange_from_vec(poly.to_vec());
+            domain.lagrange_to_coeff(lagrange_vec)
+        })
+        .collect();
 
-        let aux_polys: Vec<_> = aux
-            .iter()
-            .map(|poly| {
-                let lagrange_vec = domain.lagrange_from_vec(poly.to_vec());
-                domain.lagrange_to_coeff(lagrange_vec)
-            })
-            .collect();
+    let aux_cosets: Vec<_> = meta
+        .aux_queries
+        .iter()
+        .map(|&(column, at)| {
+            let poly = aux_polys[column.index()].clone();
+            domain.coeff_to_extended(poly, at)
+        })
+        .collect();
 
-        let aux_cosets: Vec<_> = meta
-            .aux_queries
-            .iter()
-            .map(|&(column, at)| {
-                let poly = aux_polys[column.index()].clone();
-                domain.coeff_to_extended(poly, at)
-            })
-            .collect();
+    // Compute commitments to advice column polynomials
+    let advice_blinds: Vec<_> = witness
+        .advice
+        .iter()
+        .map(|_| Blind(C::Scalar::rand()))
+        .collect();
+    let advice_commitments_projective: Vec<_> = witness
+        .advice
+        .iter()
+        .zip(advice_blinds.iter())
+        .map(|(poly, blind)| params.commit_lagrange(poly, *blind))
+        .collect();
+    let mut advice_commitments = vec![C::zero(); advice_commitments_projective.len()];
+    C::Projective::batch_to_affine(&advice_commitments_projective, &mut advice_commitments);
+    let advice_commitments = advice_commitments;
+    drop(advice_commitments_projective);
+    metrics::counter!("advice_commitments", advice_commitments.len() as u64);
 
-        // Compute commitments to advice column polynomials
-        let advice_blinds: Vec<_> = witness
-            .advice
-            .iter()
-            .map(|_| Blind(C::Scalar::rand()))
-            .collect();
-        let advice_commitments_projective: Vec<_> = witness
-            .advice
-            .iter()
-            .zip(advice_blinds.iter())
-            .map(|(poly, blind)| params.commit_lagrange(poly, *blind))
-            .collect();
-        let mut advice_commitments = vec![C::zero(); advice_commitments_projective.len()];
-        C::Projective::batch_to_affine(&advice_commitments_projective, &mut advice_commitments);
-        let advice_commitments = advice_commitments;
-        drop(advice_commitments_projective);
-        metrics::counter!("advice_commitments", advice_commitments.len() as u64);
+    for commitment in &advice_commitments {
+        transcript
+            .write_point(*commitment)
+            .map_err(|_| Error::TranscriptError)?;
+    }
 
-        for commitment in &advice_commitments {
-            transcript
-                .absorb_point(commitment)
-                .map_err(|_| Error::TranscriptError)?;
-        }
+    let advice_polys: Vec<_> = witness
+        .advice
+        .clone()
+        .into_iter()
+        .map(|poly| domain.lagrange_to_coeff(poly))
+        .collect();
 
-        let advice_polys: Vec<_> = witness
-            .advice
-            .clone()
+    let advice_cosets: Vec<_> = meta
+        .advice_queries
+        .iter()
+        .map(|&(column, at)| {
+            let poly = advice_polys[column.index()].clone();
+            domain.coeff_to_extended(poly, at)
+        })
+        .collect();
+
+    // Sample theta challenge for keeping lookup columns linearly independent
+    let theta = ChallengeTheta::get(transcript);
+
+    // Construct and commit to permuted values for each lookup
+    let lookups = pk
+        .vk
+        .cs
+        .lookups
+        .iter()
+        .map(|lookup| {
+            lookup.commit_permuted(
+                &pk,
+                &params,
+                &domain,
+                theta,
+                &witness.advice,
+                &pk.fixed_values,
+                &aux,
+                &advice_cosets,
+                &pk.fixed_cosets,
+                &aux_cosets,
+                transcript,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Sample beta challenge
+    let beta = ChallengeBeta::get(transcript);
+
+    // Sample gamma challenge
+    let gamma = ChallengeGamma::get(transcript);
+
+    // Commit to permutations, if any.
+    let permutations = pk
+        .vk
+        .cs
+        .permutations
+        .iter()
+        .zip(pk.permutations.iter())
+        .map(|(p, pkey)| p.commit(params, pk, pkey, &witness.advice, beta, gamma, transcript))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Construct and commit to products for each lookup
+    let lookups = lookups
+        .into_iter()
+        .map(|lookup| lookup.commit_product(&pk, &params, theta, beta, gamma, transcript))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Obtain challenge for keeping all separate gates linearly independent
+    let y = ChallengeY::get(transcript);
+
+    // Evaluate the h(X) polynomial's constraint system expressions for the permutation constraints, if any.
+    let (permutations, permutation_expressions): (Vec<_>, Vec<_>) = {
+        let tmp = permutations
             .into_iter()
-            .map(|poly| domain.lagrange_to_coeff(poly))
-            .collect();
-
-        let advice_cosets: Vec<_> = meta
-            .advice_queries
-            .iter()
-            .map(|&(column, at)| {
-                let poly = advice_polys[column.index()].clone();
-                domain.coeff_to_extended(poly, at)
-            })
-            .collect();
-
-        // Sample theta challenge for keeping lookup columns linearly independent
-        let theta = ChallengeTheta::get(&mut transcript);
-
-        // Construct and commit to permuted values for each lookup
-        let lookups = pk
-            .vk
-            .cs
-            .lookups
-            .iter()
-            .map(|lookup| {
-                lookup.commit_permuted(
-                    &pk,
-                    &params,
-                    &domain,
-                    theta,
-                    &witness.advice,
-                    &pk.fixed_values,
-                    &aux,
-                    &advice_cosets,
-                    &pk.fixed_cosets,
-                    &aux_cosets,
-                    &mut transcript,
-                )
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        // Sample beta challenge
-        let beta = ChallengeBeta::get(&mut transcript);
-
-        // Sample gamma challenge
-        let gamma = ChallengeGamma::get(&mut transcript);
-
-        // Commit to permutations, if any.
-        let permutations = pk
-            .vk
-            .cs
-            .permutations
-            .iter()
+            .zip(pk.vk.cs.permutations.iter())
             .zip(pk.permutations.iter())
-            .map(|(p, pkey)| {
-                p.commit(
-                    params,
-                    pk,
-                    pkey,
-                    &witness.advice,
-                    beta,
-                    gamma,
-                    &mut transcript,
-                )
+            .map(|((p, argument), pkey)| {
+                p.construct(pk, argument, pkey, &advice_cosets, beta, gamma)
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        // Construct and commit to products for each lookup
-        let lookups = lookups
+        tmp.into_iter().unzip()
+    };
+
+    // Evaluate the h(X) polynomial's constraint system expressions for the lookup constraints, if any.
+    let (lookups, lookup_expressions): (Vec<_>, Vec<_>) = {
+        let tmp = lookups
             .into_iter()
-            .map(|lookup| lookup.commit_product(&pk, &params, theta, beta, gamma, &mut transcript))
+            .map(|p| p.construct(pk, theta, beta, gamma))
             .collect::<Result<Vec<_>, _>>()?;
 
-        // Obtain challenge for keeping all separate gates linearly independent
-        let y = ChallengeY::get(&mut transcript);
+        tmp.into_iter().unzip()
+    };
 
-        // Evaluate the h(X) polynomial's constraint system expressions for the permutation constraints, if any.
-        let (permutations, permutation_expressions): (Vec<_>, Vec<_>) = {
-            let tmp = permutations
-                .into_iter()
-                .zip(pk.vk.cs.permutations.iter())
-                .zip(pk.permutations.iter())
-                .map(|((p, argument), pkey)| {
-                    p.construct(pk, argument, pkey, &advice_cosets, beta, gamma)
-                })
-                .collect::<Result<Vec<_>, _>>()?;
+    // Evaluate the h(X) polynomial's constraint system expressions for the constraints provided
+    let expressions = iter::empty()
+        // Custom constraints
+        .chain(meta.gates.iter().map(|poly| {
+            poly.evaluate(
+                &|index| pk.fixed_cosets[index].clone(),
+                &|index| advice_cosets[index].clone(),
+                &|index| aux_cosets[index].clone(),
+                &|a, b| a + &b,
+                &|a, b| a * &b,
+                &|a, scalar| a * scalar,
+            )
+        }))
+        // Permutation constraints, if any.
+        .chain(permutation_expressions.into_iter().flatten())
+        // Lookup constraints, if any.
+        .chain(lookup_expressions.into_iter().flatten());
 
-            tmp.into_iter().unzip()
-        };
+    // Construct the vanishing argument
+    let vanishing = vanishing::Argument::construct(params, domain, expressions, y, transcript)?;
 
-        // Evaluate the h(X) polynomial's constraint system expressions for the lookup constraints, if any.
-        let (lookups, lookup_expressions): (Vec<_>, Vec<_>) = {
-            let tmp = lookups
-                .into_iter()
-                .map(|p| p.construct(pk, theta, beta, gamma))
-                .collect::<Result<Vec<_>, _>>()?;
+    let x = ChallengeX::get(transcript);
 
-            tmp.into_iter().unzip()
-        };
+    // Evaluate polynomials at omega^i x
+    let advice_evals: Vec<_> = meta
+        .advice_queries
+        .iter()
+        .map(|&(column, at)| {
+            eval_polynomial(&advice_polys[column.index()], domain.rotate_omega(*x, at))
+        })
+        .collect();
 
-        // Evaluate the h(X) polynomial's constraint system expressions for the constraints provided
-        let expressions = iter::empty()
-            // Custom constraints
-            .chain(meta.gates.iter().map(|poly| {
-                poly.evaluate(
-                    &|index| pk.fixed_cosets[index].clone(),
-                    &|index| advice_cosets[index].clone(),
-                    &|index| aux_cosets[index].clone(),
-                    &|a, b| a + &b,
-                    &|a, b| a * &b,
-                    &|a, scalar| a * scalar,
-                )
-            }))
-            // Permutation constraints, if any.
-            .chain(permutation_expressions.into_iter().flatten())
-            // Lookup constraints, if any.
-            .chain(lookup_expressions.into_iter().flatten());
+    let aux_evals: Vec<_> = meta
+        .aux_queries
+        .iter()
+        .map(|&(column, at)| {
+            eval_polynomial(&aux_polys[column.index()], domain.rotate_omega(*x, at))
+        })
+        .collect();
 
-        // Construct the vanishing argument
-        let vanishing =
-            vanishing::Argument::construct(params, domain, expressions, y, &mut transcript)?;
+    let fixed_evals: Vec<_> = meta
+        .fixed_queries
+        .iter()
+        .map(|&(column, at)| {
+            eval_polynomial(&pk.fixed_polys[column.index()], domain.rotate_omega(*x, at))
+        })
+        .collect();
 
-        let x = ChallengeX::get(&mut transcript);
+    // Hash each column evaluation
+    for eval in advice_evals
+        .iter()
+        .chain(aux_evals.iter())
+        .chain(fixed_evals.iter())
+    {
+        transcript
+            .write_scalar(*eval)
+            .map_err(|_| Error::TranscriptError)?;
+    }
 
-        // Evaluate polynomials at omega^i x
-        let advice_evals: Vec<_> = meta
-            .advice_queries
-            .iter()
-            .map(|&(column, at)| {
-                eval_polynomial(&advice_polys[column.index()], domain.rotate_omega(*x, at))
-            })
-            .collect();
+    let vanishing = vanishing.evaluate(x, transcript)?;
 
-        let aux_evals: Vec<_> = meta
-            .aux_queries
-            .iter()
-            .map(|&(column, at)| {
-                eval_polynomial(&aux_polys[column.index()], domain.rotate_omega(*x, at))
-            })
-            .collect();
+    // Evaluate the permutations, if any, at omega^i x.
+    let permutations = permutations
+        .into_iter()
+        .zip(pk.permutations.iter())
+        .map(|(p, pkey)| p.evaluate(pk, pkey, x, transcript))
+        .collect::<Result<Vec<_>, _>>()?;
 
-        let fixed_evals: Vec<_> = meta
-            .fixed_queries
-            .iter()
-            .map(|&(column, at)| {
-                eval_polynomial(&pk.fixed_polys[column.index()], domain.rotate_omega(*x, at))
-            })
-            .collect();
+    // Evaluate the lookups, if any, at omega^i x.
+    let lookups = lookups
+        .into_iter()
+        .map(|p| p.evaluate(pk, x, transcript))
+        .collect::<Result<Vec<_>, _>>()?;
 
-        // Hash each column evaluation
-        for eval in advice_evals
-            .iter()
-            .chain(aux_evals.iter())
-            .chain(fixed_evals.iter())
-        {
-            transcript.absorb_scalar(*eval);
-        }
-
-        let vanishing = vanishing.evaluate(x, &mut transcript);
-
-        // Evaluate the permutations, if any, at omega^i x.
-        let permutations = permutations
-            .into_iter()
-            .zip(pk.permutations.iter())
-            .map(|(p, pkey)| p.evaluate(pk, pkey, x, &mut transcript))
-            .collect::<Vec<_>>();
-
-        // Evaluate the lookups, if any, at omega^i x.
-        let lookups = lookups
-            .into_iter()
-            .map(|p| p.evaluate(pk, x, &mut transcript))
-            .collect::<Vec<_>>();
-
-        let instances =
-            iter::empty()
-                .chain(pk.vk.cs.advice_queries.iter().enumerate().map(
-                    |(query_index, &(column, at))| ProverQuery {
-                        point: domain.rotate_omega(*x, at),
-                        poly: &advice_polys[column.index()],
-                        blind: advice_blinds[column.index()],
-                        eval: advice_evals[query_index],
-                    },
-                ))
-                .chain(pk.vk.cs.aux_queries.iter().enumerate().map(
-                    |(query_index, &(column, at))| ProverQuery {
+    let instances =
+        iter::empty()
+            .chain(pk.vk.cs.advice_queries.iter().enumerate().map(
+                |(query_index, &(column, at))| ProverQuery {
+                    point: domain.rotate_omega(*x, at),
+                    poly: &advice_polys[column.index()],
+                    blind: advice_blinds[column.index()],
+                    eval: advice_evals[query_index],
+                },
+            ))
+            .chain(
+                pk.vk
+                    .cs
+                    .aux_queries
+                    .iter()
+                    .enumerate()
+                    .map(|(query_index, &(column, at))| ProverQuery {
                         point: domain.rotate_omega(*x, at),
                         poly: &aux_polys[column.index()],
                         blind: Blind::default(),
                         eval: aux_evals[query_index],
-                    },
-                ))
-                .chain(pk.vk.cs.fixed_queries.iter().enumerate().map(
-                    |(query_index, &(column, at))| ProverQuery {
+                    }),
+            )
+            .chain(
+                pk.vk
+                    .cs
+                    .fixed_queries
+                    .iter()
+                    .enumerate()
+                    .map(|(query_index, &(column, at))| ProverQuery {
                         point: domain.rotate_omega(*x, at),
                         poly: &pk.fixed_polys[column.index()],
                         blind: Blind::default(),
                         eval: fixed_evals[query_index],
-                    },
-                ))
-                // We query the h(X) polynomial at x
-                .chain(vanishing.open(x))
-                .chain(
-                    permutations
-                        .iter()
-                        .zip(pk.permutations.iter())
-                        .map(|(p, pkey)| p.open(pk, pkey, x))
-                        .into_iter()
-                        .flatten(),
-                )
-                .chain(lookups.iter().map(|p| p.open(pk, x)).into_iter().flatten());
+                    }),
+            )
+            // We query the h(X) polynomial at x
+            .chain(vanishing.open(x))
+            .chain(
+                permutations
+                    .iter()
+                    .zip(pk.permutations.iter())
+                    .map(|(p, pkey)| p.open(pk, pkey, x))
+                    .into_iter()
+                    .flatten(),
+            )
+            .chain(lookups.iter().map(|p| p.open(pk, x)).into_iter().flatten());
 
-        let multiopening = multiopen::Proof::create(params, &mut transcript, instances)
-            .map_err(|_| Error::OpeningError)?;
-
-        Ok(Proof {
-            advice_commitments,
-            permutations: permutations.into_iter().map(|p| p.build()).collect(),
-            lookups: lookups.into_iter().map(|p| p.build()).collect(),
-            advice_evals,
-            fixed_evals,
-            aux_evals,
-            vanishing: vanishing.build(),
-            multiopening,
-        })
-    }
+    multiopen::create_proof(params, transcript, instances).map_err(|_| Error::OpeningError)
 }

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -1,5 +1,4 @@
 use ff::Field;
-use std::io::Write;
 use std::iter;
 
 use super::{
@@ -18,12 +17,7 @@ use crate::transcript::TranscriptWrite;
 /// This creates a proof for the provided `circuit` when given the public
 /// parameters `params` and the proving key [`ProvingKey`] that was
 /// generated previously for the same circuit.
-pub fn create_proof<
-    C: CurveAffine,
-    W: Write,
-    T: TranscriptWrite<W, C>,
-    ConcreteCircuit: Circuit<C::Scalar>,
->(
+pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circuit<C::Scalar>>(
     params: &Params<C>,
     pk: &ProvingKey<C>,
     circuit: &ConcreteCircuit,

--- a/src/plonk/vanishing.rs
+++ b/src/plonk/vanishing.rs
@@ -9,9 +9,3 @@ mod verifier;
 pub(crate) struct Argument<C: CurveAffine> {
     _marker: PhantomData<C>,
 }
-
-#[derive(Debug, Clone)]
-pub(crate) struct Proof<C: CurveAffine> {
-    h_commitments: Vec<C>,
-    h_evals: Vec<C::Scalar>,
-}

--- a/src/plonk/vanishing/prover.rs
+++ b/src/plonk/vanishing/prover.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use super::Argument;
 use crate::{
     arithmetic::{eval_polynomial, Curve, CurveAffine, FieldExt},
@@ -23,7 +21,7 @@ pub(in crate::plonk) struct Evaluated<C: CurveAffine> {
 }
 
 impl<C: CurveAffine> Argument<C> {
-    pub(in crate::plonk) fn construct<W: Write, T: TranscriptWrite<W, C>>(
+    pub(in crate::plonk) fn construct<T: TranscriptWrite<C>>(
         params: &Params<C>,
         domain: &EvaluationDomain<C::Scalar>,
         expressions: impl Iterator<Item = Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,
@@ -69,7 +67,7 @@ impl<C: CurveAffine> Argument<C> {
 }
 
 impl<C: CurveAffine> Constructed<C> {
-    pub(in crate::plonk) fn evaluate<W: Write, T: TranscriptWrite<W, C>>(
+    pub(in crate::plonk) fn evaluate<T: TranscriptWrite<C>>(
         self,
         x: ChallengeX<C>,
         transcript: &mut T,

--- a/src/plonk/vanishing/verifier.rs
+++ b/src/plonk/vanishing/verifier.rs
@@ -19,7 +19,7 @@ pub struct Evaluated<C: CurveAffine> {
 }
 
 impl<C: CurveAffine> Argument<C> {
-    pub(in crate::plonk) fn absorb_commitments<T: TranscriptRead<C>>(
+    pub(in crate::plonk) fn read_commitments<T: TranscriptRead<C>>(
         vk: &VerifyingKey<C>,
         transcript: &mut T,
     ) -> Result<Committed<C>, Error> {

--- a/src/plonk/vanishing/verifier.rs
+++ b/src/plonk/vanishing/verifier.rs
@@ -1,5 +1,4 @@
 use ff::Field;
-use std::io::Read;
 
 use crate::{
     arithmetic::CurveAffine,
@@ -20,7 +19,7 @@ pub struct Evaluated<C: CurveAffine> {
 }
 
 impl<C: CurveAffine> Argument<C> {
-    pub(in crate::plonk) fn absorb_commitments<R: Read, T: TranscriptRead<R, C>>(
+    pub(in crate::plonk) fn absorb_commitments<T: TranscriptRead<C>>(
         vk: &VerifyingKey<C>,
         transcript: &mut T,
     ) -> Result<Committed<C>, Error> {
@@ -33,7 +32,7 @@ impl<C: CurveAffine> Argument<C> {
 }
 
 impl<C: CurveAffine> Committed<C> {
-    pub(in crate::plonk) fn evaluate<R: Read, T: TranscriptRead<R, C>>(
+    pub(in crate::plonk) fn evaluate<T: TranscriptRead<C>>(
         self,
         transcript: &mut T,
     ) -> Result<Evaluated<C>, Error> {

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -1,5 +1,4 @@
 use ff::Field;
-use std::io::Read;
 use std::iter;
 
 use super::{
@@ -14,7 +13,7 @@ use crate::poly::{
 use crate::transcript::{read_n_points, read_n_scalars, TranscriptRead};
 
 /// Returns a boolean indicating whether or not the proof is valid
-pub fn verify_proof<'a, C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
+pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
     params: &'a Params<C>,
     vk: &VerifyingKey<C>,
     msm: MSM<'a, C>,

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -44,7 +44,7 @@ pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
         .cs
         .lookups
         .iter()
-        .map(|argument| argument.absorb_permuted_commitments(transcript))
+        .map(|argument| argument.read_permuted_commitments(transcript))
         .collect::<Result<Vec<_>, _>>()?;
 
     // Sample beta challenge
@@ -58,19 +58,19 @@ pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
         .cs
         .permutations
         .iter()
-        .map(|argument| argument.absorb_product_commitment(transcript))
+        .map(|argument| argument.read_product_commitment(transcript))
         .collect::<Result<Vec<_>, _>>()?;
 
     // Hash each lookup product commitment
     let lookups = lookups
         .into_iter()
-        .map(|lookup| lookup.absorb_product_commitment(transcript))
+        .map(|lookup| lookup.read_product_commitment(transcript))
         .collect::<Result<Vec<_>, _>>()?;
 
     // Sample y challenge, which keeps the gates linearly independent.
     let y = ChallengeY::get(transcript);
 
-    let vanishing = vanishing::Argument::absorb_commitments(vk, transcript)?;
+    let vanishing = vanishing::Argument::read_commitments(vk, transcript)?;
 
     // Sample x challenge, which is used to ensure the circuit is
     // satisfied with high probability.

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -16,9 +16,9 @@ use crate::transcript::{read_n_points, read_n_scalars, TranscriptRead};
 /// Returns a boolean indicating whether or not the proof is valid
 pub fn verify_proof<'a, C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
     params: &'a Params<C>,
-    vk: &'a VerifyingKey<C>,
+    vk: &VerifyingKey<C>,
     msm: MSM<'a, C>,
-    aux_commitments: &'a [C],
+    aux_commitments: &[C],
     transcript: &mut T,
 ) -> Result<Guard<'a, C>, Error> {
     // Check that aux_commitments matches the expected number of aux columns

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -1,216 +1,105 @@
 use ff::Field;
+use std::io::Read;
 use std::iter;
 
 use super::{
-    ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, ChallengeY, Error, Proof,
+    vanishing, ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, ChallengeY, Error,
     VerifyingKey,
 };
 use crate::arithmetic::{CurveAffine, FieldExt};
 use crate::poly::{
     commitment::{Guard, Params, MSM},
-    multiopen::VerifierQuery,
+    multiopen::{self, VerifierQuery},
 };
-use crate::transcript::{Hasher, Transcript};
+use crate::transcript::{read_n_points, read_n_scalars, TranscriptRead};
 
-impl<'a, C: CurveAffine> Proof<C> {
-    /// Returns a boolean indicating whether or not the proof is valid
-    pub fn verify<HBase: Hasher<C::Base>, HScalar: Hasher<C::Scalar>>(
-        &'a self,
-        params: &'a Params<C>,
-        vk: &'a VerifyingKey<C>,
-        msm: MSM<'a, C>,
-        aux_commitments: &'a [C],
-    ) -> Result<Guard<'a, C>, Error> {
-        self.check_lengths(vk, aux_commitments)?;
-
-        // Check that aux_commitments matches the expected number of aux_columns
-        // and self.aux_evals
-        if aux_commitments.len() != vk.cs.num_aux_columns
-            || self.aux_evals.len() != vk.cs.num_aux_columns
-        {
-            return Err(Error::IncompatibleParams);
-        }
-
-        // Create a transcript for obtaining Fiat-Shamir challenges.
-        let mut transcript = Transcript::<C, HBase, HScalar>::new();
-
-        // Hash the aux (external) commitments into the transcript
-        for commitment in aux_commitments {
-            transcript
-                .absorb_point(commitment)
-                .map_err(|_| Error::TranscriptError)?;
-        }
-
-        // Hash the prover's advice commitments into the transcript
-        for commitment in &self.advice_commitments {
-            transcript
-                .absorb_point(commitment)
-                .map_err(|_| Error::TranscriptError)?;
-        }
-
-        // Sample theta challenge for keeping lookup columns linearly independent
-        let theta = ChallengeTheta::get(&mut transcript);
-
-        // Hash each lookup permuted commitment
-        for lookup in &self.lookups {
-            lookup.absorb_permuted_commitments(&mut transcript)?;
-        }
-
-        // Sample beta challenge
-        let beta = ChallengeBeta::get(&mut transcript);
-
-        // Sample gamma challenge
-        let gamma = ChallengeGamma::get(&mut transcript);
-
-        // Hash each permutation product commitment
-        for permutation in &self.permutations {
-            permutation.absorb_commitments(&mut transcript)?;
-        }
-
-        // Hash each lookup product commitment
-        for lookup in &self.lookups {
-            lookup.absorb_product_commitment(&mut transcript)?;
-        }
-
-        // Sample y challenge, which keeps the gates linearly independent.
-        let y = ChallengeY::get(&mut transcript);
-
-        self.vanishing.absorb_commitments(&mut transcript)?;
-
-        // Sample x challenge, which is used to ensure the circuit is
-        // satisfied with high probability.
-        let x = ChallengeX::get(&mut transcript);
-
-        // This check ensures the circuit is satisfied so long as the polynomial
-        // commitments open to the correct values.
-        self.check_hx(params, vk, theta, beta, gamma, y, x)?;
-
-        for eval in self
-            .advice_evals
-            .iter()
-            .chain(self.aux_evals.iter())
-            .chain(self.fixed_evals.iter())
-            .chain(self.vanishing.evals())
-            .chain(
-                self.permutations
-                    .iter()
-                    .map(|p| p.evals())
-                    .into_iter()
-                    .flatten(),
-            )
-            .chain(self.lookups.iter().map(|p| p.evals()).into_iter().flatten())
-        {
-            transcript.absorb_scalar(*eval);
-        }
-
-        let queries =
-            iter::empty()
-                .chain(vk.cs.advice_queries.iter().enumerate().map(
-                    |(query_index, &(column, at))| VerifierQuery {
-                        point: vk.domain.rotate_omega(*x, at),
-                        commitment: &self.advice_commitments[column.index()],
-                        eval: self.advice_evals[query_index],
-                    },
-                ))
-                .chain(
-                    vk.cs
-                        .aux_queries
-                        .iter()
-                        .enumerate()
-                        .map(|(query_index, &(column, at))| VerifierQuery {
-                            point: vk.domain.rotate_omega(*x, at),
-                            commitment: &aux_commitments[column.index()],
-                            eval: self.aux_evals[query_index],
-                        }),
-                )
-                .chain(vk.cs.fixed_queries.iter().enumerate().map(
-                    |(query_index, &(column, at))| VerifierQuery {
-                        point: vk.domain.rotate_omega(*x, at),
-                        commitment: &vk.fixed_commitments[column.index()],
-                        eval: self.fixed_evals[query_index],
-                    },
-                ))
-                .chain(self.vanishing.queries(x));
-
-        // We are now convinced the circuit is satisfied so long as the
-        // polynomial commitments open to the correct values.
-        self.multiopening
-            .verify(
-                params,
-                &mut transcript,
-                queries
-                    .chain(
-                        self.permutations
-                            .iter()
-                            .zip(vk.permutations.iter())
-                            .map(|(p, vkey)| p.queries(vk, vkey, x))
-                            .into_iter()
-                            .flatten(),
-                    )
-                    .chain(
-                        self.lookups
-                            .iter()
-                            .map(|p| p.queries(vk, x))
-                            .into_iter()
-                            .flatten(),
-                    ),
-                msm,
-            )
-            .map_err(|_| Error::OpeningError)
+/// Returns a boolean indicating whether or not the proof is valid
+pub fn verify_proof<'a, C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
+    params: &'a Params<C>,
+    vk: &'a VerifyingKey<C>,
+    msm: MSM<'a, C>,
+    aux_commitments: &'a [C],
+    transcript: &mut T,
+) -> Result<Guard<'a, C>, Error> {
+    // Check that aux_commitments matches the expected number of aux columns
+    if aux_commitments.len() != vk.cs.num_aux_columns {
+        return Err(Error::IncompatibleParams);
     }
 
-    /// Checks that the lengths of vectors are consistent with the constraint
-    /// system
-    fn check_lengths(&self, vk: &VerifyingKey<C>, aux_commitments: &[C]) -> Result<(), Error> {
-        // Check that aux_commitments matches the expected number of aux_columns
-        // and self.aux_evals
-        if aux_commitments.len() != vk.cs.num_aux_columns
-            || self.aux_evals.len() != vk.cs.num_aux_columns
-        {
-            return Err(Error::IncompatibleParams);
-        }
-
-        if self.fixed_evals.len() != vk.cs.fixed_queries.len() {
-            return Err(Error::IncompatibleParams);
-        }
-
-        if self.advice_evals.len() != vk.cs.advice_queries.len() {
-            return Err(Error::IncompatibleParams);
-        }
-
-        if self.permutations.len() != vk.cs.permutations.len() {
-            return Err(Error::IncompatibleParams);
-        }
-
-        for (permutation, p) in self.permutations.iter().zip(vk.cs.permutations.iter()) {
-            permutation.check_lengths(p)?;
-        }
-
-        self.vanishing.check_lengths(vk)?;
-
-        if self.lookups.len() != vk.cs.lookups.len() {
-            return Err(Error::IncompatibleParams);
-        }
-
-        if self.advice_commitments.len() != vk.cs.num_advice_columns {
-            return Err(Error::IncompatibleParams);
-        }
-
-        Ok(())
+    // Hash the aux (external) commitments into the transcript
+    for commitment in aux_commitments {
+        transcript
+            .common_point(*commitment)
+            .map_err(|_| Error::TranscriptError)?
     }
 
-    /// Checks that this proof's h_evals are correct, and thus that all of the
-    /// rules are satisfied.
-    fn check_hx(
-        &self,
-        params: &'a Params<C>,
-        vk: &VerifyingKey<C>,
-        theta: ChallengeTheta<C::Scalar>,
-        beta: ChallengeBeta<C::Scalar>,
-        gamma: ChallengeGamma<C::Scalar>,
-        y: ChallengeY<C::Scalar>,
-        x: ChallengeX<C::Scalar>,
-    ) -> Result<(), Error> {
+    // Hash the prover's advice commitments into the transcript
+    let advice_commitments =
+        read_n_points(transcript, vk.cs.num_advice_columns).map_err(|_| Error::TranscriptError)?;
+
+    // Sample theta challenge for keeping lookup columns linearly independent
+    let theta = ChallengeTheta::get(transcript);
+
+    // Hash each lookup permuted commitment
+    let lookups = vk
+        .cs
+        .lookups
+        .iter()
+        .map(|argument| argument.absorb_permuted_commitments(transcript))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Sample beta challenge
+    let beta = ChallengeBeta::get(transcript);
+
+    // Sample gamma challenge
+    let gamma = ChallengeGamma::get(transcript);
+
+    // Hash each permutation product commitment
+    let permutations = vk
+        .cs
+        .permutations
+        .iter()
+        .map(|argument| argument.absorb_product_commitment(transcript))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Hash each lookup product commitment
+    let lookups = lookups
+        .into_iter()
+        .map(|lookup| lookup.absorb_product_commitment(transcript))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Sample y challenge, which keeps the gates linearly independent.
+    let y = ChallengeY::get(transcript);
+
+    let vanishing = vanishing::Argument::absorb_commitments(vk, transcript)?;
+
+    // Sample x challenge, which is used to ensure the circuit is
+    // satisfied with high probability.
+    let x = ChallengeX::get(transcript);
+
+    let advice_evals = read_n_scalars(transcript, vk.cs.advice_queries.len())
+        .map_err(|_| Error::TranscriptError)?;
+    let aux_evals =
+        read_n_scalars(transcript, vk.cs.aux_queries.len()).map_err(|_| Error::TranscriptError)?;
+    let fixed_evals = read_n_scalars(transcript, vk.cs.fixed_queries.len())
+        .map_err(|_| Error::TranscriptError)?;
+
+    let vanishing = vanishing.evaluate(transcript)?;
+
+    let permutations = permutations
+        .into_iter()
+        .zip(vk.permutations.iter())
+        .map(|(permutation, vkey)| permutation.evaluate(vkey, transcript))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let lookups = lookups
+        .into_iter()
+        .map(|lookup| lookup.evaluate(transcript))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // This check ensures the circuit is satisfied so long as the polynomial
+    // commitments open to the correct values.
+    {
         // x^n
         let xn = x.pow(&[params.n as u64, 0, 0, 0]);
 
@@ -225,26 +114,26 @@ impl<'a, C: CurveAffine> Proof<C> {
             // Evaluate the circuit using the custom gates provided
             .chain(vk.cs.gates.iter().map(|poly| {
                 poly.evaluate(
-                    &|index| self.fixed_evals[index],
-                    &|index| self.advice_evals[index],
-                    &|index| self.aux_evals[index],
+                    &|index| fixed_evals[index],
+                    &|index| advice_evals[index],
+                    &|index| aux_evals[index],
                     &|a, b| a + &b,
                     &|a, b| a * &b,
                     &|a, scalar| a * &scalar,
                 )
             }))
             .chain(
-                self.permutations
+                permutations
                     .iter()
                     .zip(vk.cs.permutations.iter())
                     .map(|(p, argument)| {
-                        p.expressions(vk, argument, &self.advice_evals, l_0, beta, gamma, x)
+                        p.expressions(vk, argument, &advice_evals, l_0, beta, gamma, x)
                     })
                     .into_iter()
                     .flatten(),
             )
             .chain(
-                self.lookups
+                lookups
                     .iter()
                     .zip(vk.cs.lookups.iter())
                     .map(|(p, argument)| {
@@ -255,15 +144,70 @@ impl<'a, C: CurveAffine> Proof<C> {
                             theta,
                             beta,
                             gamma,
-                            &self.advice_evals,
-                            &self.fixed_evals,
-                            &self.aux_evals,
+                            &advice_evals,
+                            &fixed_evals,
+                            &aux_evals,
                         )
                     })
                     .into_iter()
                     .flatten(),
             );
 
-        self.vanishing.verify(expressions, y, xn)
+        vanishing.verify(expressions, y, xn)?;
     }
+
+    let queries = iter::empty()
+        .chain(
+            vk.cs
+                .advice_queries
+                .iter()
+                .enumerate()
+                .map(|(query_index, &(column, at))| VerifierQuery {
+                    point: vk.domain.rotate_omega(*x, at),
+                    commitment: &advice_commitments[column.index()],
+                    eval: advice_evals[query_index],
+                }),
+        )
+        .chain(
+            vk.cs
+                .aux_queries
+                .iter()
+                .enumerate()
+                .map(|(query_index, &(column, at))| VerifierQuery {
+                    point: vk.domain.rotate_omega(*x, at),
+                    commitment: &aux_commitments[column.index()],
+                    eval: aux_evals[query_index],
+                }),
+        )
+        .chain(
+            vk.cs
+                .fixed_queries
+                .iter()
+                .enumerate()
+                .map(|(query_index, &(column, at))| VerifierQuery {
+                    point: vk.domain.rotate_omega(*x, at),
+                    commitment: &vk.fixed_commitments[column.index()],
+                    eval: fixed_evals[query_index],
+                }),
+        )
+        .chain(vanishing.queries(x))
+        .chain(
+            permutations
+                .iter()
+                .zip(vk.permutations.iter())
+                .map(|(p, vkey)| p.queries(vk, vkey, x))
+                .into_iter()
+                .flatten(),
+        )
+        .chain(
+            lookups
+                .iter()
+                .map(|p| p.queries(vk, x))
+                .into_iter()
+                .flatten(),
+        );
+
+    // We are now convinced the circuit is satisfied so long as the
+    // polynomial commitments open to the correct values.
+    multiopen::verify_proof(params, transcript, queries, msm).map_err(|_| Error::OpeningError)
 }

--- a/src/poly/commitment.rs
+++ b/src/poly/commitment.rs
@@ -229,8 +229,8 @@ fn test_commit_lagrange_epaffine() {
     const K: u32 = 6;
 
     use crate::pasta::{EpAffine, Fq};
-    use crate::transcript::DummyHashWriter;
-    let params = Params::<EpAffine>::new::<DummyHashWriter<std::io::Sink, _>>(K);
+    use crate::transcript::DummyHashWrite;
+    let params = Params::<EpAffine>::new::<DummyHashWrite<std::io::Sink, _>>(K);
     let domain = super::EvaluationDomain::new(1, K);
 
     let mut a = domain.empty_lagrange();
@@ -251,8 +251,8 @@ fn test_commit_lagrange_eqaffine() {
     const K: u32 = 6;
 
     use crate::pasta::{EqAffine, Fp};
-    use crate::transcript::DummyHashWriter;
-    let params = Params::<EqAffine>::new::<DummyHashWriter<std::io::Sink, _>>(K);
+    use crate::transcript::DummyHashWrite;
+    let params = Params::<EqAffine>::new::<DummyHashWrite<std::io::Sink, _>>(K);
     let domain = super::EvaluationDomain::new(1, K);
 
     let mut a = domain.empty_lagrange();
@@ -281,11 +281,10 @@ fn test_opening_proof() {
     use crate::arithmetic::{eval_polynomial, Curve, FieldExt};
     use crate::pasta::{EpAffine, Fq};
     use crate::transcript::{
-        ChallengeScalar, DummyHashReader, DummyHashWriter, Transcript, TranscriptRead,
-        TranscriptWrite,
+        ChallengeScalar, DummyHashRead, DummyHashWrite, Transcript, TranscriptRead, TranscriptWrite,
     };
 
-    let params = Params::<EpAffine>::new::<DummyHashWriter<std::io::Sink, _>>(K);
+    let params = Params::<EpAffine>::new::<DummyHashWrite<std::io::Sink, _>>(K);
     let domain = EvaluationDomain::new(1, K);
 
     let mut px = domain.empty_coeff();
@@ -298,7 +297,7 @@ fn test_opening_proof() {
 
     let p = params.commit(&px, blind).to_affine();
 
-    let mut transcript = DummyHashWriter::<Vec<u8>, EpAffine>::init(vec![], Field::zero());
+    let mut transcript = DummyHashWrite::<Vec<u8>, EpAffine>::init(vec![], Field::zero());
     transcript.write_point(p).unwrap();
     let x = ChallengeScalar::<_, ()>::get(&mut transcript);
     // Evaluate the polynomial
@@ -312,7 +311,7 @@ fn test_opening_proof() {
     };
 
     // Verify the opening proof
-    let mut transcript = DummyHashReader::<&[u8], EpAffine>::init(&proof[..], Field::zero());
+    let mut transcript = DummyHashRead::<&[u8], EpAffine>::init(&proof[..], Field::zero());
     let p_prime = transcript.read_point().unwrap();
     assert_eq!(p, p_prime);
     let x_prime = ChallengeScalar::<_, ()>::get(&mut transcript);

--- a/src/poly/commitment.rs
+++ b/src/poly/commitment.rs
@@ -322,15 +322,7 @@ fn test_opening_proof() {
 
     let mut commitment_msm = params.empty_msm();
     commitment_msm.append_term(Field::one(), p);
-    let guard = verify_proof(
-        &params,
-        params.empty_msm(),
-        &mut transcript,
-        *x,
-        commitment_msm,
-        v,
-    )
-    .unwrap();
+    let guard = verify_proof(&params, commitment_msm, &mut transcript, *x, v).unwrap();
     let ch_verifier = transcript.squeeze_challenge();
     assert_eq!(ch_prover, ch_verifier);
 

--- a/src/poly/commitment.rs
+++ b/src/poly/commitment.rs
@@ -9,6 +9,7 @@ use super::{Coeff, LagrangeCoeff, Polynomial};
 use crate::arithmetic::{best_fft, best_multiexp, parallelize, Curve, CurveAffine, FieldExt};
 
 use ff::{Field, PrimeField};
+use std::convert::TryInto;
 use std::ops::{Add, AddAssign, Mul, MulAssign};
 
 mod msm;
@@ -47,9 +48,7 @@ impl<C: CurveAffine> Params<C> {
             loop {
                 let mut hasher = hasher.clone();
                 hasher.update(&(trial.to_le_bytes())[..]);
-                let mut hash = [0u8; 32];
-                hash[..].copy_from_slice(hasher.finalize().as_bytes());
-                let p = C::from_bytes(&hash);
+                let p = C::from_bytes(&hasher.finalize().as_bytes().try_into().unwrap());
                 if bool::from(p.is_some()) {
                     break p.unwrap();
                 }

--- a/src/poly/commitment/prover.rs
+++ b/src/poly/commitment/prover.rs
@@ -140,7 +140,7 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>>(
     let a = a[0];
 
     transcript.write_scalar(a)?;
-    transcript.write_scalar(blind)?;
+    transcript.write_scalar(blind)?; // \xi
 
     Ok(())
 }

--- a/src/poly/commitment/prover.rs
+++ b/src/poly/commitment/prover.rs
@@ -7,7 +7,7 @@ use crate::arithmetic::{
     CurveAffine, FieldExt,
 };
 use crate::transcript::{Challenge, ChallengeScalar, TranscriptWrite};
-use std::io::{self, Write};
+use std::io;
 
 /// Create a polynomial commitment opening proof for the polynomial defined
 /// by the coefficients `px`, the blinding factor `blind` used for the
@@ -22,7 +22,7 @@ use std::io::{self, Write};
 /// opening v, and the point x. It's probably also nice for the transcript
 /// to have seen the elliptic curve description and the SRS, if you want to
 /// be rigorous.
-pub fn create_proof<C: CurveAffine, W: Write, T: TranscriptWrite<W, C>>(
+pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>>(
     params: &Params<C>,
     transcript: &mut T,
     px: &Polynomial<C::Scalar, Coeff>,

--- a/src/poly/commitment/prover.rs
+++ b/src/poly/commitment/prover.rs
@@ -1,202 +1,183 @@
 use ff::Field;
 
-use super::super::{Coeff, Error, Polynomial};
-use super::{Blind, Params, Proof};
+use super::super::{Coeff, Polynomial};
+use super::{Blind, Params};
 use crate::arithmetic::{
-    best_multiexp, compute_inner_product, parallelize, small_multiexp, Curve, CurveAffine, FieldExt,
+    best_multiexp, compute_inner_product, eval_polynomial, parallelize, small_multiexp, Curve,
+    CurveAffine, FieldExt,
 };
-use crate::transcript::{Challenge, ChallengeScalar, Hasher, Transcript};
+use crate::transcript::{Challenge, ChallengeScalar, TranscriptWrite};
+use std::io::{self, Write};
 
-impl<C: CurveAffine> Proof<C> {
-    /// Create a polynomial commitment opening proof for the polynomial defined
-    /// by the coefficients `px`, the blinding factor `blind` used for the
-    /// polynomial commitment, and the point `x` that the polynomial is
-    /// evaluated at.
-    ///
-    /// This function will panic if the provided polynomial is too large with
-    /// respect to the polynomial commitment parameters.
-    ///
-    /// **Important:** This function assumes that the provided `transcript` has
-    /// already seen the common inputs: the polynomial commitment P, the claimed
-    /// opening v, and the point x. It's probably also nice for the transcript
-    /// to have seen the elliptic curve description and the SRS, if you want to
-    /// be rigorous.
-    pub fn create<HBase, HScalar>(
-        params: &Params<C>,
-        transcript: &mut Transcript<C, HBase, HScalar>,
-        px: &Polynomial<C::Scalar, Coeff>,
-        blind: Blind<C::Scalar>,
-        x: C::Scalar,
-    ) -> Result<Self, Error>
-    where
-        HBase: Hasher<C::Base>,
-        HScalar: Hasher<C::Scalar>,
+/// Create a polynomial commitment opening proof for the polynomial defined
+/// by the coefficients `px`, the blinding factor `blind` used for the
+/// polynomial commitment, and the point `x` that the polynomial is
+/// evaluated at.
+///
+/// This function will panic if the provided polynomial is too large with
+/// respect to the polynomial commitment parameters.
+///
+/// **Important:** This function assumes that the provided `transcript` has
+/// already seen the common inputs: the polynomial commitment P, the claimed
+/// opening v, and the point x. It's probably also nice for the transcript
+/// to have seen the elliptic curve description and the SRS, if you want to
+/// be rigorous.
+pub fn create_proof<C: CurveAffine, W: Write, T: TranscriptWrite<W, C>>(
+    params: &Params<C>,
+    transcript: &mut T,
+    px: &Polynomial<C::Scalar, Coeff>,
+    blind: Blind<C::Scalar>,
+    x: C::Scalar,
+) -> io::Result<()> {
+    // We're limited to polynomials of degree n - 1.
+    assert!(px.len() <= params.n as usize);
+
+    // Sample a random polynomial (of same degree) that has a root at x, first
+    // by setting all coefficients to random values.
+    let mut s_poly = (*px).clone();
+    for coeff in s_poly.iter_mut() {
+        *coeff = C::Scalar::rand();
+    }
+    // Evaluate the random polynomial at x
+    let v_prime = eval_polynomial(&s_poly[..], x);
+    // Subtract constant coefficient to get a random polynomial with a root at x
+    s_poly[0] = s_poly[0] - &v_prime;
+    // And sample a random blind
+    let s_poly_blind = Blind(C::Scalar::rand());
+
+    // Write a commitment to the random polynomial to the transcript
+    let s_poly_commitment = params.commit(&s_poly, s_poly_blind).to_affine();
+    transcript.write_point(s_poly_commitment)?;
+
+    // Challenge that will ensure that the prover cannot change P but can only
+    // witness a random polynomial commitment that agrees with P at x, with high
+    // probability.
+    let iota = *ChallengeScalar::<C, ()>::get(transcript);
+
+    // Challenge that ensures that the prover did not interfere with the U term
+    // in their commitments.
+    let z = *ChallengeScalar::<C, ()>::get(transcript);
+
+    // We'll be opening `s_poly_commitment * iota + P - [v] G_0` to ensure it
+    // has a root at zero.
+    let mut final_poly = s_poly * iota + px;
+    let v = eval_polynomial(&final_poly, x);
+    final_poly[0] = final_poly[0] - &v;
+    drop(px);
+    let blind = s_poly_blind * Blind(iota) + blind;
+    let mut blind = blind.0;
+    drop(s_poly_blind);
+
+    // Initialize the vector `a` as the coefficients of the polynomial,
+    // rounding up to the parameters.
+    let mut a = final_poly.values;
+    a.resize(params.n as usize, C::Scalar::zero());
+
+    // Initialize the vector `b` as the powers of `x`. The inner product of
+    // `a` and `b` is the evaluation of the polynomial at `x`.
+    let mut b = Vec::with_capacity(1 << params.k);
     {
-        let mut blind = blind.0;
+        let mut cur = C::Scalar::one();
+        for _ in 0..(1 << params.k) {
+            b.push(cur);
+            cur *= &x;
+        }
+    }
 
-        // We're limited to polynomials of degree n - 1.
-        assert!(px.len() <= params.n as usize);
+    // Initialize the vector `G` from the SRS. We'll be progressively
+    // collapsing this vector into smaller and smaller vectors until it is
+    // of length 1.
+    let mut g = params.g.clone();
 
-        // Compute U
-        let u = {
-            let u_x = transcript.squeeze();
-            // y^2 = x^3 + B
-            let u_y2 = u_x.square() * &u_x + &C::b();
-            if let Some(u_y) = u_y2.deterministic_sqrt() {
-                C::from_xy(u_x, u_y).unwrap()
+    // Perform the inner product argument, round by round.
+    for k in (1..=params.k).rev() {
+        let half = 1 << (k - 1); // half the length of `a`, `b`, `G`
+
+        // Compute L, R
+        //
+        // TODO: If we modify multiexp to take "extra" bases, we could speed
+        // this piece up a bit by combining the multiexps.
+        metrics::counter!("multiexp", 2, "val" => "l/r", "size" => format!("{}", half));
+        let l = best_multiexp(&a[0..half], &g[half..]);
+        let r = best_multiexp(&a[half..], &g[0..half]);
+        let value_l = compute_inner_product(&a[0..half], &b[half..]);
+        let value_r = compute_inner_product(&a[half..], &b[0..half]);
+        let mut l_randomness = C::Scalar::rand();
+        let r_randomness = C::Scalar::rand();
+        metrics::counter!("multiexp", 2, "val" => "l/r", "size" => "2");
+        let l = l + &best_multiexp(&[value_l * &z, l_randomness], &[params.u, params.h]);
+        let r = r + &best_multiexp(&[value_r * &z, r_randomness], &[params.u, params.h]);
+        let mut l = l.to_affine();
+        let r = r.to_affine();
+
+        let challenge = loop {
+            // We'll fork the transcript and adjust our randomness
+            // until the challenge is a square.
+            let mut transcript = transcript.fork();
+
+            // Feed L and R into the cloned transcript.
+            // We expect these to not be points at infinity due to the randomness.
+            transcript.write_point(l)?;
+            transcript.write_point(r)?;
+
+            // ... and get the squared challenge.
+            let challenge_sq_packed = Challenge::get(&mut transcript);
+            let challenge_sq = *ChallengeScalar::<C, ()>::from(challenge_sq_packed);
+
+            // There might be no square root, in which case we'll fork the
+            // transcript.
+            let challenge = challenge_sq.deterministic_sqrt();
+            if let Some(challenge) = challenge {
+                break challenge;
             } else {
-                return Err(Error::SamplingError);
+                // Try again, with slightly different randomness
+                l = (l + params.h).to_affine();
+                l_randomness += &C::Scalar::one();
             }
         };
 
-        // Initialize the vector `a` as the coefficients of the polynomial,
-        // rounding up to the parameters.
-        let mut a = px.to_vec();
-        a.resize(params.n as usize, C::Scalar::zero());
+        // Challenge is unlikely to be zero.
+        let challenge_inv = challenge.invert().unwrap();
+        let challenge_sq_inv = challenge_inv.square();
+        let challenge_sq = challenge.square();
 
-        // Initialize the vector `b` as the powers of `x`. The inner product of
-        // `a` and `b` is the evaluation of the polynomial at `x`.
-        let mut b = Vec::with_capacity(1 << params.k);
+        // Feed L and R into the real transcript
+        transcript.write_point(l)?;
+        transcript.write_point(r)?;
+
+        // And obtain the challenge, even though we already have it, since
+        // squeezing affects the transcript.
         {
-            let mut cur = C::Scalar::one();
-            for _ in 0..(1 << params.k) {
-                b.push(cur);
-                cur *= &x;
-            }
+            let challenge_sq_expected = ChallengeScalar::<_, ()>::get(transcript);
+            assert_eq!(challenge_sq, *challenge_sq_expected);
         }
 
-        // Initialize the vector `G` from the SRS. We'll be progressively
-        // collapsing this vector into smaller and smaller vectors until it is
-        // of length 1.
-        let mut g = params.g.clone();
-
-        // Perform the inner product argument, round by round.
-        let mut rounds = Vec::with_capacity(params.k as usize);
-        for k in (1..=params.k).rev() {
-            let half = 1 << (k - 1); // half the length of `a`, `b`, `G`
-
-            // Compute L, R
-            //
-            // TODO: If we modify multiexp to take "extra" bases, we could speed
-            // this piece up a bit by combining the multiexps.
-            metrics::counter!("multiexp", 2, "val" => "l/r", "size" => format!("{}", half));
-            let l = best_multiexp(&a[0..half], &g[half..]);
-            let r = best_multiexp(&a[half..], &g[0..half]);
-            let value_l = compute_inner_product(&a[0..half], &b[half..]);
-            let value_r = compute_inner_product(&a[half..], &b[0..half]);
-            let mut l_randomness = C::Scalar::rand();
-            let r_randomness = C::Scalar::rand();
-            metrics::counter!("multiexp", 2, "val" => "l/r", "size" => "2");
-            let l = l + &best_multiexp(&[value_l, l_randomness], &[u, params.h]);
-            let r = r + &best_multiexp(&[value_r, r_randomness], &[u, params.h]);
-            let mut l = l.to_affine();
-            let r = r.to_affine();
-
-            let challenge = loop {
-                // We'll fork the transcript and adjust our randomness
-                // until the challenge is a square.
-                let mut transcript = transcript.clone();
-
-                // Feed L and R into the cloned transcript.
-                // We expect these to not be points at infinity due to the randomness.
-                transcript
-                    .absorb_point(&l)
-                    .map_err(|_| Error::SamplingError)?;
-                transcript
-                    .absorb_point(&r)
-                    .map_err(|_| Error::SamplingError)?;
-
-                // ... and get the squared challenge.
-                let challenge_sq_packed = Challenge::get(&mut transcript);
-                let challenge_sq: C::Scalar = *ChallengeScalar::<_, ()>::from(challenge_sq_packed);
-
-                // There might be no square root, in which case we'll fork the
-                // transcript.
-                let challenge = challenge_sq.deterministic_sqrt();
-                if let Some(challenge) = challenge {
-                    break challenge;
-                } else {
-                    // Try again, with slightly different randomness
-                    l = (l + params.h).to_affine();
-                    l_randomness += &C::Scalar::one();
-                }
-            };
-
-            // Challenge is unlikely to be zero.
-            let challenge_inv = challenge.invert().unwrap();
-            let challenge_sq_inv = challenge_inv.square();
-            let challenge_sq = challenge.square();
-
-            // Feed L and R into the real transcript
-            transcript
-                .absorb_point(&l)
-                .map_err(|_| Error::SamplingError)?;
-            transcript
-                .absorb_point(&r)
-                .map_err(|_| Error::SamplingError)?;
-
-            // And obtain the challenge, even though we already have it, since
-            // squeezing affects the transcript.
-            {
-                let challenge_sq_expected = ChallengeScalar::<_, ()>::get(transcript);
-                assert_eq!(challenge_sq, *challenge_sq_expected);
-            }
-
-            // Done with this round.
-            rounds.push((l, r));
-
-            // Collapse `a` and `b`.
-            // TODO: parallelize
-            for i in 0..half {
-                a[i] = (a[i] * &challenge) + &(a[i + half] * &challenge_inv);
-                b[i] = (b[i] * &challenge_inv) + &(b[i + half] * &challenge);
-            }
-            a.truncate(half);
-            b.truncate(half);
-
-            // Collapse `G`
-            parallel_generator_collapse(&mut g, challenge, challenge_inv);
-            g.truncate(half);
-
-            // Update randomness (the synthetic blinding factor at the end)
-            blind += &(l_randomness * &challenge_sq);
-            blind += &(r_randomness * &challenge_sq_inv);
+        // Collapse `a` and `b`.
+        // TODO: parallelize
+        for i in 0..half {
+            a[i] = (a[i] * &challenge) + &(a[i + half] * &challenge_inv);
+            b[i] = (b[i] * &challenge_inv) + &(b[i + half] * &challenge);
         }
+        a.truncate(half);
+        b.truncate(half);
 
-        // We have fully collapsed `a`, `b`, `G`
-        assert_eq!(a.len(), 1);
-        let a = a[0];
-        assert_eq!(b.len(), 1);
-        let b = b[0];
-        assert_eq!(g.len(), 1);
-        let g = g[0];
+        // Collapse `G`
+        parallel_generator_collapse(&mut g, challenge, challenge_inv);
+        g.truncate(half);
 
-        // Random nonces for the zero-knowledge opening
-        let d = C::Scalar::rand();
-        let s = C::Scalar::rand();
-
-        metrics::increment_counter!("multiexp", "val" => "delta", "size" => "3");
-        let delta = best_multiexp(&[d, d * &b, s], &[g, u, params.h]).to_affine();
-
-        // Feed delta into the transcript
-        transcript
-            .absorb_point(&delta)
-            .map_err(|_| Error::SamplingError)?;
-
-        // Obtain the challenge c.
-        let c = ChallengeScalar::<C::Scalar, ()>::get(transcript);
-
-        // Compute z1 and z2 as described in the Halo paper.
-        let z1 = a * &*c + &d;
-        let z2 = *c * &blind + &s;
-
-        Ok(Proof {
-            rounds,
-            delta,
-            z1,
-            z2,
-        })
+        // Update randomness (the synthetic blinding factor at the end)
+        blind += &(l_randomness * &challenge_sq);
+        blind += &(r_randomness * &challenge_sq_inv);
     }
+
+    // We have fully collapsed `a`, `b`, `G`
+    assert_eq!(a.len(), 1);
+    let a = a[0];
+
+    transcript.write_scalar(a)?;
+    transcript.write_scalar(blind)?;
+
+    Ok(())
 }
 
 fn parallel_generator_collapse<C: CurveAffine>(

--- a/src/poly/commitment/verifier.rs
+++ b/src/poly/commitment/verifier.rs
@@ -119,23 +119,23 @@ pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
     // Our goal is to open
     //     msm - [v] G_0 + random_poly_commitment * iota
     //   + \sum(L_i * u_i^2) + \sum(R_i * u_i^-2)
-    // at x to 0, by asking the prover to supply (a, h) such that it equals
-    //   = [a] (G + [b * z] U) + [h] H
+    // at x to 0, by asking the prover to supply (a, \xi) such that it equals
+    //   = [a] (G + [b * z] U) + [\xi] H
     // except that we wish for the prover to supply G as Commit(g(X); 1) so
     // we must substitute to get
-    //   = [a] ((G - H) + [b * z] U) + [h] H
-    //   = [a] G + [-a] H + [abz] U + [h] H
-    //   = [a] G + [abz] U + [h - a] H
+    //   = [a] ((G - H) + [b * z] U) + [\xi] H
+    //   = [a] G + [-a] H + [abz] U + [\xi] H
+    //   = [a] G + [abz] U + [\xi - a] H
     // but subtracting to get the desired equality
-    //   ... + [-a] G + [-abz] U + [a - h] H = 0
+    //   ... + [-a] G + [-abz] U + [a - \xi] H = 0
 
     let a = transcript.read_scalar().map_err(|_| Error::SamplingError)?;
     let neg_a = -a;
-    let h = transcript.read_scalar().map_err(|_| Error::SamplingError)?;
+    let xi = transcript.read_scalar().map_err(|_| Error::SamplingError)?;
     let b = compute_b(x, &challenges);
 
     msm.add_to_u_scalar(neg_a * &b * &z);
-    msm.add_to_h_scalar(a - &h);
+    msm.add_to_h_scalar(a - &xi);
 
     let guard = Guard {
         msm,

--- a/src/poly/commitment/verifier.rs
+++ b/src/poly/commitment/verifier.rs
@@ -6,8 +6,6 @@ use crate::transcript::{Challenge, ChallengeScalar, TranscriptRead};
 
 use crate::arithmetic::{best_multiexp, Curve, CurveAffine, FieldExt};
 
-use std::io::Read;
-
 /// A guard returned by the verifier
 #[derive(Debug, Clone)]
 pub struct Guard<'a, C: CurveAffine> {
@@ -67,7 +65,7 @@ impl<'a, C: CurveAffine> Guard<'a, C> {
 /// Checks to see if an [`Proof`] is valid given the current `transcript`, and a
 /// point `x` that the polynomial commitment `P` opens purportedly to the value
 /// `v`. The provided `msm` should evaluate to the commitment `P` being opened.
-pub fn verify_proof<'a, C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
+pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
     params: &'a Params<C>,
     mut msm: MSM<'a, C>,
     transcript: &mut T,

--- a/src/poly/multiopen.rs
+++ b/src/poly/multiopen.rs
@@ -15,6 +15,9 @@ use crate::{
 mod prover;
 mod verifier;
 
+pub use prover::create_proof;
+pub use verifier::verify_proof;
+
 #[derive(Clone, Copy, Debug)]
 struct X1 {}
 /// Challenge for compressing openings at the same point sets together.
@@ -35,19 +38,6 @@ struct X4 {}
 /// Challenge for collapsing the openings of the various remaining polynomials at x_3
 /// together.
 type ChallengeX4<F> = ChallengeScalar<F, X4>;
-
-/// This is a multi-point opening proof used in the polynomial commitment scheme opening.
-#[derive(Debug, Clone)]
-pub struct Proof<C: CurveAffine> {
-    // A vector of evaluations at each set of query points
-    q_evals: Vec<C::Scalar>,
-
-    // Commitment to final polynomial
-    f_commitment: C,
-
-    // Commitment proof
-    opening: commitment::Proof<C>,
-}
 
 /// A polynomial query at a point
 #[derive(Debug, Clone)]

--- a/src/poly/multiopen/prover.rs
+++ b/src/poly/multiopen/prover.rs
@@ -65,7 +65,7 @@ where
             // Each polynomial is evaluated at a set of points. For each set,
             // we collapse each polynomial's evals pointwise.
             for (eval, set_eval) in evals.iter().zip(q_eval_sets[set_idx].iter_mut()) {
-                *set_eval *= &x_1;
+                *set_eval *= &(*x_1);
                 *set_eval += eval;
             }
         };
@@ -130,7 +130,7 @@ where
         |(f_poly, f_blind), (poly, blind)| {
             (
                 f_poly * *x_4 + poly.as_ref().unwrap(),
-                Blind((f_blind.0 * &x_4) + &blind.0),
+                Blind((f_blind.0 * &(*x_4)) + &blind.0),
             )
         },
     );

--- a/src/poly/multiopen/prover.rs
+++ b/src/poly/multiopen/prover.rs
@@ -1,18 +1,19 @@
 use super::super::{
     commitment::{self, Blind, Params},
-    Coeff, Error, Polynomial,
+    Coeff, Polynomial,
 };
 use super::{
-    construct_intermediate_sets, ChallengeX1, ChallengeX2, ChallengeX3, ChallengeX4, Proof,
-    ProverQuery, Query,
+    construct_intermediate_sets, ChallengeX1, ChallengeX2, ChallengeX3, ChallengeX4, ProverQuery,
+    Query,
 };
 
 use crate::arithmetic::{
     eval_polynomial, kate_division, lagrange_interpolate, Curve, CurveAffine, FieldExt,
 };
-use crate::transcript::{Hasher, Transcript};
+use crate::transcript::TranscriptWrite;
 
 use ff::Field;
+use std::io::{self, Write};
 use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
@@ -23,138 +24,118 @@ struct CommitmentData<C: CurveAffine> {
     evals: Vec<C::Scalar>,
 }
 
-impl<C: CurveAffine> Proof<C> {
-    /// Create a multi-opening proof
-    pub fn create<'a, I, HBase: Hasher<C::Base>, HScalar: Hasher<C::Scalar>>(
-        params: &Params<C>,
-        transcript: &mut Transcript<C, HBase, HScalar>,
-        queries: I,
-    ) -> Result<Self, Error>
-    where
-        I: IntoIterator<Item = ProverQuery<'a, C>> + Clone,
+/// Create a multi-opening proof
+pub fn create_proof<'a, I, C: CurveAffine, W: Write, T: TranscriptWrite<W, C>>(
+    params: &Params<C>,
+    transcript: &mut T,
+    queries: I,
+) -> io::Result<()>
+where
+    I: IntoIterator<Item = ProverQuery<'a, C>> + Clone,
+{
+    let x_1 = ChallengeX1::get(transcript);
+    let x_2 = ChallengeX2::get(transcript);
+
+    let (poly_map, point_sets) = construct_intermediate_sets(queries);
+
+    // Collapse openings at same point sets together into single openings using
+    // x_1 challenge.
+    let mut q_polys: Vec<Option<Polynomial<C::Scalar, Coeff>>> = vec![None; point_sets.len()];
+    let mut q_blinds = vec![Blind(C::Scalar::zero()); point_sets.len()];
+
+    // A vec of vecs of evals. The outer vec corresponds to the point set,
+    // while the inner vec corresponds to the points in a particular set.
+    let mut q_eval_sets = Vec::with_capacity(point_sets.len());
+    for point_set in point_sets.iter() {
+        q_eval_sets.push(vec![C::Scalar::zero(); point_set.len()]);
+    }
+
     {
-        let x_1 = ChallengeX1::get(transcript);
-        let x_2 = ChallengeX2::get(transcript);
-
-        let (poly_map, point_sets) = construct_intermediate_sets(queries);
-
-        // Collapse openings at same point sets together into single openings using
-        // x_1 challenge.
-        let mut q_polys: Vec<Option<Polynomial<C::Scalar, Coeff>>> = vec![None; point_sets.len()];
-        let mut q_blinds = vec![Blind(C::Scalar::zero()); point_sets.len()];
-
-        // A vec of vecs of evals. The outer vec corresponds to the point set,
-        // while the inner vec corresponds to the points in a particular set.
-        let mut q_eval_sets = Vec::with_capacity(point_sets.len());
-        for point_set in point_sets.iter() {
-            q_eval_sets.push(vec![C::Scalar::zero(); point_set.len()]);
-        }
-
-        {
-            let mut accumulate = |set_idx: usize,
-                                  new_poly: &Polynomial<C::Scalar, Coeff>,
-                                  blind: Blind<C::Scalar>,
-                                  evals: Vec<C::Scalar>| {
-                if let Some(poly) = &q_polys[set_idx] {
-                    q_polys[set_idx] = Some(poly.clone() * *x_1 + new_poly);
-                } else {
-                    q_polys[set_idx] = Some(new_poly.clone());
-                }
-                q_blinds[set_idx] *= *x_1;
-                q_blinds[set_idx] += blind;
-                // Each polynomial is evaluated at a set of points. For each set,
-                // we collapse each polynomial's evals pointwise.
-                for (eval, set_eval) in evals.iter().zip(q_eval_sets[set_idx].iter_mut()) {
-                    *set_eval *= &*x_1;
-                    *set_eval += eval;
-                }
-            };
-
-            for commitment_data in poly_map.into_iter() {
-                accumulate(
-                    commitment_data.set_index,        // set_idx,
-                    commitment_data.commitment.poly,  // poly,
-                    commitment_data.commitment.blind, // blind,
-                    commitment_data.evals,            // evals
-                );
-            }
-        }
-
-        let f_poly = point_sets
-            .iter()
-            .zip(q_eval_sets.iter())
-            .zip(q_polys.iter())
-            .fold(None, |f_poly, ((points, evals), poly)| {
-                let mut poly = poly.clone().unwrap().values;
-                // TODO: makes implicit asssumption that poly degree is smaller than interpolation poly degree
-                for (p, r) in poly.iter_mut().zip(lagrange_interpolate(points, evals)) {
-                    *p -= &r;
-                }
-                let mut poly = points
-                    .iter()
-                    .fold(poly, |poly, point| kate_division(&poly, *point));
-                poly.resize(params.n as usize, C::Scalar::zero());
-                let poly = Polynomial {
-                    values: poly,
-                    _marker: PhantomData,
-                };
-
-                if f_poly.is_none() {
-                    Some(poly)
-                } else {
-                    f_poly.map(|f_poly| f_poly * *x_2 + &poly)
-                }
-            })
-            .unwrap();
-
-        let mut f_blind = Blind(C::Scalar::rand());
-        let mut f_commitment = params.commit(&f_poly, f_blind).to_affine();
-
-        let (opening, q_evals) = loop {
-            let mut transcript = transcript.clone();
-            transcript
-                .absorb_point(&f_commitment)
-                .map_err(|_| Error::SamplingError)?;
-
-            let x_3 = ChallengeX3::get(&mut transcript);
-
-            let q_evals: Vec<C::Scalar> = q_polys
-                .iter()
-                .map(|poly| eval_polynomial(poly.as_ref().unwrap(), *x_3))
-                .collect();
-
-            for eval in q_evals.iter() {
-                transcript.absorb_scalar(*eval);
-            }
-
-            let x_4 = ChallengeX4::get(&mut transcript);
-
-            let (f_poly, f_blind_try) = q_polys.iter().zip(q_blinds.iter()).fold(
-                (f_poly.clone(), f_blind),
-                |(f_poly, f_blind), (poly, blind)| {
-                    (
-                        f_poly * *x_4 + poly.as_ref().unwrap(),
-                        Blind((f_blind.0 * &*x_4) + &blind.0),
-                    )
-                },
-            );
-
-            if let Ok(opening) =
-                commitment::Proof::create(&params, &mut transcript, &f_poly, f_blind_try, *x_3)
-            {
-                break (opening, q_evals);
+        let mut accumulate = |set_idx: usize,
+                              new_poly: &Polynomial<C::Scalar, Coeff>,
+                              blind: Blind<C::Scalar>,
+                              evals: Vec<C::Scalar>| {
+            if let Some(poly) = &q_polys[set_idx] {
+                q_polys[set_idx] = Some(poly.clone() * *x_1 + new_poly);
             } else {
-                f_blind += C::Scalar::one();
-                f_commitment = (f_commitment + params.h).to_affine();
+                q_polys[set_idx] = Some(new_poly.clone());
+            }
+            q_blinds[set_idx] *= *x_1;
+            q_blinds[set_idx] += blind;
+            // Each polynomial is evaluated at a set of points. For each set,
+            // we collapse each polynomial's evals pointwise.
+            for (eval, set_eval) in evals.iter().zip(q_eval_sets[set_idx].iter_mut()) {
+                *set_eval *= &x_1;
+                *set_eval += eval;
             }
         };
 
-        Ok(Proof {
-            q_evals,
-            f_commitment,
-            opening,
-        })
+        for commitment_data in poly_map.into_iter() {
+            accumulate(
+                commitment_data.set_index,        // set_idx,
+                commitment_data.commitment.poly,  // poly,
+                commitment_data.commitment.blind, // blind,
+                commitment_data.evals,            // evals
+            );
+        }
     }
+
+    let f_poly = point_sets
+        .iter()
+        .zip(q_eval_sets.iter())
+        .zip(q_polys.iter())
+        .fold(None, |f_poly, ((points, evals), poly)| {
+            let mut poly = poly.clone().unwrap().values;
+            // TODO: makes implicit asssumption that poly degree is smaller than interpolation poly degree
+            for (p, r) in poly.iter_mut().zip(lagrange_interpolate(points, evals)) {
+                *p -= &r;
+            }
+            let mut poly = points
+                .iter()
+                .fold(poly, |poly, point| kate_division(&poly, *point));
+            poly.resize(params.n as usize, C::Scalar::zero());
+            let poly = Polynomial {
+                values: poly,
+                _marker: PhantomData,
+            };
+
+            if f_poly.is_none() {
+                Some(poly)
+            } else {
+                f_poly.map(|f_poly| f_poly * *x_2 + &poly)
+            }
+        })
+        .unwrap();
+
+    let f_blind = Blind(C::Scalar::rand());
+    let f_commitment = params.commit(&f_poly, f_blind).to_affine();
+
+    transcript.write_point(f_commitment)?;
+
+    let x_3 = ChallengeX3::get(transcript);
+
+    let q_evals: Vec<C::Scalar> = q_polys
+        .iter()
+        .map(|poly| eval_polynomial(poly.as_ref().unwrap(), *x_3))
+        .collect();
+
+    for eval in q_evals.iter() {
+        transcript.write_scalar(*eval)?;
+    }
+
+    let x_4 = ChallengeX4::get(transcript);
+
+    let (f_poly, f_blind_try) = q_polys.iter().zip(q_blinds.iter()).fold(
+        (f_poly.clone(), f_blind),
+        |(f_poly, f_blind), (poly, blind)| {
+            (
+                f_poly * *x_4 + poly.as_ref().unwrap(),
+                Blind((f_blind.0 * &x_4) + &blind.0),
+            )
+        },
+    );
+
+    commitment::create_proof(&params, transcript, &f_poly, f_blind_try, *x_3)
 }
 
 #[doc(hidden)]

--- a/src/poly/multiopen/prover.rs
+++ b/src/poly/multiopen/prover.rs
@@ -13,7 +13,7 @@ use crate::arithmetic::{
 use crate::transcript::TranscriptWrite;
 
 use ff::Field;
-use std::io::{self, Write};
+use std::io;
 use std::marker::PhantomData;
 
 #[derive(Debug, Clone)]
@@ -25,7 +25,7 @@ struct CommitmentData<C: CurveAffine> {
 }
 
 /// Create a multi-opening proof
-pub fn create_proof<'a, I, C: CurveAffine, W: Write, T: TranscriptWrite<W, C>>(
+pub fn create_proof<'a, I, C: CurveAffine, T: TranscriptWrite<C>>(
     params: &Params<C>,
     transcript: &mut T,
     queries: I,

--- a/src/poly/multiopen/verifier.rs
+++ b/src/poly/multiopen/verifier.rs
@@ -56,7 +56,7 @@ where
             q_commitments[set_idx].scale(*x_1);
             q_commitments[set_idx].append_term(C::Scalar::one(), new_commitment);
             for (eval, set_eval) in evals.iter().zip(q_eval_sets[set_idx].iter_mut()) {
-                *set_eval *= &x_1;
+                *set_eval *= &(*x_1);
                 *set_eval += eval;
             }
         };
@@ -98,7 +98,7 @@ where
                 let eval = points.iter().fold(*proof_eval - &r_eval, |eval, point| {
                     eval * &(*x_3 - point).invert().unwrap()
                 });
-                msm_eval * &x_2 + &eval
+                msm_eval * &(*x_2) + &eval
             },
         );
 
@@ -113,7 +113,7 @@ where
         |(mut msm, msm_eval), (q_commitment, q_eval)| {
             msm.scale(*x_4);
             msm.add_msm(&q_commitment);
-            (msm, msm_eval * &x_4 + q_eval)
+            (msm, msm_eval * &(*x_4) + q_eval)
         },
     );
 

--- a/src/poly/multiopen/verifier.rs
+++ b/src/poly/multiopen/verifier.rs
@@ -10,9 +10,6 @@ use super::{
 };
 use crate::arithmetic::{eval_polynomial, lagrange_interpolate, CurveAffine, FieldExt};
 use crate::transcript::TranscriptRead;
-
-use std::io::Read;
-
 #[derive(Debug, Clone)]
 struct CommitmentData<C: CurveAffine> {
     set_index: usize,
@@ -21,7 +18,7 @@ struct CommitmentData<C: CurveAffine> {
 }
 
 /// Verify a multi-opening proof
-pub fn verify_proof<'b, 'a: 'b, I, C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
+pub fn verify_proof<'b, 'a: 'b, I, C: CurveAffine, T: TranscriptRead<C>>(
     params: &'a Params<C>,
     transcript: &mut T,
     queries: I,

--- a/src/poly/multiopen/verifier.rs
+++ b/src/poly/multiopen/verifier.rs
@@ -5,11 +5,13 @@ use super::super::{
     Error,
 };
 use super::{
-    construct_intermediate_sets, ChallengeX1, ChallengeX2, ChallengeX3, ChallengeX4, Proof, Query,
+    construct_intermediate_sets, ChallengeX1, ChallengeX2, ChallengeX3, ChallengeX4, Query,
     VerifierQuery,
 };
 use crate::arithmetic::{eval_polynomial, lagrange_interpolate, CurveAffine, FieldExt};
-use crate::transcript::{Hasher, Transcript};
+use crate::transcript::TranscriptRead;
+
+use std::io::Read;
 
 #[derive(Debug, Clone)]
 struct CommitmentData<C: CurveAffine> {
@@ -18,114 +20,109 @@ struct CommitmentData<C: CurveAffine> {
     evals: Vec<C::Scalar>,
 }
 
-impl<C: CurveAffine> Proof<C> {
-    /// Verify a multi-opening proof
-    pub fn verify<'a, I, HBase: Hasher<C::Base>, HScalar: Hasher<C::Scalar>>(
-        &self,
-        params: &'a Params<C>,
-        transcript: &mut Transcript<C, HBase, HScalar>,
-        queries: I,
-        mut msm: MSM<'a, C>,
-    ) -> Result<Guard<'a, C>, Error>
-    where
-        I: IntoIterator<Item = VerifierQuery<'a, C>> + Clone,
+/// Verify a multi-opening proof
+pub fn verify_proof<'a, I, C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
+    params: &'a Params<C>,
+    transcript: &mut T,
+    queries: I,
+    mut msm: MSM<'a, C>,
+) -> Result<Guard<'a, C>, Error>
+where
+    I: IntoIterator<Item = VerifierQuery<'a, C>> + Clone,
+{
+    // Scale the MSM by a random factor to ensure that if the existing MSM
+    // has is_zero() == false then this argument won't be able to interfere
+    // with it to make it true, with high probability.
+    msm.scale(C::Scalar::rand());
+
+    // Sample x_1 for compressing openings at the same point sets together
+    let x_1 = ChallengeX1::get(transcript);
+
+    // Sample a challenge x_2 for keeping the multi-point quotient
+    // polynomial terms linearly independent.
+    let x_2 = ChallengeX2::get(transcript);
+
+    let (commitment_map, point_sets) = construct_intermediate_sets(queries);
+
+    // Compress the commitments and expected evaluations at x together.
+    // using the challenge x_1
+    let mut q_commitments: Vec<_> = vec![params.empty_msm(); point_sets.len()];
+
+    // A vec of vecs of evals. The outer vec corresponds to the point set,
+    // while the inner vec corresponds to the points in a particular set.
+    let mut q_eval_sets = Vec::with_capacity(point_sets.len());
+    for point_set in point_sets.iter() {
+        q_eval_sets.push(vec![C::Scalar::zero(); point_set.len()]);
+    }
     {
-        // Scale the MSM by a random factor to ensure that if the existing MSM
-        // has is_zero() == false then this argument won't be able to interfere
-        // with it to make it true, with high probability.
-        msm.scale(C::Scalar::rand());
-
-        // Sample x_1 for compressing openings at the same point sets together
-        let x_1 = ChallengeX1::get(transcript);
-
-        // Sample a challenge x_2 for keeping the multi-point quotient
-        // polynomial terms linearly independent.
-        let x_2 = ChallengeX2::<C::Scalar>::get(transcript);
-
-        let (commitment_map, point_sets) = construct_intermediate_sets(queries);
-
-        // Compress the commitments and expected evaluations at x together.
-        // using the challenge x_1
-        let mut q_commitments: Vec<_> = vec![params.empty_msm(); point_sets.len()];
-
-        // A vec of vecs of evals. The outer vec corresponds to the point set,
-        // while the inner vec corresponds to the points in a particular set.
-        let mut q_eval_sets = Vec::with_capacity(point_sets.len());
-        for point_set in point_sets.iter() {
-            q_eval_sets.push(vec![C::Scalar::zero(); point_set.len()]);
-        }
-        {
-            let mut accumulate = |set_idx: usize, new_commitment, evals: Vec<C::Scalar>| {
-                q_commitments[set_idx].scale(*x_1);
-                q_commitments[set_idx].append_term(C::Scalar::one(), new_commitment);
-                for (eval, set_eval) in evals.iter().zip(q_eval_sets[set_idx].iter_mut()) {
-                    *set_eval *= &*x_1;
-                    *set_eval += eval;
-                }
-            };
-
-            // Each commitment corresponds to evaluations at a set of points.
-            // For each set, we collapse each commitment's evals pointwise.
-            for commitment_data in commitment_map.into_iter() {
-                accumulate(
-                    commitment_data.set_index,     // set_idx,
-                    *commitment_data.commitment.0, // commitment,
-                    commitment_data.evals,         // evals
-                );
+        let mut accumulate = |set_idx: usize, new_commitment, evals: Vec<C::Scalar>| {
+            q_commitments[set_idx].scale(*x_1);
+            q_commitments[set_idx].append_term(C::Scalar::one(), new_commitment);
+            for (eval, set_eval) in evals.iter().zip(q_eval_sets[set_idx].iter_mut()) {
+                *set_eval *= &x_1;
+                *set_eval += eval;
             }
-        }
+        };
 
-        // Obtain the commitment to the multi-point quotient polynomial f(X).
-        transcript
-            .absorb_point(&self.f_commitment)
-            .map_err(|_| Error::SamplingError)?;
-
-        // Sample a challenge x_3 for checking that f(X) was committed to
-        // correctly.
-        let x_3 = ChallengeX3::get(transcript);
-
-        for eval in self.q_evals.iter() {
-            transcript.absorb_scalar(*eval);
-        }
-
-        // We can compute the expected msm_eval at x_3 using the q_evals provided
-        // by the prover and from x_2
-        let msm_eval = point_sets
-            .iter()
-            .zip(q_eval_sets.iter())
-            .zip(self.q_evals.iter())
-            .fold(
-                C::Scalar::zero(),
-                |msm_eval, ((points, evals), proof_eval)| {
-                    let r_poly = lagrange_interpolate(points, evals);
-                    let r_eval = eval_polynomial(&r_poly, *x_3);
-                    let eval = points.iter().fold(*proof_eval - &r_eval, |eval, point| {
-                        eval * &(*x_3 - point).invert().unwrap()
-                    });
-                    msm_eval * &*x_2 + &eval
-                },
+        // Each commitment corresponds to evaluations at a set of points.
+        // For each set, we collapse each commitment's evals pointwise.
+        for commitment_data in commitment_map.into_iter() {
+            accumulate(
+                commitment_data.set_index,     // set_idx,
+                *commitment_data.commitment.0, // commitment,
+                commitment_data.evals,         // evals
             );
+        }
+    }
 
-        // Sample a challenge x_4 that we will use to collapse the openings of
-        // the various remaining polynomials at x_3 together.
-        let x_4 = ChallengeX4::get(transcript);
+    // Obtain the commitment to the multi-point quotient polynomial f(X).
+    let f_commitment = transcript.read_point().map_err(|_| Error::SamplingError)?;
 
-        // Compute the final commitment that has to be opened
-        let mut commitment_msm = params.empty_msm();
-        commitment_msm.append_term(C::Scalar::one(), self.f_commitment);
-        let (commitment_msm, msm_eval) = q_commitments.into_iter().zip(self.q_evals.iter()).fold(
-            (commitment_msm, msm_eval),
-            |(mut commitment_msm, msm_eval), (q_commitment, q_eval)| {
-                commitment_msm.scale(*x_4);
-                commitment_msm.add_msm(&q_commitment);
-                (commitment_msm, msm_eval * &*x_4 + q_eval)
+    // Sample a challenge x_3 for checking that f(X) was committed to
+    // correctly.
+    let x_3 = ChallengeX3::get(transcript);
+
+    let mut q_evals = Vec::with_capacity(q_eval_sets.len());
+    for _ in 0..q_eval_sets.len() {
+        q_evals.push(transcript.read_scalar().map_err(|_| Error::SamplingError)?);
+    }
+
+    // We can compute the expected msm_eval at x_3 using the q_evals provided
+    // by the prover and from x_2
+    let msm_eval = point_sets
+        .iter()
+        .zip(q_eval_sets.iter())
+        .zip(q_evals.iter())
+        .fold(
+            C::Scalar::zero(),
+            |msm_eval, ((points, evals), proof_eval)| {
+                let r_poly = lagrange_interpolate(points, evals);
+                let r_eval = eval_polynomial(&r_poly, *x_3);
+                let eval = points.iter().fold(*proof_eval - &r_eval, |eval, point| {
+                    eval * &(*x_3 - point).invert().unwrap()
+                });
+                msm_eval * &x_2 + &eval
             },
         );
 
-        // Verify the opening proof
-        self.opening
-            .verify(params, msm, transcript, *x_3, commitment_msm, msm_eval)
-    }
+    // Sample a challenge x_4 that we will use to collapse the openings of
+    // the various remaining polynomials at x_3 together.
+    let x_4 = ChallengeX4::get(transcript);
+
+    // Compute the final commitment that has to be opened
+    let mut commitment_msm = params.empty_msm();
+    commitment_msm.append_term(C::Scalar::one(), f_commitment);
+    let (commitment_msm, msm_eval) = q_commitments.into_iter().zip(q_evals.iter()).fold(
+        (commitment_msm, msm_eval),
+        |(mut commitment_msm, msm_eval), (q_commitment, q_eval)| {
+            commitment_msm.scale(*x_4);
+            commitment_msm.add_msm(&q_commitment);
+            (commitment_msm, msm_eval * &x_4 + q_eval)
+        },
+    );
+
+    // Verify the opening proof
+    super::commitment::verify_proof(params, msm, transcript, *x_3, commitment_msm, msm_eval)
 }
 
 #[doc(hidden)]

--- a/src/poly/multiopen/verifier.rs
+++ b/src/poly/multiopen/verifier.rs
@@ -21,14 +21,14 @@ struct CommitmentData<C: CurveAffine> {
 }
 
 /// Verify a multi-opening proof
-pub fn verify_proof<'a, I, C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
+pub fn verify_proof<'b, 'a: 'b, I, C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
     params: &'a Params<C>,
     transcript: &mut T,
     queries: I,
     mut msm: MSM<'a, C>,
 ) -> Result<Guard<'a, C>, Error>
 where
-    I: IntoIterator<Item = VerifierQuery<'a, C>> + Clone,
+    I: IntoIterator<Item = VerifierQuery<'b, C>> + Clone,
 {
     // Scale the MSM by a random factor to ensure that if the existing MSM
     // has is_zero() == false then this argument won't be able to interfere

--- a/src/poly/multiopen/verifier.rs
+++ b/src/poly/multiopen/verifier.rs
@@ -110,19 +110,18 @@ where
     let x_4 = ChallengeX4::get(transcript);
 
     // Compute the final commitment that has to be opened
-    let mut commitment_msm = params.empty_msm();
-    commitment_msm.append_term(C::Scalar::one(), f_commitment);
-    let (commitment_msm, msm_eval) = q_commitments.into_iter().zip(q_evals.iter()).fold(
-        (commitment_msm, msm_eval),
-        |(mut commitment_msm, msm_eval), (q_commitment, q_eval)| {
-            commitment_msm.scale(*x_4);
-            commitment_msm.add_msm(&q_commitment);
-            (commitment_msm, msm_eval * &x_4 + q_eval)
+    msm.append_term(C::Scalar::one(), f_commitment);
+    let (msm, msm_eval) = q_commitments.into_iter().zip(q_evals.iter()).fold(
+        (msm, msm_eval),
+        |(mut msm, msm_eval), (q_commitment, q_eval)| {
+            msm.scale(*x_4);
+            msm.add_msm(&q_commitment);
+            (msm, msm_eval * &x_4 + q_eval)
         },
     );
 
     // Verify the opening proof
-    super::commitment::verify_proof(params, msm, transcript, *x_3, commitment_msm, msm_eval)
+    super::commitment::verify_proof(params, msm, transcript, *x_3, msm_eval)
 }
 
 #[doc(hidden)]

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -271,20 +271,12 @@ pub(crate) fn read_n_points<C: CurveAffine, T: TranscriptRead<C>>(
     transcript: &mut T,
     n: usize,
 ) -> io::Result<Vec<C>> {
-    let mut v = Vec::with_capacity(n);
-    for _ in 0..n {
-        v.push(transcript.read_point()?);
-    }
-    Ok(v)
+    (0..n).map(|_| transcript.read_point()).collect()
 }
 
 pub(crate) fn read_n_scalars<C: CurveAffine, T: TranscriptRead<C>>(
     transcript: &mut T,
     n: usize,
 ) -> io::Result<Vec<C::Scalar>> {
-    let mut v = Vec::with_capacity(n);
-    for _ in 0..n {
-        v.push(transcript.read_scalar()?);
-    }
-    Ok(v)
+    (0..n).map(|_| transcript.read_scalar()).collect()
 }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -148,7 +148,7 @@ impl<W: Write, C: CurveAffine> DummyHashWrite<W, C> {
 
     /// Conclude the interaction and return the output buffer (writer).
     pub fn finalize(self) -> W {
-        // TODO: handle outstanding scalars?
+        // TODO: handle outstanding scalars? see issue #138
         self.writer
     }
 }

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -60,16 +60,16 @@ pub trait TranscriptWrite<W: Write, C: CurveAffine>: Transcript<C> {
 /// implementation, standing in for some algebraic hash function that we'll
 /// switch to later.
 #[derive(Debug, Clone)]
-pub struct DummyHashReader<R: Read, C: CurveAffine> {
+pub struct DummyHashRead<R: Read, C: CurveAffine> {
     base_state: C::Base,
     scalar_state: C::Scalar,
     read_scalar: bool,
     reader: R,
 }
 
-impl<R: Read, C: CurveAffine> TranscriptRead<R, C> for DummyHashReader<R, C> {
+impl<R: Read, C: CurveAffine> TranscriptRead<R, C> for DummyHashRead<R, C> {
     fn init(reader: R, key: C::Base) -> Self {
-        DummyHashReader {
+        DummyHashRead {
             base_state: key + &C::Base::from_u64(1013),
             scalar_state: C::Scalar::from_u64(1013),
             read_scalar: false,
@@ -104,7 +104,7 @@ impl<R: Read, C: CurveAffine> TranscriptRead<R, C> for DummyHashReader<R, C> {
     }
 }
 
-impl<R: Read, C: CurveAffine> Transcript<C> for DummyHashReader<R, C> {
+impl<R: Read, C: CurveAffine> Transcript<C> for DummyHashRead<R, C> {
     fn common_point(&mut self, point: C) -> io::Result<()> {
         let (x, y) = Option::from(point.get_xy()).ok_or(io::Error::new(
             io::ErrorKind::Other,
@@ -142,18 +142,18 @@ impl<R: Read, C: CurveAffine> Transcript<C> for DummyHashReader<R, C> {
 /// implementation, standing in for some algebraic hash function that we'll
 /// switch to later.
 #[derive(Debug, Clone)]
-pub struct DummyHashWriter<W: Write, C: CurveAffine> {
+pub struct DummyHashWrite<W: Write, C: CurveAffine> {
     base_state: C::Base,
     scalar_state: C::Scalar,
     written_scalar: bool,
     writer: W,
 }
 
-impl<W: Write, C: CurveAffine> TranscriptWrite<W, C> for DummyHashWriter<W, C> {
-    type ForkedTranscript = DummyHashWriter<io::Sink, C>;
+impl<W: Write, C: CurveAffine> TranscriptWrite<W, C> for DummyHashWrite<W, C> {
+    type ForkedTranscript = DummyHashWrite<io::Sink, C>;
 
     fn init(writer: W, key: C::Base) -> Self {
-        DummyHashWriter {
+        DummyHashWrite {
             base_state: key + &C::Base::from_u64(1013),
             scalar_state: C::Scalar::from_u64(1013),
             written_scalar: false,
@@ -173,7 +173,7 @@ impl<W: Write, C: CurveAffine> TranscriptWrite<W, C> for DummyHashWriter<W, C> {
         self.writer.write_all(&data[..])
     }
     fn fork(&self) -> Self::ForkedTranscript {
-        DummyHashWriter {
+        DummyHashWrite {
             base_state: self.base_state,
             scalar_state: self.scalar_state,
             written_scalar: self.written_scalar,
@@ -186,7 +186,7 @@ impl<W: Write, C: CurveAffine> TranscriptWrite<W, C> for DummyHashWriter<W, C> {
     }
 }
 
-impl<W: Write, C: CurveAffine> Transcript<C> for DummyHashWriter<W, C> {
+impl<W: Write, C: CurveAffine> Transcript<C> for DummyHashWrite<W, C> {
     fn common_point(&mut self, point: C) -> io::Result<()> {
         let (x, y) = Option::from(point.get_xy()).ok_or(io::Error::new(
             io::ErrorKind::Other,

--- a/src/transcript.rs
+++ b/src/transcript.rs
@@ -284,3 +284,25 @@ impl<C: CurveAffine, Type> Deref for ChallengeScalar<C, Type> {
         &self.inner
     }
 }
+
+pub(crate) fn read_n_points<C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
+    transcript: &mut T,
+    n: usize,
+) -> io::Result<Vec<C>> {
+    let mut v = Vec::with_capacity(n);
+    for _ in 0..n {
+        v.push(transcript.read_point()?);
+    }
+    Ok(v)
+}
+
+pub(crate) fn read_n_scalars<C: CurveAffine, R: Read, T: TranscriptRead<R, C>>(
+    transcript: &mut T,
+    n: usize,
+) -> io::Result<Vec<C::Scalar>> {
+    let mut v = Vec::with_capacity(n);
+    for _ in 0..n {
+        v.push(transcript.read_scalar()?);
+    }
+    Ok(v)
+}


### PR DESCRIPTION
Closes #66.

The goal of this PR is to solve multiple problems:

1. Currently, we have various `Proof` objects scattered around the codebase for each of the different subprotocols. Some of these proof objects contain vectors of (vectors of) curve points and scalars. This complicates serialization/deserialization of proofs because the lengths of these vectors depend on the configuration of the circuit. We don't want to encode the lengths of vectors inside of proofs because we'll know them at runtime and they do not change. We should instead treat proof objects as opaque byte streams into the verifier.
2. It's easy to accidentally put stuff in a `Proof` object that isn't also placed in the transcript.
3. In #67 we need to be able to create multiple PLONK proofs at the same time and they will share many different substructures when they're for the same circuit.
4. (Bonus) Now verification also accounts for the cost of deserialization, which isn't negligible due to point compression.

The idea is to refactor the `transcript` module to provide two separate concepts: a `TranscriptWrite` trait that represents something we can write to (at proving time) and a `TranscriptRead` trait that represents something we can read from (at verifying time). Crucially, implementations of these traits are responsible for simultaneously writing to some `std::io::Write` buffer at the same time that they hash things into the transcript, and similarly for `TranscriptRead/std::io::Read`.

We can then remove all of the `Proof`-like structures from the codebase.

In addition, we perform a few refactorings of the PLONK implementation to reflect the fact that the verifier needs to temporarily store values in the proof and cannot simply access a `Proof` object anymore. This makes the verifier look a lot more like the prover, which does the same thing for other reasons.

In order to make this easier I had to also change the commitment scheme to more closely match the one from the accumulation scheme paper. That involved three changes:

1. We subtract `[v] G_0` from the commitment `P` that we're opening at `x`; the argument from then forward becomes "does the polynomial committed at `P` have a root at `x`" which will be efficient inside of recursive circuits because it's just a fixed-based scalar multiplication, versus the variable base `P' = P + [v] U` thing that we do in the Halo paper.
2. The prover supplies a commitment `R` to a random polynomial that also has a root at `x`. The verifier samples random `iota` and computes `P' = P - [v] G_0 + [iota] R` and the inner product argument is run on `P'`. This makes it so that we don't need to do a Schnorr proof at the end because `P'` is uniformly distributed in the space of polynomials with a root at `x`.
3. We don't sample `U` for checking the values; we use a fixed `U` and compute a challenge `z` to compute `U' = [z] U` and use `U'` for that purpose. It was never really necessary for `U` to be sampled from the group, which I didn't realize at the time.