### PR TITLE
Store `Loaded` chip state in chip

### DIFF
--- a/examples/simple-example.rs
+++ b/examples/simple-example.rs
@@ -136,6 +136,7 @@ impl<F: FieldExt> FieldChip<F> {
 // ANCHOR: chip-impl
 impl<F: FieldExt> Chip for FieldChip<F> {
     type Config = FieldConfig;
+    type Loaded = ();
     type Field = F;
 
     fn load(_layouter: &mut impl Layouter<Self>) -> Result<(), halo2::plonk::Error> {
@@ -284,7 +285,7 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
     }
 
     fn synthesize(&self, cs: &mut impl Assignment<F>, config: Self::Config) -> Result<(), Error> {
-        let mut layouter = SingleChip::new(cs, config);
+        let mut layouter = SingleChip::new(cs, config)?;
 
         // Load our private values into the circuit.
         let a = FieldChip::load_private(&mut layouter, self.a)?;

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -16,8 +16,16 @@ pub mod layouter;
 /// [`Layouter::config`].
 pub trait Chip: Sized {
     /// A type that holds the configuration for this chip, and any other state it may need
-    /// during circuit synthesis.
+    /// during circuit synthesis, that can be derived during [`Circuit::configure`].
+    ///
+    /// [`Circuit::configure`]: crate::plonk::Circuit::configure
     type Config: fmt::Debug;
+
+    /// A type that holds any general chip state that needs to be loaded at the start of
+    /// [`Circuit::synthesize`]. This might simply be `()` for some chips.
+    ///
+    /// [`Circuit::synthesize`]: crate::plonk::Circuit::synthesize
+    type Loaded: fmt::Debug;
 
     /// The field that the chip is defined over.
     ///
@@ -25,7 +33,9 @@ pub trait Chip: Sized {
     type Field: FieldExt;
 
     /// Load any fixed configuration for this chip into the circuit.
-    fn load(layouter: &mut impl Layouter<Self>) -> Result<(), Error>;
+    ///
+    /// `layouter.loaded()` will panic if called inside this function.
+    fn load(layouter: &mut impl Layouter<Self>) -> Result<Self::Loaded, Error>;
 }
 
 /// Index of a region in a layouter
@@ -179,6 +189,12 @@ pub trait Layouter<C: Chip> {
     /// Provides access to the chip configuration.
     fn config(&self) -> &C::Config;
 
+    /// Provides access to general chip state loaded at the beginning of circuit
+    /// synthesis.
+    ///
+    /// Panics if called inside `C::load`.
+    fn loaded(&self) -> &C::Loaded;
+
     /// Assign a region of gates to an absolute row number.
     ///
     /// Inside the closure, the chip may freely use relative offsets; the `Layouter` will
@@ -236,6 +252,10 @@ impl<'a, C: Chip, L: Layouter<C> + 'a> Layouter<C> for NamespacedLayouter<'a, C,
 
     fn config(&self) -> &C::Config {
         self.0.config()
+    }
+
+    fn loaded(&self) -> &C::Loaded {
+        self.0.loaded()
     }
 
     fn assign_region<A, AR, N, NR>(&mut self, name: N, assignment: A) -> Result<AR, Error>


### PR DESCRIPTION
Provide access to general chip state loaded at the beginning of circuit synthesis.