### PR TITLE
Avoid square challenges in inner product argument

### DIFF
--- a/src/pasta/fields.rs
+++ b/src/pasta/fields.rs
@@ -6,21 +6,3 @@ mod fq;
 
 pub use fp::*;
 pub use fq::*;
-
-#[cfg(test)]
-use ff::{Field, PrimeField};
-
-#[cfg(test)]
-use crate::arithmetic::FieldExt;
-
-#[test]
-fn test_extract() {
-    let a = Fq::rand();
-    let a = a.square();
-    let (t, s) = a.extract_radix2_vartime().unwrap();
-    assert_eq!(
-        t.pow_vartime(&[1 << Fq::S, 0, 0, 0]) * Fq::ROOT_OF_UNITY.pow_vartime(&[s, 0, 0, 0]),
-        a
-    );
-    assert_eq!(a.deterministic_sqrt().unwrap().square(), a);
-}

--- a/src/pasta/fields/fp.rs
+++ b/src/pasta/fields/fp.rs
@@ -643,20 +643,7 @@ impl FieldExt for Fp {
         0xb4ed8e647196dad1,
         0x2cd5282c53116b5c,
     ]);
-    const UNROLL_T_EXPONENT: [u64; 4] = [
-        0x955a0a417453113c,
-        0x0000000022016b89,
-        0xc000000000000000,
-        0x3f7ed4c6,
-    ];
-    const T_EXPONENT: [u64; 4] = [
-        0x094cf91b992d30ed,
-        0x00000000224698fc,
-        0x0000000000000000,
-        0x40000000,
-    ];
     const DELTA: Self = DELTA;
-    const UNROLL_S_EXPONENT: u64 = 0x204ace5;
     const TWO_INV: Self = Fp::from_raw([
         0xcc96987680000001,
         0x11234c7e04a67c8d,
@@ -788,13 +775,6 @@ fn test_rescue() {
 fn test_sqrt() {
     // NB: TWO_INV is standing in as a "random" field element
     let v = (Fp::TWO_INV).square().sqrt().unwrap();
-    assert!(v == Fp::TWO_INV || (-v) == Fp::TWO_INV);
-}
-
-#[test]
-fn test_deterministic_sqrt() {
-    // NB: TWO_INV is standing in as a "random" field element
-    let v = (Fp::TWO_INV).square().deterministic_sqrt().unwrap();
     assert!(v == Fp::TWO_INV || (-v) == Fp::TWO_INV);
 }
 

--- a/src/pasta/fields/fq.rs
+++ b/src/pasta/fields/fq.rs
@@ -643,20 +643,7 @@ impl FieldExt for Fq {
         0xf4c8f353124086c1,
         0x2235e1a7415bf936,
     ]);
-    const UNROLL_T_EXPONENT: [u64; 4] = [
-        0xcc771cc2ac1e1664,
-        0x00000000062dfe9e,
-        0xc000000000000000,
-        0xb89e9c7,
-    ];
-    const T_EXPONENT: [u64; 4] = [
-        0x0994a8dd8c46eb21,
-        0x00000000224698fc,
-        0x0000000000000000,
-        0x40000000,
-    ];
     const DELTA: Self = DELTA;
-    const UNROLL_S_EXPONENT: u64 = 0xd1d858e1;
     const TWO_INV: Self = Fq::from_raw([
         0xc623759080000001,
         0x11234c7e04ca546e,
@@ -788,13 +775,6 @@ fn test_rescue() {
 fn test_sqrt() {
     // NB: TWO_INV is standing in as a "random" field element
     let v = (Fq::TWO_INV).square().sqrt().unwrap();
-    assert!(v == Fq::TWO_INV || (-v) == Fq::TWO_INV);
-}
-
-#[test]
-fn test_deterministic_sqrt() {
-    // NB: TWO_INV is standing in as a "random" field element
-    let v = (Fq::TWO_INV).square().deterministic_sqrt().unwrap();
     assert!(v == Fq::TWO_INV || (-v) == Fq::TWO_INV);
 }
 


### PR DESCRIPTION
**The base of this branch is currently `transcript-api-2` which is [unmerged](https://github.com/zcash/halo2/pull/111).**

This modifies the scheme to be almost identical to the construction outlined in Appendix A.2 of "Proof-Carrying Data from Accumulation Schemes" (https://eprint.iacr.org/2020/499). The only remaining difference is that we do not compute `[v] U = [v] [z] U` but instead subtract `[v] G_0` from the commitment before opening which I figure will be more efficient in the circuit.

As a consequence of this, things are a little simpler and we can remove both

* transcript forking
* deterministic square root computation

as I don't forsee us needing either of these.