### PR TITLE
Initialize the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to Rust's notion of
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+Initial release!


### PR DESCRIPTION
Adds a base structure to the changelog. Once the first release has been cut, we can start tracking changes using the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format. For an example of this format in action, see https://github.com/str4d/rage/blob/master/age/CHANGELOG.md