### PR TITLE
Rename "auxiliary column" to "instance column" in the book and in code

### DIFF
--- a/book/src/concepts/arithmetization.md
+++ b/book/src/concepts/arithmetization.md
@@ -15,8 +15,10 @@ A UPA circuit depends on a ***configuration***:
 * A finite field $\mathbb{F}$, where cell values (for a given statement and witness) will be
   elements of $\mathbb{F}$.
 * The number of columns in the matrix, and a specification of each column as being
-  ***fixed***, ***advice***, or ***auxiliary***. Fixed columns are fixed by the circuit;
-  advice columns correspond to witness values; and auxiliary columns are used for public inputs.
+  ***fixed***, ***advice***, or ***instance***. Fixed columns are fixed by the circuit;
+  advice columns correspond to witness values; and instance columns are normally used for
+  public inputs (technically, they can be used for any elements shared between the prover
+  and verifier).
 
 * A subset of the columns that can participate in equality constraints.
 

--- a/book/src/concepts/chips.md
+++ b/book/src/concepts/chips.md
@@ -1,7 +1,7 @@
 # Chips
 
 In order to combine functionality from several cores, we use a ***chip***. To implement a
-chip, we define a set of fixed, advice, and auxiliary columns, and then specify how they
+chip, we define a set of fixed, advice, and instance columns, and then specify how they
 should be distributed between cores.
 
 In the simplest case, each core will use columns disjoint from the other cores. However, it

--- a/book/src/design/proving-system/circuit-commitments.md
+++ b/book/src/design/proving-system/circuit-commitments.md
@@ -9,9 +9,9 @@ the $i$th fixed column. Without loss of generality, we'll similarly define $A_{i
 represent the advice and instance assignments.
 
 > We separate fixed columns here because they are provided by the verifier, whereas the
-> advice columns are provided by the prover. The instance columns are agreed between both
-> parties. In practice, the commitments to instance and fixed columns are computed by
-> both the prover and verifier, and only the advice commitments are stored in the proof.
+> advice and instance columns are provided by the prover. In practice, the commitments to
+> instance and fixed columns are computed by both the prover and verifier, and only the
+> advice commitments are stored in the proof.
 
 To commit to these assignments, we construct Lagrange polynomials of degree $n - 1$ for
 each column, over an evaluation domain of size $n$ (where $\omega$ is the $n$th primitive

--- a/book/src/design/proving-system/circuit-commitments.md
+++ b/book/src/design/proving-system/circuit-commitments.md
@@ -4,14 +4,14 @@
 
 At the start of proof creation, the prover has a table of cell assignments that it claims
 satisfy the constraint system. The table has $n = 2^k$ rows, and is broken into advice,
-auxiliary, and fixed columns. We define $F_{i,j}$ as the assignment in the $j$th row of
+instance, and fixed columns. We define $F_{i,j}$ as the assignment in the $j$th row of
 the $i$th fixed column. Without loss of generality, we'll similarly define $A_{i,j}$ to
-represent the advice and auxiliary assignments.
+represent the advice and instance assignments.
 
 > We separate fixed columns here because they are provided by the verifier, whereas the
-> advice and auxiliary columns are provided by the prover. In practice, the commitments to
-> auxiliary and fixed columns are computed by both the prover and verifier, and only the
-> advice commitments are stored in the proof.
+> advice columns are provided by the prover. The instance columns are agreed between both
+> parties. In practice, the commitments to instance and fixed columns are computed by
+> both the prover and verifier, and only the advice commitments are stored in the proof.
 
 To commit to these assignments, we construct Lagrange polynomials of degree $n - 1$ for
 each column, over an evaluation domain of size $n$ (where $\omega$ is the $n$th primitive

--- a/book/src/design/proving-system/comparison.md
+++ b/book/src/design/proving-system/comparison.md
@@ -36,7 +36,7 @@ Halo 2's polynomial commitment scheme differs from Appendix A.2 of BCMS20 in two
 1. Step 8 of the $\text{Open}$ algorithm computes a "non-hiding" commitment $C'$ prior to
    the inner product argument, which opens to the same value as $C$ but is a commitment to
    a randomly-drawn polynomial. The remainder of the protocol involves no blinding. By
-   contrast, in Halo 2 we blind every single commitment that we make (even for auxiliary
+   contrast, in Halo 2 we blind every single commitment that we make (even for instance
    and fixed polynomials, though using a blinding factor of 1 for the fixed polynomials);
    this makes the protocol simpler to reason about. As a consequence of this, the verifier
    needs to handle the cumulative blinding factor at the end of the protocol, and so there

--- a/examples/circuit-layout.rs
+++ b/examples/circuit-layout.rs
@@ -255,7 +255,7 @@ fn main() {
             let sf = meta.fixed_column();
             let c = meta.advice_column();
             let d = meta.advice_column();
-            let p = meta.aux_column();
+            let p = meta.instance_column();
 
             let perm = meta.permutation(&[a, b, c]);
             let perm2 = meta.permutation(&[a, b, c]);
@@ -269,19 +269,18 @@ fn main() {
             let sl2 = meta.fixed_column();
 
             /*
-             *    A    B        ...  sl   sl2
+             *   A         B      ...  sl        sl2
              * [
-             *   aux   0        ...  0    0
-             *   a     a        ...  0    0
-             *   a     a^2      ...  0    0
-             *   a     a        ...  0    0
-             *   a     a^2      ...  0    0
-             *   ...   ...      ...  ...  ...
-             *   ...   ...      ...  aux  0
-             *   ...   ...      ...  a    a
-             *   ...   ...      ...  a    a^2
-             *   ...   ...      ...  0    0
-             *
+             *   instance  0      ...  0         0
+             *   a         a      ...  0         0
+             *   a         a^2    ...  0         0
+             *   a         a      ...  0         0
+             *   a         a^2    ...  0         0
+             *   ...       ...    ...  ...       ...
+             *   ...       ...    ...  instance  0
+             *   ...       ...    ...  a         a
+             *   ...       ...    ...  a         a^2
+             *   ...       ...    ...  0         0
              * ]
              */
             meta.lookup(&[a.into()], &[sl.into()]);
@@ -305,7 +304,7 @@ fn main() {
 
             meta.create_gate("Public input", |meta| {
                 let a = meta.query_advice(a, Rotation::cur());
-                let p = meta.query_aux(p, Rotation::cur());
+                let p = meta.query_instance(p, Rotation::cur());
                 let sp = meta.query_fixed(sp, Rotation::cur());
 
                 sp * (a + p * (-F::one()))
@@ -374,8 +373,8 @@ fn main() {
 
     let a = Fp::rand();
     let a_squared = a * a;
-    let aux = Fp::one() + Fp::one();
-    let lookup_table = vec![aux, a, a, Fp::zero()];
+    let instance = Fp::one() + Fp::one();
+    let lookup_table = vec![instance, a, a, Fp::zero()];
     let lookup_table_2 = vec![Fp::zero(), a, a_squared, Fp::zero()];
 
     let circuit: MyCircuit<Fp> = MyCircuit {

--- a/examples/performance_model.rs
+++ b/examples/performance_model.rs
@@ -194,7 +194,7 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
         let a = meta.advice_column();
         let b = meta.advice_column();
         let c = meta.advice_column();
-        let p = meta.aux_column();
+        let p = meta.instance_column();
 
         let perm = meta.permutation(&[a, b, c]);
 
@@ -219,7 +219,7 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
 
         meta.create_gate("Public input", |meta| {
             let a = meta.query_advice(a, Rotation::cur());
-            let p = meta.query_aux(p, Rotation::cur());
+            let p = meta.query_instance(p, Rotation::cur());
             let sp = meta.query_fixed(sp, Rotation::cur());
 
             sp * (a + p * (-F::one()))

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -130,9 +130,9 @@ pub enum VerifyFailure {
 /// };
 ///
 /// // This circuit has no public inputs.
-/// let aux = vec![];
+/// let instance = vec![];
 ///
-/// let prover = MockProver::<Fp>::run(K, &circuit, aux).unwrap();
+/// let prover = MockProver::<Fp>::run(K, &circuit, instance).unwrap();
 /// assert_eq!(
 ///     prover.verify(),
 ///     Err(VerifyFailure::Gate {
@@ -151,8 +151,8 @@ pub struct MockProver<F: Group> {
     fixed: Vec<Vec<F>>,
     // The advice cells in the circuit, arranged as [column][row].
     advice: Vec<Vec<F>>,
-    // The aux cells in the circuit, arranged as [column][row].
-    aux: Vec<Vec<F>>,
+    // The instance cells in the circuit, arranged as [column][row].
+    instance: Vec<Vec<F>>,
 
     permutations: Vec<permutation::keygen::Assembly>,
 }
@@ -244,7 +244,7 @@ impl<F: FieldExt> MockProver<F> {
     pub fn run<ConcreteCircuit: Circuit<F>>(
         k: u32,
         circuit: &ConcreteCircuit,
-        aux: Vec<Vec<F>>,
+        instance: Vec<Vec<F>>,
     ) -> Result<Self, Error> {
         let n = 1 << k;
 
@@ -264,7 +264,7 @@ impl<F: FieldExt> MockProver<F> {
             cs,
             fixed,
             advice,
-            aux,
+            instance,
             permutations,
         };
 
@@ -298,7 +298,7 @@ impl<F: FieldExt> MockProver<F> {
                 if gate.evaluate(
                     &load(n, row, &self.cs.fixed_queries, &self.fixed),
                     &load(n, row, &self.cs.advice_queries, &self.advice),
-                    &load(n, row, &self.cs.aux_queries, &self.aux),
+                    &load(n, row, &self.cs.instance_queries, &self.instance),
                     &|a, b| a + &b,
                     &|a, b| a * &b,
                     &|a, scalar| a * scalar,
@@ -319,7 +319,7 @@ impl<F: FieldExt> MockProver<F> {
                 let load = |column: &Column<Any>, row| match column.column_type() {
                     Any::Fixed => self.fixed[column.index()][row as usize],
                     Any::Advice => self.advice[column.index()][row as usize],
-                    Any::Aux => self.aux[column.index()][row as usize],
+                    Any::Instance => self.instance[column.index()][row as usize],
                 };
 
                 let inputs: Vec<_> = lookup

--- a/src/dev/graph/layout.rs
+++ b/src/dev/graph/layout.rs
@@ -45,18 +45,18 @@ pub fn circuit_layout<F: Field, ConcreteCircuit: Circuit<F>, DB: DrawingBackend>
 
     // Figure out what order to render the columns in.
     // TODO: For now, just render them in the order they were configured.
-    let total_columns = cs.num_advice_columns + cs.num_aux_columns + cs.num_fixed_columns;
+    let total_columns = cs.num_advice_columns + cs.num_instance_columns + cs.num_fixed_columns;
     let column_index = |column: &Column<Any>| {
         column.index()
             + match column.column_type() {
                 Any::Advice => 0,
-                Any::Aux => cs.num_advice_columns,
-                Any::Fixed => cs.num_advice_columns + cs.num_aux_columns,
+                Any::Instance => cs.num_advice_columns,
+                Any::Fixed => cs.num_advice_columns + cs.num_instance_columns,
             }
     };
 
     // Prepare the grid layout. We render a red background for advice columns, white for
-    // aux columns, and blue for fixed columns.
+    // instance columns, and blue for fixed columns.
     let root =
         drawing_area.apply_coord_spec(Cartesian2d::<RangedCoordusize, RangedCoordusize>::new(
             0..total_columns,
@@ -73,7 +73,7 @@ pub fn circuit_layout<F: Field, ConcreteCircuit: Circuit<F>, DB: DrawingBackend>
     ))?;
     root.draw(&Rectangle::new(
         [
-            (cs.num_advice_columns + cs.num_aux_columns, 0),
+            (cs.num_advice_columns + cs.num_instance_columns, 0),
             (total_columns, layout.total_rows),
         ],
         ShapeStyle::from(&BLUE.mix(0.2)).filled(),

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -394,7 +394,7 @@ fn test_proving() {
             let sf = meta.fixed_column();
             let c = meta.advice_column();
             let d = meta.advice_column();
-            let p = meta.aux_column();
+            let p = meta.instance_column();
 
             let perm = meta.permutation(&[a, b, c]);
             let perm2 = meta.permutation(&[a, b, c]);
@@ -408,19 +408,18 @@ fn test_proving() {
             let sl2 = meta.fixed_column();
 
             /*
-             *    A    B        ...  sl   sl2
+             *   A         B      ...  sl        sl2
              * [
-             *   aux   0        ...  0    0
-             *   a     a        ...  0    0
-             *   a     a^2      ...  0    0
-             *   a     a        ...  0    0
-             *   a     a^2      ...  0    0
-             *   ...   ...      ...  ...  ...
-             *   ...   ...      ...  aux  0
-             *   ...   ...      ...  a    a
-             *   ...   ...      ...  a    a^2
-             *   ...   ...      ...  0    0
-             *
+             *   instance  0      ...  0         0
+             *   a         a      ...  0         0
+             *   a         a^2    ...  0         0
+             *   a         a      ...  0         0
+             *   a         a^2    ...  0         0
+             *   ...       ...    ...  ...       ...
+             *   ...       ...    ...  instance  0
+             *   ...       ...    ...  a         a
+             *   ...       ...    ...  a         a^2
+             *   ...       ...    ...  0         0
              * ]
              */
             meta.lookup(&[a.into()], &[sl.into()]);
@@ -444,7 +443,7 @@ fn test_proving() {
 
             meta.create_gate("Public input", |meta| {
                 let a = meta.query_advice(a, Rotation::cur());
-                let p = meta.query_aux(p, Rotation::cur());
+                let p = meta.query_instance(p, Rotation::cur());
                 let sp = meta.query_fixed(sp, Rotation::cur());
 
                 sp * (a + p * (-F::one()))
@@ -507,8 +506,8 @@ fn test_proving() {
 
     let a = Fp::rand();
     let a_squared = a * &a;
-    let aux = Fp::one() + Fp::one();
-    let lookup_table = vec![aux, a, a, Fp::zero()];
+    let instance = Fp::one() + Fp::one();
+    let lookup_table = vec![instance, a, a, Fp::zero()];
     let lookup_table_2 = vec![Fp::zero(), a, a_squared, Fp::zero()];
 
     let empty_circuit: MyCircuit<Fp> = MyCircuit {
@@ -526,7 +525,7 @@ fn test_proving() {
     let pk = keygen_pk(&params, vk, &empty_circuit).expect("keygen_pk should not fail");
 
     let mut pubinputs = pk.get_vk().get_domain().empty_lagrange();
-    pubinputs[0] = aux;
+    pubinputs[0] = instance;
     let pubinput = params
         .commit_lagrange(&pubinputs, Blind::default())
         .to_affine();

--- a/src/plonk/lookup/prover.rs
+++ b/src/plonk/lookup/prover.rs
@@ -75,10 +75,10 @@ impl Argument {
         theta: ChallengeTheta<C>,
         advice_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
         fixed_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
-        aux_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
+        instance_values: &'a [Polynomial<C::Scalar, LagrangeCoeff>],
         advice_cosets: &'a [Polynomial<C::Scalar, ExtendedLagrangeCoeff>],
         fixed_cosets: &'a [Polynomial<C::Scalar, ExtendedLagrangeCoeff>],
-        aux_cosets: &'a [Polynomial<C::Scalar, ExtendedLagrangeCoeff>],
+        instance_cosets: &'a [Polynomial<C::Scalar, ExtendedLagrangeCoeff>],
         transcript: &mut T,
     ) -> Result<Permuted<'a, C>, Error> {
         // Closure to get values of columns and compress them
@@ -90,7 +90,7 @@ impl Argument {
                     let (values, cosets) = match column.column_type() {
                         Any::Advice => (advice_values, advice_cosets),
                         Any::Fixed => (fixed_values, fixed_cosets),
-                        Any::Aux => (aux_values, aux_cosets),
+                        Any::Instance => (instance_values, instance_cosets),
                     };
                     (
                         &values[column.index()],

--- a/src/plonk/lookup/verifier.rs
+++ b/src/plonk/lookup/verifier.rs
@@ -107,7 +107,7 @@ impl<C: CurveAffine> Evaluated<C> {
         gamma: ChallengeGamma<C>,
         advice_evals: &[C::Scalar],
         fixed_evals: &[C::Scalar],
-        aux_evals: &[C::Scalar],
+        instance_evals: &[C::Scalar],
     ) -> impl Iterator<Item = C::Scalar> + 'a {
         let product_expression = || {
             // z'(X) (a'(X) + \beta) (s'(X) + \gamma)
@@ -124,7 +124,7 @@ impl<C: CurveAffine> Evaluated<C> {
                         match column.column_type() {
                             Any::Advice => advice_evals[index],
                             Any::Fixed => fixed_evals[index],
-                            Any::Aux => aux_evals[index],
+                            Any::Instance => instance_evals[index],
                         }
                     })
                     .fold(C::Scalar::zero(), |acc, eval| acc * &*theta + &eval)


### PR DESCRIPTION
fixes #181

Signed-off-by: Daira Hopwood <daira@jacaranda.org>