### PR TITLE
Fix breakage of trait resolution in Rust 1.49.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
       - name: cargo build
         uses: actions-rs/cargo@v1
         with:

--- a/src/plonk/lookup/prover.rs
+++ b/src/plonk/lookup/prover.rs
@@ -243,19 +243,19 @@ impl<'a, C: CurveAffine> Permuted<'a, C> {
                 // Compress unpermuted input columns
                 let mut input_term = C::Scalar::zero();
                 for unpermuted_input_column in self.unpermuted_input_columns.iter() {
-                    input_term *= &theta;
+                    input_term *= &*theta;
                     input_term += &unpermuted_input_column[i];
                 }
 
                 // Compress unpermuted table columns
                 let mut table_term = C::Scalar::zero();
                 for unpermuted_table_column in self.unpermuted_table_columns.iter() {
-                    table_term *= &theta;
+                    table_term *= &*theta;
                     table_term += &unpermuted_table_column[i];
                 }
 
-                *product *= &(input_term + &beta);
-                *product *= &(table_term + &gamma);
+                *product *= &(input_term + &*beta);
+                *product *= &(table_term + &*gamma);
             }
         });
 
@@ -306,11 +306,11 @@ impl<'a, C: CurveAffine> Permuted<'a, C> {
                 let mut right = z[prev_idx];
                 let mut input_term = self.unpermuted_input_columns
                     .iter()
-                    .fold(C::Scalar::zero(), |acc, input| acc * &theta + &input[i]);
+                    .fold(C::Scalar::zero(), |acc, input| acc * &*theta + &input[i]);
 
                 let mut table_term = self.unpermuted_table_columns
                     .iter()
-                    .fold(C::Scalar::zero(), |acc, table| acc * &theta + &table[i]);
+                    .fold(C::Scalar::zero(), |acc, table| acc * &*theta + &table[i]);
 
                 input_term += &(*beta);
                 table_term += &(*gamma);
@@ -396,20 +396,20 @@ impl<'a, C: CurveAffine> Committed<'a, C> {
                         // Compress the unpermuted input columns
                         let mut input_term = C::Scalar::zero();
                         for input in permuted.unpermuted_input_cosets.iter() {
-                            input_term *= &theta;
+                            input_term *= &*theta;
                             input_term += &input[i];
                         }
 
                         // Compress the unpermuted table columns
                         let mut table_term = C::Scalar::zero();
                         for table in permuted.unpermuted_table_cosets.iter() {
-                            table_term *= &theta;
+                            table_term *= &*theta;
                             table_term += &table[i];
                         }
 
                         // Add \beta and \gamma offsets
-                        *right *= &(input_term + &beta);
-                        *right *= &(table_term + &gamma);
+                        *right *= &(input_term + &*beta);
+                        *right *= &(table_term + &*gamma);
                     }
                 });
 

--- a/src/plonk/lookup/verifier.rs
+++ b/src/plonk/lookup/verifier.rs
@@ -54,8 +54,8 @@ impl<C: CurveAffine> Proof<C> {
             // z'(X) (a'(X) + \beta) (s'(X) + \gamma)
             // - z'(\omega^{-1} X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \gamma)
             let left = self.product_eval
-                * &(self.permuted_input_eval + &beta)
-                * &(self.permuted_table_eval + &gamma);
+                * &(self.permuted_input_eval + &*beta)
+                * &(self.permuted_table_eval + &*gamma);
 
             let compress_columns = |columns: &[Column<Any>]| {
                 columns
@@ -68,11 +68,11 @@ impl<C: CurveAffine> Proof<C> {
                             Any::Aux => aux_evals[index],
                         }
                     })
-                    .fold(C::Scalar::zero(), |acc, eval| acc * &theta + &eval)
+                    .fold(C::Scalar::zero(), |acc, eval| acc * &*theta + &eval)
             };
             let right = self.product_inv_eval
-                * &(compress_columns(&argument.input_columns) + &beta)
-                * &(compress_columns(&argument.table_columns) + &gamma);
+                * &(compress_columns(&argument.input_columns) + &*beta)
+                * &(compress_columns(&argument.table_columns) + &*gamma);
 
             left - &right
         };

--- a/src/plonk/permutation/prover.rs
+++ b/src/plonk/permutation/prover.rs
@@ -69,7 +69,7 @@ impl Argument {
                     .zip(advice[column.index()][start..].iter())
                     .zip(permuted_column_values[start..].iter())
                 {
-                    *modified_advice *= &(*beta * permuted_advice_value + &gamma + advice_value);
+                    *modified_advice *= &(*beta * permuted_advice_value + &*gamma + advice_value);
                 }
             });
         }
@@ -89,7 +89,7 @@ impl Argument {
                     .zip(advice[column.index()][start..].iter())
                 {
                     // Multiply by p_j(\omega^i) + \delta^j \omega^i \beta
-                    *modified_advice *= &(deltaomega * &beta + &gamma + advice_value);
+                    *modified_advice *= &(deltaomega * &*beta + &*gamma + advice_value);
                     deltaomega *= &omega;
                 }
             });
@@ -180,7 +180,7 @@ impl<C: CurveAffine> Committed<C> {
                             .zip(advice[start..].iter())
                             .zip(permutation[start..].iter())
                         {
-                            *left *= &(*advice + &(*beta * permutation) + &gamma);
+                            *left *= &(*advice + &(*beta * permutation) + &*gamma);
                         }
                     });
                 }
@@ -197,7 +197,7 @@ impl<C: CurveAffine> Committed<C> {
                         let mut beta_term =
                             current_delta * &step.pow_vartime(&[start as u64, 0, 0, 0]);
                         for (right, advice) in right.iter_mut().zip(advice[start..].iter()) {
-                            *right *= &(*advice + &beta_term + &gamma);
+                            *right *= &(*advice + &beta_term + &*gamma);
                             beta_term *= &step;
                         }
                     });

--- a/src/plonk/permutation/verifier.rs
+++ b/src/plonk/permutation/verifier.rs
@@ -52,17 +52,17 @@ impl<C: CurveAffine> Proof<C> {
                     .map(|&column| advice_evals[vk.cs.get_advice_query_index(column, 0)])
                     .zip(self.permutation_evals.iter())
                 {
-                    left *= &(advice_eval + &(*beta * permutation_eval) + &gamma);
+                    left *= &(advice_eval + &(*beta * permutation_eval) + &*gamma);
                 }
 
                 let mut right = self.permutation_product_inv_eval;
-                let mut current_delta = *beta * &x;
+                let mut current_delta = *beta * &*x;
                 for advice_eval in p
                     .columns
                     .iter()
                     .map(|&column| advice_evals[vk.cs.get_advice_query_index(column, 0)])
                 {
-                    right *= &(advice_eval + &current_delta + &gamma);
+                    right *= &(advice_eval + &current_delta + &*gamma);
                     current_delta *= &C::Scalar::DELTA;
                 }
 

--- a/src/plonk/vanishing/verifier.rs
+++ b/src/plonk/vanishing/verifier.rs
@@ -43,7 +43,7 @@ impl<C: CurveAffine> Proof<C> {
         y: ChallengeY<C::Scalar>,
         xn: C::Scalar,
     ) -> Result<(), Error> {
-        let expected_h_eval = expressions.fold(C::Scalar::zero(), |h_eval, v| h_eval * &y + &v);
+        let expected_h_eval = expressions.fold(C::Scalar::zero(), |h_eval, v| h_eval * &*y + &v);
 
         // Compute h(x) from the prover
         let h_eval = self

--- a/src/poly/commitment/prover.rs
+++ b/src/poly/commitment/prover.rs
@@ -184,10 +184,10 @@ impl<C: CurveAffine> Proof<C> {
             .map_err(|_| Error::SamplingError)?;
 
         // Obtain the challenge c.
-        let c = ChallengeScalar::<_, ()>::get(transcript);
+        let c = ChallengeScalar::<C::Scalar, ()>::get(transcript);
 
         // Compute z1 and z2 as described in the Halo paper.
-        let z1 = a * &c + &d;
+        let z1 = a * &*c + &d;
         let z2 = *c * &blind + &s;
 
         Ok(Proof {

--- a/src/poly/multiopen/prover.rs
+++ b/src/poly/multiopen/prover.rs
@@ -65,7 +65,7 @@ impl<C: CurveAffine> Proof<C> {
                 // Each polynomial is evaluated at a set of points. For each set,
                 // we collapse each polynomial's evals pointwise.
                 for (eval, set_eval) in evals.iter().zip(q_eval_sets[set_idx].iter_mut()) {
-                    *set_eval *= &x_1;
+                    *set_eval *= &*x_1;
                     *set_eval += eval;
                 }
             };
@@ -134,7 +134,7 @@ impl<C: CurveAffine> Proof<C> {
                 |(f_poly, f_blind), (poly, blind)| {
                     (
                         f_poly * *x_4 + poly.as_ref().unwrap(),
-                        Blind((f_blind.0 * &x_4) + &blind.0),
+                        Blind((f_blind.0 * &*x_4) + &blind.0),
                     )
                 },
             );

--- a/src/poly/multiopen/verifier.rs
+++ b/src/poly/multiopen/verifier.rs
@@ -40,7 +40,7 @@ impl<C: CurveAffine> Proof<C> {
 
         // Sample a challenge x_2 for keeping the multi-point quotient
         // polynomial terms linearly independent.
-        let x_2 = ChallengeX2::get(transcript);
+        let x_2 = ChallengeX2::<C::Scalar>::get(transcript);
 
         let (commitment_map, point_sets) = construct_intermediate_sets(queries);
 
@@ -59,7 +59,7 @@ impl<C: CurveAffine> Proof<C> {
                 q_commitments[set_idx].scale(*x_1);
                 q_commitments[set_idx].append_term(C::Scalar::one(), new_commitment);
                 for (eval, set_eval) in evals.iter().zip(q_eval_sets[set_idx].iter_mut()) {
-                    *set_eval *= &x_1;
+                    *set_eval *= &*x_1;
                     *set_eval += eval;
                 }
             };
@@ -102,7 +102,7 @@ impl<C: CurveAffine> Proof<C> {
                     let eval = points.iter().fold(*proof_eval - &r_eval, |eval, point| {
                         eval * &(*x_3 - point).invert().unwrap()
                     });
-                    msm_eval * &x_2 + &eval
+                    msm_eval * &*x_2 + &eval
                 },
             );
 
@@ -118,7 +118,7 @@ impl<C: CurveAffine> Proof<C> {
             |(mut commitment_msm, msm_eval), (q_commitment, q_eval)| {
                 commitment_msm.scale(*x_4);
                 commitment_msm.add_msm(&q_commitment);
-                (commitment_msm, msm_eval * &x_4 + q_eval)
+                (commitment_msm, msm_eval * &*x_4 + q_eval)
             },
         );
 


### PR DESCRIPTION
Previously, `ChallengeScalar` could use the operator traits defined on
the `F: Field` type it wrapped, due to its `impl Deref<Target = F>`.
This was technically ambiguous, and Rust 1.49.0 makes that ambiguity an
error.

We could fix this by adding operator impls with `ChallengeScalar` on the
RHS, but that would conflict with zcash/halo2#111. Instead we manually
dereference every challenge scalar when used in an arithmetic operation.