### PR TITLE
Remove eval from ProverQuery in multiopen

### DIFF
--- a/src/plonk/lookup/prover.rs
+++ b/src/plonk/lookup/prover.rs
@@ -55,11 +55,6 @@ pub(in crate::plonk) struct Constructed<C: CurveAffine> {
 
 pub(in crate::plonk) struct Evaluated<C: CurveAffine> {
     constructed: Constructed<C>,
-    product_eval: C::Scalar,
-    product_inv_eval: C::Scalar,
-    permuted_input_eval: C::Scalar,
-    permuted_input_inv_eval: C::Scalar,
-    permuted_table_eval: C::Scalar,
 }
 
 impl Argument {
@@ -465,14 +460,7 @@ impl<C: CurveAffine> Constructed<C> {
                 .map_err(|_| Error::TranscriptError)?;
         }
 
-        Ok(Evaluated {
-            constructed: self,
-            product_eval,
-            product_inv_eval,
-            permuted_input_eval,
-            permuted_input_inv_eval,
-            permuted_table_eval,
-        })
+        Ok(Evaluated { constructed: self })
     }
 }
 
@@ -490,35 +478,30 @@ impl<C: CurveAffine> Evaluated<C> {
                 point: *x,
                 poly: &self.constructed.product_poly,
                 blind: self.constructed.product_blind,
-                eval: self.product_eval,
             }))
             // Open lookup input commitments at x
             .chain(Some(ProverQuery {
                 point: *x,
                 poly: &self.constructed.permuted_input_poly,
                 blind: self.constructed.permuted_input_blind,
-                eval: self.permuted_input_eval,
             }))
             // Open lookup table commitments at x
             .chain(Some(ProverQuery {
                 point: *x,
                 poly: &self.constructed.permuted_table_poly,
                 blind: self.constructed.permuted_table_blind,
-                eval: self.permuted_table_eval,
             }))
             // Open lookup input commitments at x_inv
             .chain(Some(ProverQuery {
                 point: x_inv,
                 poly: &self.constructed.permuted_input_poly,
                 blind: self.constructed.permuted_input_blind,
-                eval: self.permuted_input_inv_eval,
             }))
             // Open lookup product commitments at x_inv
             .chain(Some(ProverQuery {
                 point: x_inv,
                 poly: &self.constructed.product_poly,
                 blind: self.constructed.product_blind,
-                eval: self.product_inv_eval,
             }))
     }
 }

--- a/src/plonk/vanishing/prover.rs
+++ b/src/plonk/vanishing/prover.rs
@@ -17,7 +17,6 @@ pub(in crate::plonk) struct Constructed<C: CurveAffine> {
 
 pub(in crate::plonk) struct Evaluated<C: CurveAffine> {
     constructed: Constructed<C>,
-    h_evals: Vec<C::Scalar>,
 }
 
 impl<C: CurveAffine> Argument<C> {
@@ -85,10 +84,7 @@ impl<C: CurveAffine> Constructed<C> {
                 .map_err(|_| Error::TranscriptError)?;
         }
 
-        Ok(Evaluated {
-            constructed: self,
-            h_evals,
-        })
+        Ok(Evaluated { constructed: self })
     }
 }
 
@@ -101,12 +97,10 @@ impl<C: CurveAffine> Evaluated<C> {
             .h_pieces
             .iter()
             .zip(self.constructed.h_blinds.iter())
-            .zip(self.h_evals.iter())
-            .map(move |((h_poly, h_blind), h_eval)| ProverQuery {
+            .map(move |(h_poly, h_blind)| ProverQuery {
                 point: *x,
                 poly: h_poly,
                 blind: *h_blind,
-                eval: *h_eval,
             })
     }
 }

--- a/src/poly/multiopen/verifier.rs
+++ b/src/poly/multiopen/verifier.rs
@@ -133,6 +133,7 @@ impl<'a, C> PartialEq for CommitmentPointer<'a, C> {
 
 impl<'a, C: CurveAffine> Query<C::Scalar> for VerifierQuery<'a, C> {
     type Commitment = CommitmentPointer<'a, C>;
+    type Eval = C::Scalar;
 
     fn get_point(&self) -> C::Scalar {
         self.point


### PR DESCRIPTION
The Lagrange interpolation we were doing was pointless. kate_division sheds the constant term off each time it is invoked because the quotient polynomial isn't affected by it. This means we were modifying coefficients that end up getting discarded anyway; the quotient polynomial coefficients are already determined exactly by the leading coefficients and the fact that a root exists at each of the points.

This has some other consequences for the PLONK code that no longer needs to keep track of the evals after they end up in the transcript.