### PR TITLE
Circuit annotations and developer tooling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ readme = "README.md"
 publish = false
 
 [package.metadata.docs.rs]
-rustdoc-args = [ "--html-in-header", "katex-header.html" ]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 
 [dev-dependencies]
 criterion = "0.3"
@@ -47,6 +48,10 @@ blake2b_simd = "0.5"
 lazy_static = "1.4.0"
 static_assertions = "1.1.0"
 
+# Developer tooling dependencies
+tabbycat = { version = "0.1", features = ["attributes"], optional = true }
+
 [features]
+dev-graph = ["tabbycat"]
 gadget-traces = ["backtrace"]
 sanity-checks = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,9 +49,14 @@ lazy_static = "1.4.0"
 static_assertions = "1.1.0"
 
 # Developer tooling dependencies
+plotters = { version = "0.3.0", optional = true }
 tabbycat = { version = "0.1", features = ["attributes"], optional = true }
 
 [features]
-dev-graph = ["tabbycat"]
+dev-graph = ["plotters", "tabbycat"]
 gadget-traces = ["backtrace"]
 sanity-checks = []
+
+[[example]]
+name = "circuit-layout"
+required-features = ["dev-graph"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ name = "plonk"
 harness = false
 
 [dependencies]
+backtrace = { version = "0.3", optional = true }
 bitvec = "0.18"
 subtle = "2.3"
 crossbeam-utils = "0.7"
@@ -47,4 +48,5 @@ lazy_static = "1.4.0"
 static_assertions = "1.1.0"
 
 [features]
+gadget-traces = ["backtrace"]
 sanity-checks = []

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -189,7 +189,7 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
             let sb = meta.fixed_column();
             let sc = meta.fixed_column();
 
-            meta.create_gate(|meta| {
+            meta.create_gate("Combined add-mult", |meta| {
                 let a = meta.query_advice(a, Rotation::cur());
                 let b = meta.query_advice(b, Rotation::cur());
                 let c = meta.query_advice(c, Rotation::cur());

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -76,25 +76,36 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
             let index = self.current_gate;
             self.current_gate += 1;
             let mut value = None;
-            self.cs.assign_advice(self.config.a, index, || {
-                value = Some(f()?);
-                Ok(value.ok_or(Error::SynthesisError)?.0)
-            })?;
-            self.cs.assign_advice(self.config.b, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.1)
-            })?;
-            self.cs.assign_advice(self.config.c, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.2)
-            })?;
+            self.cs.assign_advice(
+                || "lhs",
+                self.config.a,
+                index,
+                || {
+                    value = Some(f()?);
+                    Ok(value.ok_or(Error::SynthesisError)?.0)
+                },
+            )?;
+            self.cs.assign_advice(
+                || "rhs",
+                self.config.b,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.1),
+            )?;
+            self.cs.assign_advice(
+                || "out",
+                self.config.c,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.2),
+            )?;
 
             self.cs
-                .assign_fixed(self.config.sa, index, || Ok(FF::zero()))?;
+                .assign_fixed(|| "a", self.config.sa, index, || Ok(FF::zero()))?;
             self.cs
-                .assign_fixed(self.config.sb, index, || Ok(FF::zero()))?;
+                .assign_fixed(|| "b", self.config.sb, index, || Ok(FF::zero()))?;
             self.cs
-                .assign_fixed(self.config.sc, index, || Ok(FF::one()))?;
+                .assign_fixed(|| "c", self.config.sc, index, || Ok(FF::one()))?;
             self.cs
-                .assign_fixed(self.config.sm, index, || Ok(FF::one()))?;
+                .assign_fixed(|| "a * b", self.config.sm, index, || Ok(FF::one()))?;
             Ok((
                 Variable(self.config.a, index),
                 Variable(self.config.b, index),
@@ -108,25 +119,36 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
             let index = self.current_gate;
             self.current_gate += 1;
             let mut value = None;
-            self.cs.assign_advice(self.config.a, index, || {
-                value = Some(f()?);
-                Ok(value.ok_or(Error::SynthesisError)?.0)
-            })?;
-            self.cs.assign_advice(self.config.b, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.1)
-            })?;
-            self.cs.assign_advice(self.config.c, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.2)
-            })?;
+            self.cs.assign_advice(
+                || "lhs",
+                self.config.a,
+                index,
+                || {
+                    value = Some(f()?);
+                    Ok(value.ok_or(Error::SynthesisError)?.0)
+                },
+            )?;
+            self.cs.assign_advice(
+                || "rhs",
+                self.config.b,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.1),
+            )?;
+            self.cs.assign_advice(
+                || "out",
+                self.config.c,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.2),
+            )?;
 
             self.cs
-                .assign_fixed(self.config.sa, index, || Ok(FF::one()))?;
+                .assign_fixed(|| "a", self.config.sa, index, || Ok(FF::one()))?;
             self.cs
-                .assign_fixed(self.config.sb, index, || Ok(FF::one()))?;
+                .assign_fixed(|| "b", self.config.sb, index, || Ok(FF::one()))?;
             self.cs
-                .assign_fixed(self.config.sc, index, || Ok(FF::one()))?;
+                .assign_fixed(|| "c", self.config.sc, index, || Ok(FF::one()))?;
             self.cs
-                .assign_fixed(self.config.sm, index, || Ok(FF::zero()))?;
+                .assign_fixed(|| "a * b", self.config.sm, index, || Ok(FF::zero()))?;
             Ok((
                 Variable(self.config.a, index),
                 Variable(self.config.b, index),

--- a/examples/circuit-layout.rs
+++ b/examples/circuit-layout.rs
@@ -1,0 +1,391 @@
+use halo2::{
+    arithmetic::FieldExt,
+    dev::circuit_layout,
+    pasta::Fp,
+    plonk::{Advice, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed},
+    poly::Rotation,
+};
+use plotters::prelude::*;
+use std::marker::PhantomData;
+
+fn main() {
+    /// This represents an advice column at a certain row in the ConstraintSystem
+    #[derive(Copy, Clone, Debug)]
+    pub struct Variable(Column<Advice>, usize);
+
+    struct PLONKConfig {
+        a: Column<Advice>,
+        b: Column<Advice>,
+        c: Column<Advice>,
+        d: Column<Advice>,
+        e: Column<Advice>,
+
+        sa: Column<Fixed>,
+        sb: Column<Fixed>,
+        sc: Column<Fixed>,
+        sm: Column<Fixed>,
+        sp: Column<Fixed>,
+        sl: Column<Fixed>,
+        sl2: Column<Fixed>,
+
+        perm: usize,
+        perm2: usize,
+    }
+
+    trait StandardCS<FF: FieldExt> {
+        fn raw_multiply<F>(&mut self, f: F) -> Result<(Variable, Variable, Variable), Error>
+        where
+            F: FnOnce() -> Result<(FF, FF, FF), Error>;
+        fn raw_add<F>(&mut self, f: F) -> Result<(Variable, Variable, Variable), Error>
+        where
+            F: FnOnce() -> Result<(FF, FF, FF), Error>;
+        fn copy(&mut self, a: Variable, b: Variable) -> Result<(), Error>;
+        fn public_input<F>(&mut self, f: F) -> Result<Variable, Error>
+        where
+            F: FnOnce() -> Result<FF, Error>;
+        fn lookup_table(&mut self, values: &[Vec<FF>]) -> Result<(), Error>;
+    }
+
+    struct MyCircuit<F: FieldExt> {
+        a: Option<F>,
+        lookup_tables: Vec<Vec<F>>,
+    }
+
+    struct StandardPLONK<'a, F: FieldExt, CS: Assignment<F> + 'a> {
+        cs: &'a mut CS,
+        config: PLONKConfig,
+        current_gate: usize,
+        _marker: PhantomData<F>,
+    }
+
+    impl<'a, FF: FieldExt, CS: Assignment<FF>> StandardPLONK<'a, FF, CS> {
+        fn new(cs: &'a mut CS, config: PLONKConfig) -> Self {
+            StandardPLONK {
+                cs,
+                config,
+                current_gate: 0,
+                _marker: PhantomData,
+            }
+        }
+
+        fn enter_region<NR, N>(&mut self, name_fn: N)
+        where
+            NR: Into<String>,
+            N: FnOnce() -> NR,
+        {
+            self.cs.enter_region(name_fn);
+        }
+
+        fn exit_region(&mut self) {
+            self.cs.exit_region();
+        }
+    }
+
+    impl<'a, FF: FieldExt, CS: Assignment<FF>> StandardCS<FF> for StandardPLONK<'a, FF, CS> {
+        fn raw_multiply<F>(&mut self, f: F) -> Result<(Variable, Variable, Variable), Error>
+        where
+            F: FnOnce() -> Result<(FF, FF, FF), Error>,
+        {
+            let index = self.current_gate;
+            self.current_gate += 1;
+            let mut value = None;
+            self.cs.assign_advice(
+                || "lhs",
+                self.config.a,
+                index,
+                || {
+                    value = Some(f()?);
+                    Ok(value.ok_or(Error::SynthesisError)?.0)
+                },
+            )?;
+            self.cs.assign_advice(
+                || "lhs^4",
+                self.config.d,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.0.square().square()),
+            )?;
+            self.cs.assign_advice(
+                || "rhs",
+                self.config.b,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.1),
+            )?;
+            self.cs.assign_advice(
+                || "rhs^4",
+                self.config.e,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.1.square().square()),
+            )?;
+            self.cs.assign_advice(
+                || "out",
+                self.config.c,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.2),
+            )?;
+
+            self.cs
+                .assign_fixed(|| "a", self.config.sa, index, || Ok(FF::zero()))?;
+            self.cs
+                .assign_fixed(|| "b", self.config.sb, index, || Ok(FF::zero()))?;
+            self.cs
+                .assign_fixed(|| "c", self.config.sc, index, || Ok(FF::one()))?;
+            self.cs
+                .assign_fixed(|| "a * b", self.config.sm, index, || Ok(FF::one()))?;
+            Ok((
+                Variable(self.config.a, index),
+                Variable(self.config.b, index),
+                Variable(self.config.c, index),
+            ))
+        }
+        fn raw_add<F>(&mut self, f: F) -> Result<(Variable, Variable, Variable), Error>
+        where
+            F: FnOnce() -> Result<(FF, FF, FF), Error>,
+        {
+            let index = self.current_gate;
+            self.current_gate += 1;
+            let mut value = None;
+            self.cs.assign_advice(
+                || "lhs",
+                self.config.a,
+                index,
+                || {
+                    value = Some(f()?);
+                    Ok(value.ok_or(Error::SynthesisError)?.0)
+                },
+            )?;
+            self.cs.assign_advice(
+                || "lhs^4",
+                self.config.d,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.0.square().square()),
+            )?;
+            self.cs.assign_advice(
+                || "rhs",
+                self.config.b,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.1),
+            )?;
+            self.cs.assign_advice(
+                || "rhs^4",
+                self.config.e,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.1.square().square()),
+            )?;
+            self.cs.assign_advice(
+                || "out",
+                self.config.c,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.2),
+            )?;
+
+            self.cs
+                .assign_fixed(|| "a", self.config.sa, index, || Ok(FF::one()))?;
+            self.cs
+                .assign_fixed(|| "b", self.config.sb, index, || Ok(FF::one()))?;
+            self.cs
+                .assign_fixed(|| "c", self.config.sc, index, || Ok(FF::one()))?;
+            self.cs
+                .assign_fixed(|| "a * b", self.config.sm, index, || Ok(FF::zero()))?;
+            Ok((
+                Variable(self.config.a, index),
+                Variable(self.config.b, index),
+                Variable(self.config.c, index),
+            ))
+        }
+        fn copy(&mut self, left: Variable, right: Variable) -> Result<(), Error> {
+            let left_column = match left.0 {
+                x if x == self.config.a => 0,
+                x if x == self.config.b => 1,
+                x if x == self.config.c => 2,
+                _ => unreachable!(),
+            };
+            let right_column = match right.0 {
+                x if x == self.config.a => 0,
+                x if x == self.config.b => 1,
+                x if x == self.config.c => 2,
+                _ => unreachable!(),
+            };
+
+            self.cs
+                .copy(self.config.perm, left_column, left.1, right_column, right.1)?;
+            self.cs.copy(
+                self.config.perm2,
+                left_column,
+                left.1,
+                right_column,
+                right.1,
+            )
+        }
+        fn public_input<F>(&mut self, f: F) -> Result<Variable, Error>
+        where
+            F: FnOnce() -> Result<FF, Error>,
+        {
+            let index = self.current_gate;
+            self.current_gate += 1;
+            self.cs
+                .assign_advice(|| "value", self.config.a, index, || f())?;
+            self.cs
+                .assign_fixed(|| "public", self.config.sp, index, || Ok(FF::one()))?;
+
+            Ok(Variable(self.config.a, index))
+        }
+        fn lookup_table(&mut self, values: &[Vec<FF>]) -> Result<(), Error> {
+            for (&value_0, &value_1) in values[0].iter().zip(values[1].iter()) {
+                let index = self.current_gate;
+
+                self.current_gate += 1;
+                self.cs
+                    .assign_fixed(|| "table col 1", self.config.sl, index, || Ok(value_0))?;
+                self.cs
+                    .assign_fixed(|| "table col 2", self.config.sl2, index, || Ok(value_1))?;
+            }
+            Ok(())
+        }
+    }
+
+    impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
+        type Config = PLONKConfig;
+
+        fn configure(meta: &mut ConstraintSystem<F>) -> PLONKConfig {
+            let e = meta.advice_column();
+            let a = meta.advice_column();
+            let b = meta.advice_column();
+            let sf = meta.fixed_column();
+            let c = meta.advice_column();
+            let d = meta.advice_column();
+            let p = meta.aux_column();
+
+            let perm = meta.permutation(&[a, b, c]);
+            let perm2 = meta.permutation(&[a, b, c]);
+
+            let sm = meta.fixed_column();
+            let sa = meta.fixed_column();
+            let sb = meta.fixed_column();
+            let sc = meta.fixed_column();
+            let sp = meta.fixed_column();
+            let sl = meta.fixed_column();
+            let sl2 = meta.fixed_column();
+
+            /*
+             *    A    B        ...  sl   sl2
+             * [
+             *   aux   0        ...  0    0
+             *   a     a        ...  0    0
+             *   a     a^2      ...  0    0
+             *   a     a        ...  0    0
+             *   a     a^2      ...  0    0
+             *   ...   ...      ...  ...  ...
+             *   ...   ...      ...  aux  0
+             *   ...   ...      ...  a    a
+             *   ...   ...      ...  a    a^2
+             *   ...   ...      ...  0    0
+             *
+             * ]
+             */
+            meta.lookup(&[a.into()], &[sl.into()]);
+            meta.lookup(&[a.into(), b.into()], &[sl.into(), sl2.into()]);
+
+            meta.create_gate("Combined add-mult", |meta| {
+                let d = meta.query_advice(d, Rotation::next());
+                let a = meta.query_advice(a, Rotation::cur());
+                let sf = meta.query_fixed(sf, Rotation::cur());
+                let e = meta.query_advice(e, Rotation::prev());
+                let b = meta.query_advice(b, Rotation::cur());
+                let c = meta.query_advice(c, Rotation::cur());
+
+                let sa = meta.query_fixed(sa, Rotation::cur());
+                let sb = meta.query_fixed(sb, Rotation::cur());
+                let sc = meta.query_fixed(sc, Rotation::cur());
+                let sm = meta.query_fixed(sm, Rotation::cur());
+
+                a.clone() * sa + b.clone() * sb + a * b * sm + (c * sc * (-F::one())) + sf * (d * e)
+            });
+
+            meta.create_gate("Public input", |meta| {
+                let a = meta.query_advice(a, Rotation::cur());
+                let p = meta.query_aux(p, Rotation::cur());
+                let sp = meta.query_fixed(sp, Rotation::cur());
+
+                sp * (a + p * (-F::one()))
+            });
+
+            PLONKConfig {
+                a,
+                b,
+                c,
+                d,
+                e,
+                sa,
+                sb,
+                sc,
+                sm,
+                sp,
+                sl,
+                sl2,
+                perm,
+                perm2,
+            }
+        }
+
+        fn synthesize(
+            &self,
+            cs: &mut impl Assignment<F>,
+            config: PLONKConfig,
+        ) -> Result<(), Error> {
+            let mut cs = StandardPLONK::new(cs, config);
+
+            cs.enter_region(|| "input");
+            let _ = cs.public_input(|| Ok(F::one() + F::one()))?;
+            cs.exit_region();
+
+            for i in 0..10 {
+                cs.enter_region(|| format!("region_{}", i));
+                let mut a_squared = None;
+                let (a0, _, c0) = cs.raw_multiply(|| {
+                    a_squared = self.a.map(|a| a.square());
+                    Ok((
+                        self.a.ok_or(Error::SynthesisError)?,
+                        self.a.ok_or(Error::SynthesisError)?,
+                        a_squared.ok_or(Error::SynthesisError)?,
+                    ))
+                })?;
+                let (a1, b1, _) = cs.raw_add(|| {
+                    let fin = a_squared.and_then(|a2| self.a.map(|a| a + a2));
+                    Ok((
+                        self.a.ok_or(Error::SynthesisError)?,
+                        a_squared.ok_or(Error::SynthesisError)?,
+                        fin.ok_or(Error::SynthesisError)?,
+                    ))
+                })?;
+                cs.copy(a0, a1)?;
+                cs.copy(b1, c0)?;
+                cs.exit_region();
+            }
+
+            cs.enter_region(|| "lookup table");
+            cs.lookup_table(&self.lookup_tables)?;
+            cs.exit_region();
+
+            Ok(())
+        }
+    }
+
+    let a = Fp::rand();
+    let a_squared = a * &a;
+    let aux = Fp::one() + Fp::one();
+    let lookup_table = vec![aux, a, a, Fp::zero()];
+    let lookup_table_2 = vec![Fp::zero(), a, a_squared, Fp::zero()];
+
+    let circuit: MyCircuit<Fp> = MyCircuit {
+        a: None,
+        lookup_tables: vec![lookup_table, lookup_table_2],
+    };
+
+    let root = BitMapBackend::new("example-circuit-layout.png", (1024, 768)).into_drawing_area();
+    root.fill(&WHITE).unwrap();
+    let root = root
+        .titled("Example Circuit Layout", ("sans-serif", 60))
+        .unwrap();
+
+    circuit_layout(&circuit, &root).unwrap();
+}

--- a/examples/circuit-layout.rs
+++ b/examples/circuit-layout.rs
@@ -13,6 +13,7 @@ fn main() {
     #[derive(Copy, Clone, Debug)]
     pub struct Variable(Column<Advice>, usize);
 
+    #[derive(Clone)]
     struct PLONKConfig {
         a: Column<Advice>,
         b: Column<Advice>,

--- a/examples/performance_model.rs
+++ b/examples/performance_model.rs
@@ -204,7 +204,7 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
         let sc = meta.fixed_column();
         let sp = meta.fixed_column();
 
-        meta.create_gate(|meta| {
+        meta.create_gate("Combined add-mult", |meta| {
             let a = meta.query_advice(a, Rotation::cur());
             let b = meta.query_advice(b, Rotation::cur());
             let c = meta.query_advice(c, Rotation::cur());
@@ -217,7 +217,7 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
             a.clone() * sa + b.clone() * sb + a * b * sm + (c * sc * (-F::one()))
         });
 
-        meta.create_gate(|meta| {
+        meta.create_gate("Public input", |meta| {
             let a = meta.query_advice(a, Rotation::cur());
             let p = meta.query_aux(p, Rotation::cur());
             let sp = meta.query_fixed(sp, Rotation::cur());

--- a/examples/performance_model.rs
+++ b/examples/performance_model.rs
@@ -76,25 +76,36 @@ impl<'a, FF: FieldExt, CS: Assignment<FF>> StandardCS<FF> for StandardPLONK<'a, 
         let index = self.current_gate;
         self.current_gate += 1;
         let mut value = None;
-        self.cs.assign_advice(self.config.a, index, || {
-            value = Some(f()?);
-            Ok(value.ok_or(Error::SynthesisError)?.0)
-        })?;
-        self.cs.assign_advice(self.config.b, index, || {
-            Ok(value.ok_or(Error::SynthesisError)?.1)
-        })?;
-        self.cs.assign_advice(self.config.c, index, || {
-            Ok(value.ok_or(Error::SynthesisError)?.2)
-        })?;
+        self.cs.assign_advice(
+            || "lhs",
+            self.config.a,
+            index,
+            || {
+                value = Some(f()?);
+                Ok(value.ok_or(Error::SynthesisError)?.0)
+            },
+        )?;
+        self.cs.assign_advice(
+            || "rhs",
+            self.config.b,
+            index,
+            || Ok(value.ok_or(Error::SynthesisError)?.1),
+        )?;
+        self.cs.assign_advice(
+            || "out",
+            self.config.c,
+            index,
+            || Ok(value.ok_or(Error::SynthesisError)?.2),
+        )?;
 
         self.cs
-            .assign_fixed(self.config.sa, index, || Ok(FF::zero()))?;
+            .assign_fixed(|| "a", self.config.sa, index, || Ok(FF::zero()))?;
         self.cs
-            .assign_fixed(self.config.sb, index, || Ok(FF::zero()))?;
+            .assign_fixed(|| "b", self.config.sb, index, || Ok(FF::zero()))?;
         self.cs
-            .assign_fixed(self.config.sc, index, || Ok(FF::one()))?;
+            .assign_fixed(|| "c", self.config.sc, index, || Ok(FF::one()))?;
         self.cs
-            .assign_fixed(self.config.sm, index, || Ok(FF::one()))?;
+            .assign_fixed(|| "a * b", self.config.sm, index, || Ok(FF::one()))?;
         Ok((
             Variable(self.config.a, index),
             Variable(self.config.b, index),
@@ -108,25 +119,36 @@ impl<'a, FF: FieldExt, CS: Assignment<FF>> StandardCS<FF> for StandardPLONK<'a, 
         let index = self.current_gate;
         self.current_gate += 1;
         let mut value = None;
-        self.cs.assign_advice(self.config.a, index, || {
-            value = Some(f()?);
-            Ok(value.ok_or(Error::SynthesisError)?.0)
-        })?;
-        self.cs.assign_advice(self.config.b, index, || {
-            Ok(value.ok_or(Error::SynthesisError)?.1)
-        })?;
-        self.cs.assign_advice(self.config.c, index, || {
-            Ok(value.ok_or(Error::SynthesisError)?.2)
-        })?;
+        self.cs.assign_advice(
+            || "lhs",
+            self.config.a,
+            index,
+            || {
+                value = Some(f()?);
+                Ok(value.ok_or(Error::SynthesisError)?.0)
+            },
+        )?;
+        self.cs.assign_advice(
+            || "rhs",
+            self.config.b,
+            index,
+            || Ok(value.ok_or(Error::SynthesisError)?.1),
+        )?;
+        self.cs.assign_advice(
+            || "out",
+            self.config.c,
+            index,
+            || Ok(value.ok_or(Error::SynthesisError)?.2),
+        )?;
 
         self.cs
-            .assign_fixed(self.config.sa, index, || Ok(FF::one()))?;
+            .assign_fixed(|| "a", self.config.sa, index, || Ok(FF::one()))?;
         self.cs
-            .assign_fixed(self.config.sb, index, || Ok(FF::one()))?;
+            .assign_fixed(|| "b", self.config.sb, index, || Ok(FF::one()))?;
         self.cs
-            .assign_fixed(self.config.sc, index, || Ok(FF::one()))?;
+            .assign_fixed(|| "c", self.config.sc, index, || Ok(FF::one()))?;
         self.cs
-            .assign_fixed(self.config.sm, index, || Ok(FF::zero()))?;
+            .assign_fixed(|| "a * b", self.config.sm, index, || Ok(FF::zero()))?;
         Ok((
             Variable(self.config.a, index),
             Variable(self.config.b, index),
@@ -156,9 +178,10 @@ impl<'a, FF: FieldExt, CS: Assignment<FF>> StandardCS<FF> for StandardPLONK<'a, 
     {
         let index = self.current_gate;
         self.current_gate += 1;
-        self.cs.assign_advice(self.config.a, index, || f())?;
         self.cs
-            .assign_fixed(self.config.sp, index, || Ok(FF::one()))?;
+            .assign_advice(|| "value", self.config.a, index, || f())?;
+        self.cs
+            .assign_fixed(|| "public", self.config.sp, index, || Ok(FF::one()))?;
 
         Ok(Variable(self.config.a, index))
     }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -146,12 +146,13 @@ pub trait Layouter<C: Chip> {
     /// closure, the `Layouter` is allowed to optimise as it sees fit.
     ///
     /// ```ignore
-    /// fn assign_region(&mut self, |region| {
+    /// fn assign_region(&mut self, || "region name", |region| {
     ///     region.assign_advice(self.config.a, offset, || { Some(value)});
     /// });
     /// ```
-    fn assign_region(
-        &mut self,
-        assignment: impl FnMut(Region<'_, C>) -> Result<(), Error>,
-    ) -> Result<(), Error>;
+    fn assign_region<A, N, NR>(&mut self, name: N, assignment: A) -> Result<(), Error>
+    where
+        A: FnMut(Region<'_, C>) -> Result<(), Error>,
+        N: Fn() -> NR,
+        NR: Into<String>;
 }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -81,25 +81,39 @@ impl<'r, C: Chip> Region<'r, C> {
     /// Assign an advice column value (witness).
     ///
     /// Even though `to` has `FnMut` bounds, it is guaranteed to be called at most once.
-    pub fn assign_advice<'v>(
+    pub fn assign_advice<'v, V, A, AR>(
         &'v mut self,
+        annotation: A,
         column: Column<Advice>,
         offset: usize,
-        mut to: impl FnMut() -> Result<C::Field, Error> + 'v,
-    ) -> Result<Cell, Error> {
-        self.region.assign_advice(column, offset, &mut to)
+        mut to: V,
+    ) -> Result<Cell, Error>
+    where
+        V: FnMut() -> Result<C::Field, Error> + 'v,
+        A: Fn() -> AR,
+        AR: Into<String>,
+    {
+        self.region
+            .assign_advice(&|| annotation().into(), column, offset, &mut to)
     }
 
     /// Assign a fixed value.
     ///
     /// Even though `to` has `FnMut` bounds, it is guaranteed to be called at most once.
-    pub fn assign_fixed<'v>(
+    pub fn assign_fixed<'v, V, A, AR>(
         &'v mut self,
+        annotation: A,
         column: Column<Fixed>,
         offset: usize,
-        mut to: impl FnMut() -> Result<C::Field, Error> + 'v,
-    ) -> Result<Cell, Error> {
-        self.region.assign_fixed(column, offset, &mut to)
+        mut to: V,
+    ) -> Result<Cell, Error>
+    where
+        V: FnMut() -> Result<C::Field, Error> + 'v,
+        A: Fn() -> AR,
+        AR: Into<String>,
+    {
+        self.region
+            .assign_fixed(&|| annotation().into(), column, offset, &mut to)
     }
 
     /// Constraint two cells to have the same value.

--- a/src/circuit/layouter.rs
+++ b/src/circuit/layouter.rs
@@ -100,6 +100,8 @@ impl<'a, C: Chip, CS: Assignment<C::Field>> SingleChip<'a, C, CS> {
 }
 
 impl<'a, C: Chip, CS: Assignment<C::Field> + 'a> Layouter<C> for SingleChip<'a, C, CS> {
+    type Root = Self;
+
     fn config(&self) -> &C::Config {
         &self.config
     }
@@ -141,6 +143,22 @@ impl<'a, C: Chip, CS: Assignment<C::Field> + 'a> Layouter<C> for SingleChip<'a, 
         self.cs.exit_region();
 
         Ok(())
+    }
+
+    fn get_root(&mut self) -> &mut Self::Root {
+        self
+    }
+
+    fn push_namespace<NR, N>(&mut self, name_fn: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        self.cs.push_namespace(name_fn)
+    }
+
+    fn pop_namespace(&mut self, gadget_name: Option<String>) {
+        self.cs.pop_namespace(gadget_name)
     }
 }
 

--- a/src/circuit/layouter.rs
+++ b/src/circuit/layouter.rs
@@ -40,6 +40,7 @@ pub trait RegionLayouter<C: Chip>: fmt::Debug {
     /// Assign an advice column value (witness)
     fn assign_advice<'v>(
         &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Advice>,
         offset: usize,
         to: &'v mut (dyn FnMut() -> Result<C::Field, Error> + 'v),
@@ -48,6 +49,7 @@ pub trait RegionLayouter<C: Chip>: fmt::Debug {
     /// Assign a fixed value
     fn assign_fixed<'v>(
         &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Fixed>,
         offset: usize,
         to: &'v mut (dyn FnMut() -> Result<C::Field, Error> + 'v),
@@ -176,6 +178,7 @@ impl RegionShape {
 impl<C: Chip> RegionLayouter<C> for RegionShape {
     fn assign_advice<'v>(
         &'v mut self,
+        _: &'v (dyn Fn() -> String + 'v),
         column: Column<Advice>,
         offset: usize,
         _to: &'v mut (dyn FnMut() -> Result<C::Field, Error> + 'v),
@@ -192,6 +195,7 @@ impl<C: Chip> RegionLayouter<C> for RegionShape {
 
     fn assign_fixed<'v>(
         &'v mut self,
+        _: &'v (dyn Fn() -> String + 'v),
         column: Column<Fixed>,
         offset: usize,
         _to: &'v mut (dyn FnMut() -> Result<C::Field, Error> + 'v),
@@ -247,11 +251,13 @@ impl<'r, 'a, C: Chip, CS: Assignment<C::Field> + 'a> RegionLayouter<C>
 {
     fn assign_advice<'v>(
         &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Advice>,
         offset: usize,
         to: &'v mut (dyn FnMut() -> Result<C::Field, Error> + 'v),
     ) -> Result<Cell, Error> {
         self.layouter.cs.assign_advice(
+            annotation,
             column,
             self.layouter.regions[self.region_index] + offset,
             to,
@@ -266,11 +272,13 @@ impl<'r, 'a, C: Chip, CS: Assignment<C::Field> + 'a> RegionLayouter<C>
 
     fn assign_fixed<'v>(
         &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Fixed>,
         offset: usize,
         to: &'v mut (dyn FnMut() -> Result<C::Field, Error> + 'v),
     ) -> Result<Cell, Error> {
         self.layouter.cs.assign_fixed(
+            annotation,
             column,
             self.layouter.regions[self.region_index] + offset,
             to,

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -213,6 +213,18 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
 
         self.permutations[permutation].copy(left_column, left_row, right_column, right_row)
     }
+
+    fn push_namespace<NR, N>(&mut self, _: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        // TODO: Do something with namespaces :)
+    }
+
+    fn pop_namespace(&mut self, _: Option<String>) {
+        // TODO: Do something with namespaces :)
+    }
 }
 
 impl<F: FieldExt> MockProver<F> {

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -147,6 +147,15 @@ pub struct MockProver<F: Group> {
 }
 
 impl<F: Field + Group> Assignment<F> for MockProver<F> {
+    fn enter_region<NR, N>(&mut self, _: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+    }
+
+    fn exit_region(&mut self) {}
+
     fn assign_advice<V, A, AR>(
         &mut self,
         _: A,

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -16,7 +16,7 @@ mod graph;
 
 #[cfg(feature = "dev-graph")]
 #[cfg_attr(docsrs, doc(cfg(feature = "dev-graph")))]
-pub use graph::circuit_dot_graph;
+pub use graph::{circuit_dot_graph, layout::circuit_layout};
 
 /// The reasons why a particular circuit is not satisfied.
 #[derive(Debug, PartialEq)]

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -11,6 +11,13 @@ use crate::{
     poly::Rotation,
 };
 
+#[cfg(feature = "dev-graph")]
+mod graph;
+
+#[cfg(feature = "dev-graph")]
+#[cfg_attr(docsrs, doc(cfg(feature = "dev-graph")))]
+pub use graph::circuit_dot_graph;
+
 /// The reasons why a particular circuit is not satisfied.
 #[derive(Debug, PartialEq)]
 pub enum VerifyFailure {

--- a/src/dev/graph.rs
+++ b/src/dev/graph.rs
@@ -1,0 +1,158 @@
+use ff::Field;
+use tabbycat::{AttrList, Edge, GraphBuilder, GraphType, Identity, StmtList};
+
+use crate::plonk::{Advice, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed};
+
+/// Builds a dot graph string representing the given circuit.
+///
+/// The graph is built from calls to [`Layouter::namespace`] both within the circuit, and
+/// inside the gadgets and chips that it uses.
+///
+/// [`Layouter::namespace`]: crate::circuit::Layouter#method.namespace
+pub fn circuit_dot_graph<F: Field, ConcreteCircuit: Circuit<F>>(
+    circuit: &ConcreteCircuit,
+) -> String {
+    // Collect the graph details.
+    let mut cs = ConstraintSystem::default();
+    let config = ConcreteCircuit::configure(&mut cs);
+    let mut graph = Graph::default();
+    circuit.synthesize(&mut graph, config).unwrap();
+
+    // Construct the node labels. We need to store these, because tabbycat operates on
+    // string references, and we need those references to live long enough.
+    let node_labels: Vec<_> = graph
+        .nodes
+        .into_iter()
+        .map(|(name, gadget_name)| {
+            if let Some(gadget_name) = gadget_name {
+                format!("[{}] {}", gadget_name, name)
+            } else {
+                name
+            }
+        })
+        .collect();
+
+    // Construct the dot graph statements.
+    let mut stmts = StmtList::new();
+    for (id, label) in node_labels.iter().enumerate() {
+        stmts = stmts.add_node(
+            id.into(),
+            None,
+            Some(AttrList::new().add_pair(tabbycat::attributes::label(label))),
+        );
+    }
+    for (parent, child) in graph.edges {
+        stmts =
+            stmts.add_edge(Edge::head_node(parent.into(), None).arrow_to_node(child.into(), None))
+    }
+
+    // Build the graph!
+    GraphBuilder::default()
+        .graph_type(GraphType::DiGraph)
+        .strict(false)
+        .id(Identity::id("circuit").unwrap())
+        .stmts(stmts)
+        .build()
+        .unwrap()
+        .to_string()
+}
+
+#[derive(Default)]
+struct Graph {
+    /// Graph nodes in the namespace, structured as `(name, gadget_name)`.
+    nodes: Vec<(String, Option<String>)>,
+
+    /// Directed edges in the graph, as pairs of indices into `nodes`.
+    edges: Vec<(usize, usize)>,
+
+    /// The current namespace, as indices into `nodes`.
+    current_namespace: Vec<usize>,
+}
+
+impl<F: Field> Assignment<F> for Graph {
+    fn enter_region<NR, N>(&mut self, _: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        // Do nothing; we don't care about regions in this context.
+    }
+
+    fn exit_region(&mut self) {
+        // Do nothing; we don't care about regions in this context.
+    }
+
+    fn assign_advice<V, A, AR>(
+        &mut self,
+        _: A,
+        _: Column<Advice>,
+        _: usize,
+        _: V,
+    ) -> Result<(), Error>
+    where
+        V: FnOnce() -> Result<F, Error>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        // Do nothing; we don't care about cells in this context.
+        Ok(())
+    }
+
+    fn assign_fixed<V, A, AR>(
+        &mut self,
+        _: A,
+        _: Column<Fixed>,
+        _: usize,
+        _: V,
+    ) -> Result<(), Error>
+    where
+        V: FnOnce() -> Result<F, Error>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        // Do nothing; we don't care about cells in this context.
+        Ok(())
+    }
+
+    fn copy(
+        &mut self,
+        _: usize,
+        _: usize,
+        _: usize,
+        _: usize,
+        _: usize,
+    ) -> Result<(), crate::plonk::Error> {
+        // Do nothing; we don't care about permutations in this context.
+        Ok(())
+    }
+
+    fn push_namespace<NR, N>(&mut self, name_fn: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        // Store the new node.
+        let new_node = self.nodes.len();
+        self.nodes.push((name_fn().into(), None));
+
+        // Create an edge from the parent, if any.
+        if let Some(parent) = self.current_namespace.last() {
+            self.edges.push((*parent, new_node));
+        }
+
+        // Push the new namespace.
+        self.current_namespace.push(new_node);
+    }
+
+    fn pop_namespace(&mut self, gadget_name: Option<String>) {
+        // Store the gadget name that was extracted, if any.
+        let node = self
+            .current_namespace
+            .last()
+            .expect("pop_namespace should never be called on the root");
+        self.nodes[*node].1 = gadget_name;
+
+        // Pop the namespace.
+        self.current_namespace.pop();
+    }
+}

--- a/src/dev/graph.rs
+++ b/src/dev/graph.rs
@@ -3,6 +3,8 @@ use tabbycat::{AttrList, Edge, GraphBuilder, GraphType, Identity, StmtList};
 
 use crate::plonk::{Advice, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed};
 
+pub mod layout;
+
 /// Builds a dot graph string representing the given circuit.
 ///
 /// The graph is built from calls to [`Layouter::namespace`] both within the circuit, and

--- a/src/dev/graph/layout.rs
+++ b/src/dev/graph/layout.rs
@@ -1,0 +1,245 @@
+use ff::Field;
+use plotters::{
+    coord::Shift,
+    prelude::{DrawingArea, DrawingAreaErrorKind, DrawingBackend},
+};
+use std::cmp;
+use std::collections::HashSet;
+
+use crate::plonk::{Advice, Any, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed};
+
+/// Renders the circuit layout on the given drawing area.
+///
+/// # Examples
+///
+/// ```ignore
+/// use halo2::dev::circuit_layout;
+/// use plotters::prelude::*;
+///
+/// let drawing_area = BitMapBackend::new("example-circuit-layout.png", (1024, 768))
+///     .into_drawing_area();
+/// drawing_area.fill(&WHITE).unwrap();
+/// let drawing_area = drawing_area
+///     .titled("Example Circuit Layout", ("sans-serif", 60))
+///     .unwrap();
+///
+/// let circuit = MyCircuit::default();
+/// circuit_layout(&circuit, &drawing_area).unwrap();
+/// ```
+pub fn circuit_layout<F: Field, ConcreteCircuit: Circuit<F>, DB: DrawingBackend>(
+    circuit: &ConcreteCircuit,
+    drawing_area: &DrawingArea<DB, Shift>,
+) -> Result<(), DrawingAreaErrorKind<DB::ErrorType>> {
+    use plotters::coord::types::RangedCoordusize;
+    use plotters::prelude::*;
+
+    // Collect the layout details.
+    let mut cs = ConstraintSystem::default();
+    let config = ConcreteCircuit::configure(&mut cs);
+    let mut layout = Layout::default();
+    circuit.synthesize(&mut layout, config).unwrap();
+
+    // Figure out what order to render the columns in.
+    // TODO: For now, just render them in the order they were configured.
+    let total_columns = cs.num_advice_columns + cs.num_aux_columns + cs.num_fixed_columns;
+    let column_index = |column: &Column<Any>| {
+        column.index()
+            + match column.column_type() {
+                Any::Advice => 0,
+                Any::Aux => cs.num_advice_columns,
+                Any::Fixed => cs.num_advice_columns + cs.num_aux_columns,
+            }
+    };
+
+    // Prepare the grid layout. We render a red background for advice columns, white for
+    // aux columns, and blue for fixed columns.
+    let root =
+        drawing_area.apply_coord_spec(Cartesian2d::<RangedCoordusize, RangedCoordusize>::new(
+            0..total_columns,
+            0..layout.total_rows,
+            drawing_area.get_pixel_range(),
+        ));
+    root.draw(&Rectangle::new(
+        [(0, 0), (total_columns, layout.total_rows)],
+        ShapeStyle::from(&WHITE).filled(),
+    ))?;
+    root.draw(&Rectangle::new(
+        [(0, 0), (cs.num_advice_columns, layout.total_rows)],
+        ShapeStyle::from(&RED.mix(0.2)).filled(),
+    ))?;
+    root.draw(&Rectangle::new(
+        [
+            (cs.num_advice_columns + cs.num_aux_columns, 0),
+            (total_columns, layout.total_rows),
+        ],
+        ShapeStyle::from(&BLUE.mix(0.2)).filled(),
+    ))?;
+    root.draw(&Rectangle::new(
+        [(0, 0), (total_columns, layout.total_rows)],
+        &BLACK,
+    ))?;
+
+    let draw_region = |root: &DrawingArea<_, _>, top_left, bottom_right, label| {
+        root.draw(&Rectangle::new(
+            [top_left, bottom_right],
+            ShapeStyle::from(&GREEN.mix(0.2)).filled(),
+        ))?;
+        root.draw(&Rectangle::new([top_left, bottom_right], &BLACK))?;
+        root.draw(
+            &(EmptyElement::at(top_left)
+                + Text::new(label, (10, 10), ("sans-serif", 15.0).into_font())),
+        )
+    };
+
+    // Render the regions!
+    for region in layout.regions {
+        if let Some(offset) = region.offset {
+            // Sort the region's columns according to the defined ordering.
+            let mut columns: Vec<_> = region.columns.into_iter().collect();
+            columns.sort_unstable_by(|a, b| column_index(a).cmp(&column_index(b)));
+
+            // Render contiguous parts of the same region as a single box.
+            let mut width = None;
+            for column in columns {
+                let column = column_index(&column);
+                match width {
+                    Some((start, end)) if end == column => width = Some((start, end + 1)),
+                    Some((start, end)) => {
+                        draw_region(
+                            &root,
+                            (start, offset),
+                            (end, offset + region.rows),
+                            region.name.clone(),
+                        )?;
+                        width = Some((column, column + 1));
+                    }
+                    None => width = Some((column, column + 1)),
+                }
+            }
+
+            // Render the last part of the region.
+            if let Some((start, end)) = width {
+                draw_region(
+                    &root,
+                    (start, offset),
+                    (end, offset + region.rows),
+                    region.name.clone(),
+                )?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct Region {
+    /// The name of the region. Not required to be unique.
+    name: String,
+    /// The columns used by this region.
+    columns: HashSet<Column<Any>>,
+    /// The row that this region starts on, if known.
+    offset: Option<usize>,
+    /// The number of rows that this region takes up.
+    rows: usize,
+}
+
+#[derive(Default)]
+struct Layout {
+    regions: Vec<Region>,
+    current_region: Option<usize>,
+    total_rows: usize,
+}
+
+impl Layout {
+    fn update(&mut self, column: Column<Any>, row: usize) {
+        self.total_rows = cmp::max(self.total_rows, row + 1);
+
+        // TODO: Track assignments outside regions?
+        if let Some(region) = self.current_region {
+            let region = &mut self.regions[region];
+            region.columns.insert(column);
+            let offset = region.offset.unwrap_or(row);
+            region.rows = cmp::max(region.rows, row - offset + 1);
+            region.offset = Some(offset);
+        }
+    }
+}
+
+impl<F: Field> Assignment<F> for Layout {
+    fn enter_region<NR, N>(&mut self, name_fn: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        assert!(self.current_region.is_none());
+        self.current_region = Some(self.regions.len());
+        self.regions.push(Region {
+            name: name_fn().into(),
+            columns: HashSet::default(),
+            offset: None,
+            rows: 0,
+        })
+    }
+
+    fn exit_region(&mut self) {
+        assert!(self.current_region.is_some());
+        self.current_region = None;
+    }
+
+    fn assign_advice<V, A, AR>(
+        &mut self,
+        _: A,
+        column: Column<Advice>,
+        row: usize,
+        _: V,
+    ) -> Result<(), Error>
+    where
+        V: FnOnce() -> Result<F, Error>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        self.update(column.into(), row);
+        Ok(())
+    }
+
+    fn assign_fixed<V, A, AR>(
+        &mut self,
+        _: A,
+        column: Column<Fixed>,
+        row: usize,
+        _: V,
+    ) -> Result<(), Error>
+    where
+        V: FnOnce() -> Result<F, Error>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
+        self.update(column.into(), row);
+        Ok(())
+    }
+
+    fn copy(
+        &mut self,
+        _: usize,
+        _: usize,
+        _: usize,
+        _: usize,
+        _: usize,
+    ) -> Result<(), crate::plonk::Error> {
+        // Do nothing; we don't care about permutations in this context.
+        Ok(())
+    }
+
+    fn push_namespace<NR, N>(&mut self, _: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        // Do nothing; we don't care about namespaces in this context.
+    }
+
+    fn pop_namespace(&mut self, _: Option<String>) {
+        // Do nothing; we don't care about namespaces in this context.
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 //! # halo2
 
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(
     clippy::op_ref,
     clippy::assign_op_pattern,

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -230,31 +230,48 @@ fn test_proving() {
             let index = self.current_gate;
             self.current_gate += 1;
             let mut value = None;
-            self.cs.assign_advice(self.config.a, index, || {
-                value = Some(f()?);
-                Ok(value.ok_or(Error::SynthesisError)?.0)
-            })?;
-            self.cs.assign_advice(self.config.d, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.0.square().square())
-            })?;
-            self.cs.assign_advice(self.config.b, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.1)
-            })?;
-            self.cs.assign_advice(self.config.e, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.1.square().square())
-            })?;
-            self.cs.assign_advice(self.config.c, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.2)
-            })?;
+            self.cs.assign_advice(
+                || "lhs",
+                self.config.a,
+                index,
+                || {
+                    value = Some(f()?);
+                    Ok(value.ok_or(Error::SynthesisError)?.0)
+                },
+            )?;
+            self.cs.assign_advice(
+                || "lhs^4",
+                self.config.d,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.0.square().square()),
+            )?;
+            self.cs.assign_advice(
+                || "rhs",
+                self.config.b,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.1),
+            )?;
+            self.cs.assign_advice(
+                || "rhs^4",
+                self.config.e,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.1.square().square()),
+            )?;
+            self.cs.assign_advice(
+                || "out",
+                self.config.c,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.2),
+            )?;
 
             self.cs
-                .assign_fixed(self.config.sa, index, || Ok(FF::zero()))?;
+                .assign_fixed(|| "a", self.config.sa, index, || Ok(FF::zero()))?;
             self.cs
-                .assign_fixed(self.config.sb, index, || Ok(FF::zero()))?;
+                .assign_fixed(|| "b", self.config.sb, index, || Ok(FF::zero()))?;
             self.cs
-                .assign_fixed(self.config.sc, index, || Ok(FF::one()))?;
+                .assign_fixed(|| "c", self.config.sc, index, || Ok(FF::one()))?;
             self.cs
-                .assign_fixed(self.config.sm, index, || Ok(FF::one()))?;
+                .assign_fixed(|| "a * b", self.config.sm, index, || Ok(FF::one()))?;
             Ok((
                 Variable(self.config.a, index),
                 Variable(self.config.b, index),
@@ -268,31 +285,48 @@ fn test_proving() {
             let index = self.current_gate;
             self.current_gate += 1;
             let mut value = None;
-            self.cs.assign_advice(self.config.a, index, || {
-                value = Some(f()?);
-                Ok(value.ok_or(Error::SynthesisError)?.0)
-            })?;
-            self.cs.assign_advice(self.config.d, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.0.square().square())
-            })?;
-            self.cs.assign_advice(self.config.b, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.1)
-            })?;
-            self.cs.assign_advice(self.config.e, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.1.square().square())
-            })?;
-            self.cs.assign_advice(self.config.c, index, || {
-                Ok(value.ok_or(Error::SynthesisError)?.2)
-            })?;
+            self.cs.assign_advice(
+                || "lhs",
+                self.config.a,
+                index,
+                || {
+                    value = Some(f()?);
+                    Ok(value.ok_or(Error::SynthesisError)?.0)
+                },
+            )?;
+            self.cs.assign_advice(
+                || "lhs^4",
+                self.config.d,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.0.square().square()),
+            )?;
+            self.cs.assign_advice(
+                || "rhs",
+                self.config.b,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.1),
+            )?;
+            self.cs.assign_advice(
+                || "rhs^4",
+                self.config.e,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.1.square().square()),
+            )?;
+            self.cs.assign_advice(
+                || "out",
+                self.config.c,
+                index,
+                || Ok(value.ok_or(Error::SynthesisError)?.2),
+            )?;
 
             self.cs
-                .assign_fixed(self.config.sa, index, || Ok(FF::one()))?;
+                .assign_fixed(|| "a", self.config.sa, index, || Ok(FF::one()))?;
             self.cs
-                .assign_fixed(self.config.sb, index, || Ok(FF::one()))?;
+                .assign_fixed(|| "b", self.config.sb, index, || Ok(FF::one()))?;
             self.cs
-                .assign_fixed(self.config.sc, index, || Ok(FF::one()))?;
+                .assign_fixed(|| "c", self.config.sc, index, || Ok(FF::one()))?;
             self.cs
-                .assign_fixed(self.config.sm, index, || Ok(FF::zero()))?;
+                .assign_fixed(|| "a * b", self.config.sm, index, || Ok(FF::zero()))?;
             Ok((
                 Variable(self.config.a, index),
                 Variable(self.config.b, index),
@@ -329,9 +363,10 @@ fn test_proving() {
         {
             let index = self.current_gate;
             self.current_gate += 1;
-            self.cs.assign_advice(self.config.a, index, || f())?;
             self.cs
-                .assign_fixed(self.config.sp, index, || Ok(FF::one()))?;
+                .assign_advice(|| "value", self.config.a, index, || f())?;
+            self.cs
+                .assign_fixed(|| "public", self.config.sp, index, || Ok(FF::one()))?;
 
             Ok(Variable(self.config.a, index))
         }
@@ -341,9 +376,9 @@ fn test_proving() {
 
                 self.current_gate += 1;
                 self.cs
-                    .assign_fixed(self.config.sl, index, || Ok(value_0))?;
+                    .assign_fixed(|| "table col 1", self.config.sl, index, || Ok(value_0))?;
                 self.cs
-                    .assign_fixed(self.config.sl2, index, || Ok(value_1))?;
+                    .assign_fixed(|| "table col 2", self.config.sl2, index, || Ok(value_1))?;
             }
             Ok(())
         }

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -426,7 +426,7 @@ fn test_proving() {
             meta.lookup(&[a.into()], &[sl.into()]);
             meta.lookup(&[a.into(), b.into()], &[sl.into(), sl2.into()]);
 
-            meta.create_gate(|meta| {
+            meta.create_gate("Combined add-mult", |meta| {
                 let d = meta.query_advice(d, Rotation::next());
                 let a = meta.query_advice(a, Rotation::cur());
                 let sf = meta.query_fixed(sf, Rotation::cur());
@@ -442,7 +442,7 @@ fn test_proving() {
                 a.clone() * sa + b.clone() * sb + a * b * sm + (c * sc * (-F::one())) + sf * (d * e)
             });
 
-            meta.create_gate(|meta| {
+            meta.create_gate("Public input", |meta| {
                 let a = meta.query_advice(a, Rotation::cur());
                 let p = meta.query_aux(p, Rotation::cur());
                 let sp = meta.query_fixed(sp, Rotation::cur());

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -182,6 +182,23 @@ pub trait Assignment<F: Field> {
         right_column: usize,
         right_row: usize,
     ) -> Result<(), Error>;
+
+    /// Creates a new (sub)namespace and enters into it.
+    ///
+    /// Not intended for downstream consumption; use [`Layouter::namespace`] instead.
+    ///
+    /// [`Layouter::namespace`]: crate::circuit::Layouter#method.namespace
+    fn push_namespace<NR, N>(&mut self, name_fn: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR;
+
+    /// Exits out of the existing namespace.
+    ///
+    /// Not intended for downstream consumption; use [`Layouter::namespace`] instead.
+    ///
+    /// [`Layouter::namespace`]: crate::circuit::Layouter#method.namespace
+    fn pop_namespace(&mut self, gadget_name: Option<String>);
 }
 
 /// This is a trait that circuits provide implementations for so that the

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -127,20 +127,30 @@ impl TryFrom<Column<Any>> for Column<Aux> {
 /// for a constraint system.
 pub trait Assignment<F: Field> {
     /// Assign an advice column value (witness)
-    fn assign_advice(
+    fn assign_advice<V, A, AR>(
         &mut self,
+        annotation: A,
         column: Column<Advice>,
         row: usize,
-        to: impl FnOnce() -> Result<F, Error>,
-    ) -> Result<(), Error>;
+        to: V,
+    ) -> Result<(), Error>
+    where
+        V: FnOnce() -> Result<F, Error>,
+        A: FnOnce() -> AR,
+        AR: Into<String>;
 
     /// Assign a fixed value
-    fn assign_fixed(
+    fn assign_fixed<V, A, AR>(
         &mut self,
+        annotation: A,
         column: Column<Fixed>,
         row: usize,
-        to: impl FnOnce() -> Result<F, Error>,
-    ) -> Result<(), Error>;
+        to: V,
+    ) -> Result<(), Error>
+    where
+        V: FnOnce() -> Result<F, Error>,
+        A: FnOnce() -> AR,
+        AR: Into<String>;
 
     /// Assign two advice columns to have the same value
     fn copy(

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -206,7 +206,7 @@ pub trait Assignment<F: Field> {
 /// [`ConstraintSystem`] implementation.
 pub trait Circuit<F: Field> {
     /// This is a configuration object that stores things like columns.
-    type Config: Copy;
+    type Config: Clone;
 
     /// The circuit is given an opportunity to describe the exact gate
     /// arrangement, column arrangement, etc.

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -349,7 +349,7 @@ pub struct ConstraintSystem<F> {
     pub(crate) num_fixed_columns: usize,
     pub(crate) num_advice_columns: usize,
     pub(crate) num_aux_columns: usize,
-    pub(crate) gates: Vec<Expression<F>>,
+    pub(crate) gates: Vec<(&'static str, Expression<F>)>,
     pub(crate) advice_queries: Vec<(Column<Advice>, Rotation)>,
     pub(crate) aux_queries: Vec<(Column<Aux>, Rotation)>,
     pub(crate) fixed_queries: Vec<(Column<Fixed>, Rotation)>,
@@ -543,9 +543,9 @@ impl<F: Field> ConstraintSystem<F> {
     }
 
     /// Create a new gate
-    pub fn create_gate(&mut self, f: impl FnOnce(&mut Self) -> Expression<F>) {
+    pub fn create_gate(&mut self, name: &'static str, f: impl FnOnce(&mut Self) -> Expression<F>) {
         let poly = f(self);
-        self.gates.push(poly);
+        self.gates.push((name, poly));
     }
 
     /// Allocate a new fixed column

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -126,6 +126,27 @@ impl TryFrom<Column<Any>> for Column<Aux> {
 /// This trait allows a [`Circuit`] to direct some backend to assign a witness
 /// for a constraint system.
 pub trait Assignment<F: Field> {
+    /// Creates a new region and enters into it.
+    ///
+    /// Panics if we are currently in a region (if `exit_region` was not called).
+    ///
+    /// Not intended for downstream consumption; use [`Layouter::assign_region`] instead.
+    ///
+    /// [`Layouter::assign_region`]: crate::circuit::Layouter#method.assign_region
+    fn enter_region<NR, N>(&mut self, name_fn: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR;
+
+    /// Exits the current region.
+    ///
+    /// Panics if we are not currently in a region (if `enter_region` was not called).
+    ///
+    /// Not intended for downstream consumption; use [`Layouter::assign_region`] instead.
+    ///
+    /// [`Layouter::assign_region`]: crate::circuit::Layouter#method.assign_region
+    fn exit_region(&mut self);
+
     /// Assign an advice column value (witness)
     fn assign_advice<V, A, AR>(
         &mut self,

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -128,6 +128,18 @@ impl<F: Field> Assignment<F> for Assembly<F> {
 
         self.permutations[permutation].copy(left_column, left_row, right_column, right_row)
     }
+
+    fn push_namespace<NR, N>(&mut self, _: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        // Do nothing; we don't care about namespaces in this context.
+    }
+
+    fn pop_namespace(&mut self, _: Option<String>) {
+        // Do nothing; we don't care about namespaces in this context.
+    }
 }
 
 /// Generate a `VerifyingKey` from an instance of `Circuit`.

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -64,6 +64,18 @@ struct Assembly<F: Field> {
 }
 
 impl<F: Field> Assignment<F> for Assembly<F> {
+    fn enter_region<NR, N>(&mut self, _: N)
+    where
+        NR: Into<String>,
+        N: FnOnce() -> NR,
+    {
+        // Do nothing; we don't care about regions in this context.
+    }
+
+    fn exit_region(&mut self) {
+        // Do nothing; we don't care about regions in this context.
+    }
+
     fn assign_advice<V, A, AR>(
         &mut self,
         _: A,

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -46,7 +46,7 @@ where
 
     // Account for each gate to ensure our quotient polynomial is the
     // correct degree and that our extended domain is the right size.
-    for poly in cs.gates.iter() {
+    for (_, poly) in cs.gates.iter() {
         degree = std::cmp::max(degree, poly.degree());
     }
 

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -57,29 +57,41 @@ where
 
 /// Assembly to be used in circuit synthesis.
 #[derive(Debug)]
-pub struct Assembly<F: Field> {
+struct Assembly<F: Field> {
     fixed: Vec<Polynomial<F, LagrangeCoeff>>,
     permutations: Vec<permutation::keygen::Assembly>,
     _marker: std::marker::PhantomData<F>,
 }
 
 impl<F: Field> Assignment<F> for Assembly<F> {
-    fn assign_advice(
+    fn assign_advice<V, A, AR>(
         &mut self,
+        _: A,
         _: Column<Advice>,
         _: usize,
-        _: impl FnOnce() -> Result<F, Error>,
-    ) -> Result<(), Error> {
+        _: V,
+    ) -> Result<(), Error>
+    where
+        V: FnOnce() -> Result<F, Error>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
         // We only care about fixed columns here
         Ok(())
     }
 
-    fn assign_fixed(
+    fn assign_fixed<V, A, AR>(
         &mut self,
+        _: A,
         column: Column<Fixed>,
         row: usize,
-        to: impl FnOnce() -> Result<F, Error>,
-    ) -> Result<(), Error> {
+        to: V,
+    ) -> Result<(), Error>
+    where
+        V: FnOnce() -> Result<F, Error>,
+        A: FnOnce() -> AR,
+        AR: Into<String>,
+    {
         *self
             .fixed
             .get_mut(column.index())

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -182,7 +182,7 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
             };
 
             // Synthesize the circuit to obtain the witness and other information.
-            circuit.synthesize(&mut witness, config)?;
+            circuit.synthesize(&mut witness, config.clone())?;
 
             let witness = witness;
 

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -100,12 +100,18 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
             }
 
             impl<F: Field> Assignment<F> for WitnessCollection<F> {
-                fn assign_advice(
+                fn assign_advice<V, A, AR>(
                     &mut self,
+                    _: A,
                     column: Column<Advice>,
                     row: usize,
-                    to: impl FnOnce() -> Result<F, Error>,
-                ) -> Result<(), Error> {
+                    to: V,
+                ) -> Result<(), Error>
+                where
+                    V: FnOnce() -> Result<F, Error>,
+                    A: FnOnce() -> AR,
+                    AR: Into<String>,
+                {
                     *self
                         .advice
                         .get_mut(column.index())
@@ -115,12 +121,18 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
                     Ok(())
                 }
 
-                fn assign_fixed(
+                fn assign_fixed<V, A, AR>(
                     &mut self,
+                    _: A,
                     _: Column<Fixed>,
                     _: usize,
-                    _: impl FnOnce() -> Result<F, Error>,
-                ) -> Result<(), Error> {
+                    _: V,
+                ) -> Result<(), Error>
+                where
+                    V: FnOnce() -> Result<F, Error>,
+                    A: FnOnce() -> AR,
+                    AR: Into<String>,
+                {
                     // We only care about advice columns here
 
                     Ok(())

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -100,6 +100,18 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
             }
 
             impl<F: Field> Assignment<F> for WitnessCollection<F> {
+                fn enter_region<NR, N>(&mut self, _: N)
+                where
+                    NR: Into<String>,
+                    N: FnOnce() -> NR,
+                {
+                    // Do nothing; we don't care about regions in this context.
+                }
+
+                fn exit_region(&mut self) {
+                    // Do nothing; we don't care about regions in this context.
+                }
+
                 fn assign_advice<V, A, AR>(
                     &mut self,
                     _: A,

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -162,6 +162,18 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
 
                     Ok(())
                 }
+
+                fn push_namespace<NR, N>(&mut self, _: N)
+                where
+                    NR: Into<String>,
+                    N: FnOnce() -> NR,
+                {
+                    // Do nothing; we don't care about namespaces in this context.
+                }
+
+                fn pop_namespace(&mut self, _: Option<String>) {
+                    // Do nothing; we don't care about namespaces in this context.
+                }
             }
 
             let mut witness = WitnessCollection {

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -350,7 +350,7 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
             |(((advice, aux), permutation_expressions), lookup_expressions)| {
                 iter::empty()
                     // Custom constraints
-                    .chain(meta.gates.iter().map(move |poly| {
+                    .chain(meta.gates.iter().map(move |(_, poly)| {
                         poly.evaluate(
                             &|index| pk.fixed_cosets[index].clone(),
                             &|index| advice.advice_cosets[index].clone(),

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -159,7 +159,7 @@ pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
 
                 std::iter::empty()
                     // Evaluate the circuit using the custom gates provided
-                    .chain(vk.cs.gates.iter().map(move |poly| {
+                    .chain(vk.cs.gates.iter().map(move |(_, poly)| {
                         poly.evaluate(
                             &|index| fixed_evals[index],
                             &|index| advice_evals[index],


### PR DESCRIPTION
This adds support for:
- Gate naming
- User namespacing of gadgets
  - As-implemented, I think this also can just keep on namespacing through into instructions until a region boundary, which may or may not be desirable.
- Gadget name extraction (behind the `gadget-traces` feature flag)
- Region naming
- Cell annotations
- Developer tooling to:
  - render a circuit's namespace as a dot graph.
  - render a circuit as a table.

Closes #124.
Part of #157.