### PR TITLE
Simple layouter strategy to track column usage

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -138,6 +138,6 @@ pub trait Layouter<C: Chip> {
     /// ```
     fn assign_region(
         &mut self,
-        assignment: impl FnOnce(Region<'_, C>) -> Result<(), Error>,
+        assignment: impl FnMut(Region<'_, C>) -> Result<(), Error>,
     ) -> Result<(), Error>;
 }

--- a/src/circuit/layouter.rs
+++ b/src/circuit/layouter.rs
@@ -138,20 +138,38 @@ impl<'a, C: Chip, CS: Assignment<C::Field> + 'a> Layouter<C> for SingleChip<'a, 
     }
 }
 
+/// The shape of a region. For a region at a certain index, we track
+/// the set of columns it uses as well as the number of rows it uses.
 #[derive(Debug)]
-struct RegionShape {
+pub struct RegionShape {
     region_index: usize,
     columns: HashSet<Column<Any>>,
     row_count: usize,
 }
 
 impl RegionShape {
-    fn new(region_index: usize) -> Self {
+    /// Create a new `RegionShape` for a region at `region_index`.
+    pub fn new(region_index: usize) -> Self {
         RegionShape {
             region_index,
             columns: HashSet::default(),
             row_count: 0,
         }
+    }
+
+    /// Get the `region_index` of a `RegionShape`.
+    pub fn region_index(&self) -> usize {
+        self.region_index
+    }
+
+    /// Get a reference to the set of `columns` used in a `RegionShape`.
+    pub fn columns(&self) -> &HashSet<Column<Any>> {
+        &self.columns
+    }
+
+    /// Get the `row_count` of a `RegionShape`.
+    pub fn row_count(&self) -> usize {
+        self.row_count
     }
 }
 

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -10,7 +10,7 @@ use crate::poly::Rotation;
 pub trait ColumnType: 'static + Sized {}
 
 /// A column with an index and type
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Column<C: ColumnType> {
     index: usize,
     column_type: C,
@@ -27,19 +27,19 @@ impl<C: ColumnType> Column<C> {
 }
 
 /// An advice column
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Advice;
 
 /// A fixed column
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Fixed;
 
 /// An auxiliary column
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub struct Aux;
 
 /// An enum over the Advice, Fixed, Aux structs
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum Any {
     /// An Advice variant
     Advice,


### PR DESCRIPTION
We implement the simplest approach here: position the region starting at the earliest row for which none of the columns are in use.