### PR TITLE
semi-final zero-knowledge changes

### DIFF
--- a/book/src/design/proving-system/vanishing.md
+++ b/book/src/design/proving-system/vanishing.md
@@ -44,8 +44,8 @@ verifier samples $y$) linear combination of the circuit relations.
 $h(X)$ has degree $(d - 1)n - d$ (because the divisor $t(X)$ has degree $n$). However, the
 polynomial commitment scheme we use for Halo 2 only supports committing to polynomials of
 degree $n - 1$ (which is the maximum degree that the rest of the protocol needs to commit
-to). Instead of increasing the cost of the polynomial commitment scheme, the prover split
-$h(X)$ into pieces of degree $n - 1$
+to). Instead of increasing the cost of the polynomial commitment scheme, the prover splits
+$h(X)$ into pieces of degree at most $n - 1$
 
 $$h_0(X) + X^n h_1(X) + \dots + X^{n(d-1)} h_{d-1}(X),$$
 
@@ -58,7 +58,7 @@ $$\mathbf{H} = [\text{Commit}(h_0(X)), \text{Commit}(h_1(X)), \dots, \text{Commi
 At this point, all properties of the circuit have been committed to. The verifier now
 wants to see if the prover committed to the correct $h(X)$ polynomial. The verifier
 samples $x$, and the prover produces the purported evaluations of the various polynomials
-at $x$, for all the relative offsets used in the circuit, as well as $h(X)$.
+at $x$, for all the relative offsets used in the circuit.
 
 > In our [example](../proving-system.md#example), this would be:
 >
@@ -69,11 +69,12 @@ at $x$, for all the relative offsets used in the circuit, as well as $h(X)$.
 > - $f_0(x)$, $f_0(x \omega^{-1})$
 > - $h_0(x)$, ..., $h_{d-1}(x)$
 
-The verifier checks that these evaluations satisfy the form of $h(X)$:
+The verifier computes $\sum_{i=0}^{d-1} [x^{ni}] \mathbf{H}_i$ which should be a commitment to a polynomial
+that evaluates to the value
+$$\frac{\text{gate}_0(x) + \dots + y^i \cdot \text{gate}_i(x) + \dots}{t(x)}$$
+at $x$ if the prover was honest and the gate constraints are satisfied, with high probability.
 
-$$\frac{\text{gate}_0(x) + \dots + y^i \cdot \text{gate}_i(x) + \dots}{t(x)} = h_0(x) + \dots + x^{n(d-1)} h_{d-1}(x)$$
-
-Now content that the evaluations collectively satisfy the gate constraints, the verifier
-needs to check that the evaluations themselves are consistent with the original
-[circuit commitments](circuit-commitments.md), as well as $\mathbf{H}$. To implement this
-efficiently, we use a [multipoint opening argument](multipoint-opening.md).
+The verifier finally needs to check that the evaluations provided by the prover
+are consistent with the original [circuit commitments](circuit-commitments.md).
+To implement this efficiently, we use a [multipoint opening
+argument](multipoint-opening.md).

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -126,8 +126,9 @@ pub struct PinnedVerificationKey<'a, C: CurveAffine> {
 #[derive(Debug)]
 pub struct ProvingKey<C: CurveAffine> {
     vk: VerifyingKey<C>,
-    // TODO: get rid of this?
     l0: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
+    l_cover: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
+    l_last: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
     fixed_values: Vec<Polynomial<C::Scalar, LagrangeCoeff>>,
     fixed_polys: Vec<Polynomial<C::Scalar, Coeff>>,
     fixed_cosets: Vec<Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -807,6 +807,10 @@ impl<F: Field> ConstraintSystem<F> {
         // h(x) is derived by the other evaluations so it does not reveal
         // anything; in fact it does not even appear in the proof.
 
+        // h(x_3) is also not revealed; the verifier only learns a single
+        // evaluation of a polynomial in x_1 which has h(x_3) and another random
+        // polynomial evaluated at x_3 as coefficients
+
         // Add an additional blinding factor so that each polynomial becomes
         // computationally indistinguishable from random
         factors + 1

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -473,6 +473,7 @@ pub struct ConstraintSystem<F: Field> {
     pub(crate) num_instance_columns: usize,
     pub(crate) gates: Vec<(&'static str, Expression<F>)>,
     pub(crate) advice_queries: Vec<(Column<Advice>, Rotation)>,
+    num_advice_queries: Vec<usize>,
     pub(crate) instance_queries: Vec<(Column<Instance>, Rotation)>,
     pub(crate) fixed_queries: Vec<(Column<Fixed>, Rotation)>,
 
@@ -518,6 +519,7 @@ impl<F: Field> Default for ConstraintSystem<F> {
             gates: vec![],
             fixed_queries: Vec::new(),
             advice_queries: Vec::new(),
+            num_advice_queries: Vec::new(),
             instance_queries: Vec::new(),
             permutations: Vec::new(),
             lookups: Vec::new(),
@@ -613,6 +615,7 @@ impl<F: Field> ConstraintSystem<F> {
         // Make a new query
         let index = self.advice_queries.len();
         self.advice_queries.push((column, at));
+        self.num_advice_queries[column.index] += 1;
 
         index
     }
@@ -741,6 +744,7 @@ impl<F: Field> ConstraintSystem<F> {
             column_type: Advice,
         };
         self.num_advice_columns += 1;
+        self.num_advice_queries.push(0);
         tmp
     }
 
@@ -784,5 +788,27 @@ impl<F: Field> ConstraintSystem<F> {
         }
 
         degree
+    }
+
+    /// Compute the number of blinding factors necessary to perfectly blind
+    /// each of the prover's witness polynomials.
+    pub fn blinding_factors(&self) -> usize {
+        // All of the prover's advice columns are evaluated at most
+        let factors = *self.num_advice_queries.iter().max().unwrap_or(&1);
+        // distinct points during gate checks. In the permutation and lookup
+        // argument the witness polynomials are evaluated at most 2 times:
+
+        let factors = std::cmp::max(2, factors);
+
+        // Each polynomial is evaluated at most an additional time during
+        // multiopen
+        let factors = factors + 1;
+
+        // h(x) is derived by the other evaluations so it does not reveal
+        // anything; in fact it does not even appear in the proof.
+
+        // Add an additional blinding factor so that each polynomial becomes
+        // computationally indistinguishable from random
+        factors + 1
     }
 }

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -784,7 +784,8 @@ impl<F: Field> ConstraintSystem<F> {
         // Account for each gate to ensure our quotient polynomial is the
         // correct degree and that our extended domain is the right size.
         for (_, poly) in self.gates.iter() {
-            degree = std::cmp::max(degree, poly.degree());
+            // All gates are multiplied by (1 - l_cover(X))
+            degree = std::cmp::max(degree, poly.degree() + 1);
         }
 
         degree

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -253,10 +253,10 @@ where
     let l0 = vk.domain.lagrange_to_coeff(l0);
     let l0 = vk.domain.coeff_to_extended(l0, Rotation::cur());
 
-    // Compute l_cover(X) which evaluates to 1 for each inactive row and 0
-    // otherwise over the domain.
+    // Compute l_cover(X) which evaluates to 1 for each inactive row (except
+    // the first one) and 0 otherwise over the domain.
     let mut l_cover = vk.domain.empty_lagrange(0);
-    for evaluation in l_cover[..].iter_mut().rev().take(cs.blinding_factors() + 1) {
+    for evaluation in l_cover[..].iter_mut().rev().take(cs.blinding_factors()) {
         *evaluation = C::Scalar::one();
     }
     let l_cover = vk.domain.lagrange_to_coeff(l_cover);

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -147,7 +147,7 @@ where
     let (domain, cs, config) = create_domain::<C, ConcreteCircuit>(params);
 
     let mut assembly: Assembly<C::Scalar> = Assembly {
-        fixed: vec![domain.empty_lagrange(); cs.num_fixed_columns],
+        fixed: vec![domain.empty_lagrange(0); cs.num_fixed_columns],
         permutations: cs
             .permutations
             .iter()
@@ -196,7 +196,7 @@ where
     let config = ConcreteCircuit::configure(&mut cs);
 
     let mut assembly: Assembly<C::Scalar> = Assembly {
-        fixed: vec![vk.domain.empty_lagrange(); vk.cs.num_fixed_columns],
+        fixed: vec![vk.domain.empty_lagrange(0); vk.cs.num_fixed_columns],
         permutations: vk
             .cs
             .permutations
@@ -238,7 +238,7 @@ where
 
     // Compute l_0(X)
     // TODO: this can be done more efficiently
-    let mut l0 = vk.domain.empty_lagrange();
+    let mut l0 = vk.domain.empty_lagrange(0);
     l0[0] = C::Scalar::one();
     let l0 = vk.domain.lagrange_to_coeff(l0);
     let l0 = vk.domain.coeff_to_extended(l0, Rotation::cur());

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -204,14 +204,18 @@ where
 
     let cs = cs;
     let blinding_factors = cs.blinding_factors();
-    // There needs to be enough room for at least one row.
-    assert!(
-        blinding_factors // m blinding factors
-        + 1 // for l_{-(m + 1)}
-        + 1 // for l_0
-        + 1 // for at least one row
-        <= (params.n as usize)
-    );
+
+    #[allow(clippy::int_plus_one)]
+    {
+        // There needs to be enough room for at least one row.
+        assert!(
+            blinding_factors // m blinding factors
+            + 1 // for l_{-(m + 1)}
+            + 1 // for l_0
+            + 1 // for at least one row
+            <= (params.n as usize)
+        );
+    }
 
     let mut empty_poly = vk.domain.empty_lagrange(blinding_factors + 1);
     empty_poly.clear_inactive();
@@ -281,8 +285,7 @@ where
     *(l_last[..]
         .iter_mut()
         .rev()
-        .skip(cs.blinding_factors())
-        .next()
+        .nth(cs.blinding_factors())
         .unwrap()) = C::Scalar::one();
     let l_last = vk.domain.lagrange_to_coeff(l_last);
     let l_last = vk.domain.coeff_to_extended(l_last, Rotation::cur());

--- a/src/plonk/lookup.rs
+++ b/src/plonk/lookup.rs
@@ -25,15 +25,20 @@ impl<F: Field> Argument<F> {
         // degree 2:
         // l_0(X) * (1 - z'(X)) = 0
         //
-        // degree (1 + input_degree + table_degree):
-        // z'(X) (a'(X) + \beta) (s'(X) + \gamma)
-        // - z'(\omega^{-1} X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \gamma)
+        // degree 2:
+        // l_last(X) * (1 - z'(X)) = 0
+        //
+        // degree (2 + input_degree + table_degree):
+        // (1 - (l_last(X) + l_cover(X))) * (
+        // z'(omega X) (a'(X) + \beta) (s'(X) + \gamma)
+        // - z'(X) (\theta^{m-1} a_0(X) + ... + a_{m-1}(X) + \beta) (\theta^{m-1} s_0(X) + ... + s_{m-1}(X) + \gamma)
+        // )
         //
         // degree 2:
-        // l_0(X) * (a'(X) - s'(X)) = 0
+        // l_0(X) * (a'(X) - s'(X))
         //
-        // degree 2:
-        // (a′(X)−s′(X))⋅(a′(X)−a′(\omega{-1} X)) = 0
+        // degree 3:
+        // (1 - (l_last(X) + l_cover(X))) * ((a′(X)−s′(X))⋅(a′(X)−a′(\omega{-1} X)))
         let mut input_degree = 1;
         for expr in self.input_expressions.iter() {
             input_degree = std::cmp::max(input_degree, expr.degree());
@@ -43,6 +48,6 @@ impl<F: Field> Argument<F> {
             table_degree = std::cmp::max(table_degree, expr.degree());
         }
 
-        1 + input_degree + table_degree
+        std::cmp::max(3, 2 + input_degree + table_degree)
     }
 }

--- a/src/plonk/lookup/prover.rs
+++ b/src/plonk/lookup/prover.rs
@@ -90,6 +90,8 @@ impl<F: FieldExt> Argument<F> {
         C: CurveAffine<ScalarExt = F>,
         C::Curve: Mul<F, Output = C::Curve> + MulAssign<F>,
     {
+        let blinding_factors = pk.vk.cs.blinding_factors();
+
         // Closure to get values of expressions and compress them
         let compress_expressions = |expressions: &[Expression<C::Scalar>]| {
             // Values of input expressions involved in the lookup
@@ -97,7 +99,7 @@ impl<F: FieldExt> Argument<F> {
                 .iter()
                 .map(|expression| {
                     expression.evaluate(
-                        &|scalar| pk.vk.domain.constant_lagrange(scalar),
+                        &|scalar| pk.vk.domain.constant_lagrange(scalar, blinding_factors + 1),
                         &|index| {
                             let query = pk.vk.cs.fixed_queries[index];
                             let column_index = query.0.index();

--- a/src/plonk/lookup/verifier.rs
+++ b/src/plonk/lookup/verifier.rs
@@ -159,43 +159,43 @@ impl<C: CurveAffine> Evaluated<C> {
             ))
     }
 
-    pub(in crate::plonk) fn queries<'a>(
-        &'a self,
-        vk: &'a VerifyingKey<C>,
+    pub(in crate::plonk) fn queries<'r, 'params: 'r>(
+        &'r self,
+        vk: &'r VerifyingKey<C>,
         x: ChallengeX<C>,
-    ) -> impl Iterator<Item = VerifierQuery<'a, C>> + Clone {
+    ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone {
         let x_inv = vk.domain.rotate_omega(*x, Rotation(-1));
 
         iter::empty()
             // Open lookup product commitments at x
-            .chain(Some(VerifierQuery {
-                point: *x,
-                commitment: &self.committed.product_commitment,
-                eval: self.product_eval,
-            }))
+            .chain(Some(VerifierQuery::new_commitment(
+                &self.committed.product_commitment,
+                *x,
+                self.product_eval,
+            )))
             // Open lookup input commitments at x
-            .chain(Some(VerifierQuery {
-                point: *x,
-                commitment: &self.committed.permuted.permuted_input_commitment,
-                eval: self.permuted_input_eval,
-            }))
+            .chain(Some(VerifierQuery::new_commitment(
+                &self.committed.permuted.permuted_input_commitment,
+                *x,
+                self.permuted_input_eval,
+            )))
             // Open lookup table commitments at x
-            .chain(Some(VerifierQuery {
-                point: *x,
-                commitment: &self.committed.permuted.permuted_table_commitment,
-                eval: self.permuted_table_eval,
-            }))
+            .chain(Some(VerifierQuery::new_commitment(
+                &self.committed.permuted.permuted_table_commitment,
+                *x,
+                self.permuted_table_eval,
+            )))
             // Open lookup input commitments at \omega^{-1} x
-            .chain(Some(VerifierQuery {
-                point: x_inv,
-                commitment: &self.committed.permuted.permuted_input_commitment,
-                eval: self.permuted_input_inv_eval,
-            }))
+            .chain(Some(VerifierQuery::new_commitment(
+                &self.committed.permuted.permuted_input_commitment,
+                x_inv,
+                self.permuted_input_inv_eval,
+            )))
             // Open lookup product commitments at \omega^{-1} x
-            .chain(Some(VerifierQuery {
-                point: x_inv,
-                commitment: &self.committed.product_commitment,
-                eval: self.product_inv_eval,
-            }))
+            .chain(Some(VerifierQuery::new_commitment(
+                &self.committed.product_commitment,
+                x_inv,
+                self.product_inv_eval,
+            )))
     }
 }

--- a/src/plonk/permutation.rs
+++ b/src/plonk/permutation.rs
@@ -35,8 +35,8 @@ impl Argument {
         // l_0(X) * (1 - z(X)) = 0
         //
         // degree columns + 1
-        // z(X) \prod (p(X) + \beta s_i(X) + \gamma)
-        // - z(omega^{-1} X) \prod (p(X) + \delta^i \beta X + \gamma)
+        // z(omega X) \prod (p(X) + \beta s_i(X) + \gamma)
+        // - z(X) \prod (p(X) + \delta^i \beta X + \gamma)
         std::cmp::max(self.columns.len() + 1, 2)
     }
 

--- a/src/plonk/permutation.rs
+++ b/src/plonk/permutation.rs
@@ -34,10 +34,15 @@ impl Argument {
         // degree 2:
         // l_0(X) * (1 - z(X)) = 0
         //
-        // degree columns + 1
+        // degree 2:
+        // l_last(X) * (1 - z(X)) = 0
+        //
+        // degree columns + 2
+        // (1 - (l_cover(X) + l_last(X))) * (
         // z(omega X) \prod (p(X) + \beta s_i(X) + \gamma)
         // - z(X) \prod (p(X) + \delta^i \beta X + \gamma)
-        std::cmp::max(self.columns.len() + 1, 2)
+        // )
+        self.columns.len() + 2
     }
 
     pub(crate) fn get_columns(&self) -> Vec<Column<Any>> {

--- a/src/plonk/permutation/keygen.rs
+++ b/src/plonk/permutation/keygen.rs
@@ -145,7 +145,7 @@ impl Assembly {
         for i in 0..p.columns.len() {
             // Computes the permutation polynomial based on the permutation
             // description in the assembly.
-            let mut permutation_poly = domain.empty_lagrange();
+            let mut permutation_poly = domain.empty_lagrange(0);
             for (j, p) in permutation_poly.iter_mut().enumerate() {
                 let (permuted_i, permuted_j) = self.mapping[i][j];
                 *p = helper.deltaomega[permuted_i][permuted_j];
@@ -174,7 +174,7 @@ impl Assembly {
         for i in 0..p.columns.len() {
             // Computes the permutation polynomial based on the permutation
             // description in the assembly.
-            let mut permutation_poly = domain.empty_lagrange();
+            let mut permutation_poly = domain.empty_lagrange(0);
             for (j, p) in permutation_poly.iter_mut().enumerate() {
                 let (permuted_i, permuted_j) = self.mapping[i][j];
                 *p = helper.deltaomega[permuted_i][permuted_j];

--- a/src/plonk/permutation/prover.rs
+++ b/src/plonk/permutation/prover.rs
@@ -112,14 +112,16 @@ impl Argument {
 
         // Compute the evaluations of the permutation product polynomial
         // over our domain, starting with z[0] = 1
-        let mut z = vec![C::Scalar::one()];
+        let mut z_values = vec![C::Scalar::one()];
         for row in 1..(params.n as usize) {
-            let mut tmp = z[row - 1];
+            let mut tmp = z_values[row - 1];
 
             tmp *= &modified_values[row];
-            z.push(tmp);
+            z_values.push(tmp);
         }
-        let z = domain.lagrange_from_vec(z);
+        let mut z = domain.empty_lagrange(0);
+        z[..].copy_from_slice(&z_values[..]);
+        drop(z_values);
 
         let blind = Blind(C::Scalar::rand());
 

--- a/src/plonk/permutation/prover.rs
+++ b/src/plonk/permutation/prover.rs
@@ -18,7 +18,7 @@ use crate::{
 pub(crate) struct Committed<C: CurveAffine> {
     permutation_product_poly: Polynomial<C::Scalar, Coeff>,
     permutation_product_coset: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
-    permutation_product_coset_inv: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
+    permutation_product_coset_next: Polynomial<C::Scalar, ExtendedLagrangeCoeff>,
     permutation_product_blind: Blind<C::Scalar>,
 }
 
@@ -116,7 +116,7 @@ impl Argument {
         for row in 1..(params.n as usize) {
             let mut tmp = z_values[row - 1];
 
-            tmp *= &modified_values[row];
+            tmp *= &modified_values[row - 1];
             z_values.push(tmp);
         }
         let mut z = domain.empty_lagrange(0);
@@ -130,7 +130,7 @@ impl Argument {
         let z = domain.lagrange_to_coeff(z);
         let permutation_product_poly = z.clone();
         let permutation_product_coset = domain.coeff_to_extended(z.clone(), Rotation::cur());
-        let permutation_product_coset_inv = domain.coeff_to_extended(z, Rotation::prev());
+        let permutation_product_coset_next = domain.coeff_to_extended(z, Rotation::next());
 
         let permutation_product_commitment = permutation_product_commitment_projective.to_affine();
 
@@ -142,7 +142,7 @@ impl Argument {
         Ok(Committed {
             permutation_product_poly,
             permutation_product_coset,
-            permutation_product_coset_inv,
+            permutation_product_coset_next,
             permutation_product_blind,
         })
     }
@@ -169,9 +169,9 @@ impl<C: CurveAffine> Committed<C> {
             .chain(Some(
                 Polynomial::one_minus(self.permutation_product_coset.clone()) * &pk.l0,
             ))
-            // z(X) \prod (p(X) + \beta s_i(X) + \gamma) - z(omega^{-1} X) \prod (p(X) + \delta^i \beta X + \gamma)
+            // z(omega X) \prod (p(X) + \beta s_i(X) + \gamma) - z(X) \prod (p(X) + \delta^i \beta X + \gamma)
             .chain(Some({
-                let mut left = self.permutation_product_coset.clone();
+                let mut left = self.permutation_product_coset_next.clone();
                 for (values, permutation) in p
                     .columns
                     .iter()
@@ -199,7 +199,7 @@ impl<C: CurveAffine> Committed<C> {
                     });
                 }
 
-                let mut right = self.permutation_product_coset_inv.clone();
+                let mut right = self.permutation_product_coset.clone();
                 let mut current_delta = *beta * &C::Scalar::ZETA;
                 let step = domain.get_extended_omega();
                 for values in p.columns.iter().map(|&column| match column.column_type() {
@@ -266,9 +266,9 @@ impl<C: CurveAffine> Constructed<C> {
 
         let permutation_product_eval = eval_polynomial(&self.permutation_product_poly, *x);
 
-        let permutation_product_inv_eval = eval_polynomial(
+        let permutation_product_next_eval = eval_polynomial(
             &self.permutation_product_poly,
-            domain.rotate_omega(*x, Rotation(-1)),
+            domain.rotate_omega(*x, Rotation::next()),
         );
 
         let permutation_evals = pkey.evaluate(x);
@@ -276,7 +276,7 @@ impl<C: CurveAffine> Constructed<C> {
         // Hash permutation product evals
         for eval in iter::empty()
             .chain(Some(&permutation_product_eval))
-            .chain(Some(&permutation_product_inv_eval))
+            .chain(Some(&permutation_product_next_eval))
             .chain(permutation_evals.iter())
         {
             transcript
@@ -295,7 +295,7 @@ impl<C: CurveAffine> Evaluated<C> {
         pkey: &'a ProvingKey<C>,
         x: ChallengeX<C>,
     ) -> impl Iterator<Item = ProverQuery<'a, C>> + Clone {
-        let x_inv = pk.vk.domain.rotate_omega(*x, Rotation(-1));
+        let x_next = pk.vk.domain.rotate_omega(*x, Rotation::next());
 
         iter::empty()
             // Open permutation product commitments at x and \omega^{-1} x
@@ -305,7 +305,7 @@ impl<C: CurveAffine> Evaluated<C> {
                 blind: self.constructed.permutation_product_blind,
             }))
             .chain(Some(ProverQuery {
-                point: x_inv,
+                point: x_next,
                 poly: &self.constructed.permutation_product_poly,
                 blind: self.constructed.permutation_product_blind,
             }))

--- a/src/plonk/permutation/verifier.rs
+++ b/src/plonk/permutation/verifier.rs
@@ -124,35 +124,33 @@ impl<C: CurveAffine> Evaluated<C> {
             }))
     }
 
-    pub(in crate::plonk) fn queries<'a>(
-        &'a self,
-        vk: &'a plonk::VerifyingKey<C>,
-        vkey: &'a VerifyingKey<C>,
+    pub(in crate::plonk) fn queries<'r, 'params: 'r>(
+        &'r self,
+        vk: &'r plonk::VerifyingKey<C>,
+        vkey: &'r VerifyingKey<C>,
         x: ChallengeX<C>,
-    ) -> impl Iterator<Item = VerifierQuery<'a, C>> + Clone {
+    ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone {
         let x_inv = vk.domain.rotate_omega(*x, Rotation(-1));
 
         iter::empty()
             // Open permutation product commitments at x and \omega^{-1} x
-            .chain(Some(VerifierQuery {
-                point: *x,
-                commitment: &self.permutation_product_commitment,
-                eval: self.permutation_product_eval,
-            }))
-            .chain(Some(VerifierQuery {
-                point: x_inv,
-                commitment: &self.permutation_product_commitment,
-                eval: self.permutation_product_inv_eval,
-            }))
+            .chain(Some(VerifierQuery::new_commitment(
+                &self.permutation_product_commitment,
+                *x,
+                self.permutation_product_eval,
+            )))
+            .chain(Some(VerifierQuery::new_commitment(
+                &self.permutation_product_commitment,
+                x_inv,
+                self.permutation_product_inv_eval,
+            )))
             // Open permutation commitments for each permutation argument at x
             .chain(
                 vkey.commitments
                     .iter()
                     .zip(self.permutation_evals.iter())
-                    .map(move |(commitment, &eval)| VerifierQuery {
-                        point: *x,
-                        commitment,
-                        eval,
+                    .map(move |(commitment, &eval)| {
+                        VerifierQuery::new_commitment(commitment, *x, eval)
                     }),
             )
     }

--- a/src/plonk/permutation/verifier.rs
+++ b/src/plonk/permutation/verifier.rs
@@ -17,7 +17,7 @@ pub struct Committed<C: CurveAffine> {
 pub struct Evaluated<C: CurveAffine> {
     permutation_product_commitment: C,
     permutation_product_eval: C::Scalar,
-    permutation_product_inv_eval: C::Scalar,
+    permutation_product_next_eval: C::Scalar,
     permutation_evals: Vec<C::Scalar>,
 }
 
@@ -45,7 +45,7 @@ impl<C: CurveAffine> Committed<C> {
         let permutation_product_eval = transcript
             .read_scalar()
             .map_err(|_| Error::TranscriptError)?;
-        let permutation_product_inv_eval = transcript
+        let permutation_product_next_eval = transcript
             .read_scalar()
             .map_err(|_| Error::TranscriptError)?;
         let mut permutation_evals = Vec::with_capacity(vkey.commitments.len());
@@ -60,7 +60,7 @@ impl<C: CurveAffine> Committed<C> {
         Ok(Evaluated {
             permutation_product_commitment: self.permutation_product_commitment,
             permutation_product_eval,
-            permutation_product_inv_eval,
+            permutation_product_next_eval,
             permutation_evals,
         })
     }
@@ -84,10 +84,10 @@ impl<C: CurveAffine> Evaluated<C> {
             .chain(Some(
                 l_0 * &(C::Scalar::one() - &self.permutation_product_eval),
             ))
-            // z(X) \prod (p(X) + \beta s_i(X) + \gamma)
-            // - z(omega^{-1} X) \prod (p(X) + \delta^i \beta X + \gamma)
+            // z(omega X) \prod (p(X) + \beta s_i(X) + \gamma)
+            // - z(X) \prod (p(X) + \delta^i \beta X + \gamma)
             .chain(Some({
-                let mut left = self.permutation_product_eval;
+                let mut left = self.permutation_product_next_eval;
                 for (eval, permutation_eval) in p
                     .columns
                     .iter()
@@ -107,7 +107,7 @@ impl<C: CurveAffine> Evaluated<C> {
                     left *= &(eval + &(*beta * permutation_eval) + &*gamma);
                 }
 
-                let mut right = self.permutation_product_inv_eval;
+                let mut right = self.permutation_product_eval;
                 let mut current_delta = *beta * &*x;
                 for eval in p.columns.iter().map(|&column| match column.column_type() {
                     Any::Advice => advice_evals[vk.cs.get_any_query_index(column, Rotation::cur())],
@@ -130,10 +130,10 @@ impl<C: CurveAffine> Evaluated<C> {
         vkey: &'r VerifyingKey<C>,
         x: ChallengeX<C>,
     ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone {
-        let x_inv = vk.domain.rotate_omega(*x, Rotation(-1));
+        let x_next = vk.domain.rotate_omega(*x, Rotation::next());
 
         iter::empty()
-            // Open permutation product commitments at x and \omega^{-1} x
+            // Open permutation product commitments at x and \omega x
             .chain(Some(VerifierQuery::new_commitment(
                 &self.permutation_product_commitment,
                 *x,
@@ -141,8 +141,8 @@ impl<C: CurveAffine> Evaluated<C> {
             )))
             .chain(Some(VerifierQuery::new_commitment(
                 &self.permutation_product_commitment,
-                x_inv,
-                self.permutation_product_inv_eval,
+                x_next,
+                self.permutation_product_next_eval,
             )))
             // Open permutation commitments for each permutation argument at x
             .chain(

--- a/src/plonk/permutation/verifier.rs
+++ b/src/plonk/permutation/verifier.rs
@@ -75,6 +75,8 @@ impl<C: CurveAffine> Evaluated<C> {
         fixed_evals: &[C::Scalar],
         instance_evals: &'a [C::Scalar],
         l_0: C::Scalar,
+        l_last: C::Scalar,
+        l_cover: C::Scalar,
         beta: ChallengeBeta<C>,
         gamma: ChallengeGamma<C>,
         x: ChallengeX<C>,
@@ -84,8 +86,14 @@ impl<C: CurveAffine> Evaluated<C> {
             .chain(Some(
                 l_0 * &(C::Scalar::one() - &self.permutation_product_eval),
             ))
+            // l_last(X) * (1 - z(X)) = 0
+            .chain(Some(
+                l_last * &(C::Scalar::one() - &self.permutation_product_eval),
+            ))
+            // (1 - (l_cover(X) + l_last(X))) * (
             // z(omega X) \prod (p(X) + \beta s_i(X) + \gamma)
             // - z(X) \prod (p(X) + \delta^i \beta X + \gamma)
+            // )
             .chain(Some({
                 let mut left = self.permutation_product_next_eval;
                 for (eval, permutation_eval) in p
@@ -120,7 +128,7 @@ impl<C: CurveAffine> Evaluated<C> {
                     current_delta *= &C::Scalar::DELTA;
                 }
 
-                left - &right
+                (left - &right) * (C::Scalar::one() - (l_cover + l_last))
             }))
     }
 

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -67,10 +67,7 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
 
             let instance_polys: Vec<_> = instance
                 .iter()
-                .map(|poly| {
-                    let lagrange_vec = domain.lagrange_from_vec(poly.to_vec());
-                    domain.lagrange_to_coeff(lagrange_vec)
-                })
+                .map(|poly| domain.lagrange_to_coeff(poly.clone()))
                 .collect();
 
             let instance_cosets: Vec<_> = meta
@@ -183,7 +180,7 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
             }
 
             let mut witness = WitnessCollection {
-                advice: vec![domain.empty_lagrange(); meta.num_advice_columns],
+                advice: vec![domain.empty_lagrange(0); meta.num_advice_columns],
                 _marker: std::marker::PhantomData,
             };
 

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -390,6 +390,7 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
     let vanishing = vanishing::Argument::construct(params, domain, expressions, y, transcript)?;
 
     let x = ChallengeX::get(transcript);
+    let xn = x.pow(&[params.n as u64, 0, 0, 0]);
 
     // Compute and hash instance evals for each circuit instance
     for instance in instance.iter() {
@@ -451,7 +452,7 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
             .map_err(|_| Error::TranscriptError)?;
     }
 
-    let vanishing = vanishing.evaluate(x, transcript)?;
+    let vanishing = vanishing.evaluate(xn, domain);
 
     // Evaluate the permutations, if any, at omega^i x.
     let permutations: Vec<Vec<permutation::prover::Evaluated<C>>> = permutations

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -390,6 +390,7 @@ pub fn create_proof<C: CurveAffine, T: TranscriptWrite<C>, ConcreteCircuit: Circ
     // Construct the vanishing argument's h(X) commitments
     let vanishing = vanishing.construct(
         params,
+        pk,
         domain,
         gate_expressions,
         custom_expressions,

--- a/src/plonk/vanishing/prover.rs
+++ b/src/plonk/vanishing/prover.rs
@@ -1,8 +1,9 @@
+use ff::Field;
 use group::Curve;
 
 use super::Argument;
 use crate::{
-    arithmetic::{eval_polynomial, CurveAffine, FieldExt},
+    arithmetic::{CurveAffine, FieldExt},
     plonk::{ChallengeX, ChallengeY, Error},
     poly::{
         commitment::{Blind, Params},
@@ -18,7 +19,8 @@ pub(in crate::plonk) struct Constructed<C: CurveAffine> {
 }
 
 pub(in crate::plonk) struct Evaluated<C: CurveAffine> {
-    constructed: Constructed<C>,
+    h_poly: Polynomial<C::Scalar, Coeff>,
+    h_blind: Blind<C::Scalar>,
 }
 
 impl<C: CurveAffine> Argument<C> {
@@ -68,25 +70,26 @@ impl<C: CurveAffine> Argument<C> {
 }
 
 impl<C: CurveAffine> Constructed<C> {
-    pub(in crate::plonk) fn evaluate<T: TranscriptWrite<C>>(
+    pub(in crate::plonk) fn evaluate(
         self,
-        x: ChallengeX<C>,
-        transcript: &mut T,
-    ) -> Result<Evaluated<C>, Error> {
-        let h_evals: Vec<_> = self
+        xn: C::Scalar,
+        domain: &EvaluationDomain<C::Scalar>,
+    ) -> Evaluated<C> {
+        let h_poly = self
             .h_pieces
             .iter()
-            .map(|poly| eval_polynomial(poly, *x))
-            .collect();
+            .rev()
+            .fold(domain.empty_coeff(), |acc, eval| acc * xn + eval);
 
-        // Hash each advice evaluation
-        for eval in &h_evals {
-            transcript
-                .write_scalar(*eval)
-                .map_err(|_| Error::TranscriptError)?;
-        }
+        let h_blind = self
+            .h_blinds
+            .iter()
+            .rev()
+            .fold(Blind(C::Scalar::zero()), |acc, eval| {
+                acc * Blind(xn) + *eval
+            });
 
-        Ok(Evaluated { constructed: self })
+        Evaluated { h_poly, h_blind }
     }
 }
 
@@ -95,14 +98,11 @@ impl<C: CurveAffine> Evaluated<C> {
         &self,
         x: ChallengeX<C>,
     ) -> impl Iterator<Item = ProverQuery<'_, C>> + Clone {
-        self.constructed
-            .h_pieces
-            .iter()
-            .zip(self.constructed.h_blinds.iter())
-            .map(move |(h_poly, h_blind)| ProverQuery {
-                point: *x,
-                poly: h_poly,
-                blind: *h_blind,
-            })
+        Some(ProverQuery {
+            point: *x,
+            poly: &self.h_poly,
+            blind: self.h_blind,
+        })
+        .into_iter()
     }
 }

--- a/src/plonk/vanishing/prover.rs
+++ b/src/plonk/vanishing/prover.rs
@@ -1,9 +1,11 @@
+use std::iter;
+
 use ff::Field;
 use group::Curve;
 
 use super::Argument;
 use crate::{
-    arithmetic::{CurveAffine, FieldExt},
+    arithmetic::{eval_polynomial, CurveAffine, FieldExt},
     plonk::{ChallengeX, ChallengeY, Error},
     poly::{
         commitment::{Blind, Params},
@@ -13,18 +15,55 @@ use crate::{
     transcript::TranscriptWrite,
 };
 
+pub(in crate::plonk) struct Committed<C: CurveAffine> {
+    random_poly: Polynomial<C::Scalar, Coeff>,
+    random_blind: Blind<C::Scalar>,
+}
+
 pub(in crate::plonk) struct Constructed<C: CurveAffine> {
     h_pieces: Vec<Polynomial<C::Scalar, Coeff>>,
     h_blinds: Vec<Blind<C::Scalar>>,
+    random_poly: Polynomial<C::Scalar, Coeff>,
+    random_blind: Blind<C::Scalar>,
 }
 
 pub(in crate::plonk) struct Evaluated<C: CurveAffine> {
     h_poly: Polynomial<C::Scalar, Coeff>,
     h_blind: Blind<C::Scalar>,
+    random_poly: Polynomial<C::Scalar, Coeff>,
+    random_blind: Blind<C::Scalar>,
 }
 
 impl<C: CurveAffine> Argument<C> {
+    pub(in crate::plonk) fn commit<T: TranscriptWrite<C>>(
+        params: &Params<C>,
+        domain: &EvaluationDomain<C::Scalar>,
+        transcript: &mut T,
+    ) -> Result<Committed<C>, Error> {
+        // Sample a random polynomial of degree n - 1
+        let mut random_poly = domain.empty_coeff();
+        for coeff in random_poly.iter_mut() {
+            *coeff = C::Scalar::rand();
+        }
+        // Sample a random blinding factor
+        let random_blind = Blind(C::Scalar::rand());
+
+        // Commit
+        let c = params.commit(&random_poly, random_blind).to_affine();
+        transcript
+            .write_point(c)
+            .map_err(|_| Error::TranscriptError)?;
+
+        Ok(Committed {
+            random_poly,
+            random_blind,
+        })
+    }
+}
+
+impl<C: CurveAffine> Committed<C> {
     pub(in crate::plonk) fn construct<T: TranscriptWrite<C>>(
+        self,
         params: &Params<C>,
         domain: &EvaluationDomain<C::Scalar>,
         expressions: impl Iterator<Item = Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,
@@ -65,16 +104,23 @@ impl<C: CurveAffine> Argument<C> {
                 .map_err(|_| Error::TranscriptError)?;
         }
 
-        Ok(Constructed { h_pieces, h_blinds })
+        Ok(Constructed {
+            h_pieces,
+            h_blinds,
+            random_poly: self.random_poly,
+            random_blind: self.random_blind,
+        })
     }
 }
 
 impl<C: CurveAffine> Constructed<C> {
-    pub(in crate::plonk) fn evaluate(
+    pub(in crate::plonk) fn evaluate<T: TranscriptWrite<C>>(
         self,
+        x: ChallengeX<C>,
         xn: C::Scalar,
         domain: &EvaluationDomain<C::Scalar>,
-    ) -> Evaluated<C> {
+        transcript: &mut T,
+    ) -> Result<Evaluated<C>, Error> {
         let h_poly = self
             .h_pieces
             .iter()
@@ -89,7 +135,17 @@ impl<C: CurveAffine> Constructed<C> {
                 acc * Blind(xn) + *eval
             });
 
-        Evaluated { h_poly, h_blind }
+        let random_eval = eval_polynomial(&self.random_poly, *x);
+        transcript
+            .write_scalar(random_eval)
+            .map_err(|_| Error::TranscriptError)?;
+
+        Ok(Evaluated {
+            h_poly,
+            h_blind,
+            random_poly: self.random_poly,
+            random_blind: self.random_blind,
+        })
     }
 }
 
@@ -98,11 +154,16 @@ impl<C: CurveAffine> Evaluated<C> {
         &self,
         x: ChallengeX<C>,
     ) -> impl Iterator<Item = ProverQuery<'_, C>> + Clone {
-        Some(ProverQuery {
-            point: *x,
-            poly: &self.h_poly,
-            blind: self.h_blind,
-        })
-        .into_iter()
+        iter::empty()
+            .chain(Some(ProverQuery {
+                point: *x,
+                poly: &self.h_poly,
+                blind: self.h_blind,
+            }))
+            .chain(Some(ProverQuery {
+                point: *x,
+                poly: &self.random_poly,
+                blind: self.random_blind,
+            }))
     }
 }

--- a/src/plonk/vanishing/prover.rs
+++ b/src/plonk/vanishing/prover.rs
@@ -66,12 +66,14 @@ impl<C: CurveAffine> Committed<C> {
         self,
         params: &Params<C>,
         domain: &EvaluationDomain<C::Scalar>,
-        expressions: impl Iterator<Item = Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,
+        gate_expressions: impl Iterator<Item = Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,
+        custom_expressions: impl Iterator<Item = Polynomial<C::Scalar, ExtendedLagrangeCoeff>>,
         y: ChallengeY<C>,
         transcript: &mut T,
     ) -> Result<Constructed<C>, Error> {
         // Evaluate the h(X) polynomial's constraint system expressions for the constraints provided
-        let h_poly = expressions.fold(domain.empty_extended(), |h_poly, v| h_poly * *y + &v);
+        let h_poly = gate_expressions.fold(domain.empty_extended(), |h_poly, v| h_poly * *y + &v);
+        let h_poly = custom_expressions.fold(h_poly, |h_poly, v| h_poly * *y + &v);
 
         // Divide by t(X) = X^{params.n} - 1.
         let h_poly = domain.divide_by_vanishing_poly(h_poly);

--- a/src/plonk/vanishing/prover.rs
+++ b/src/plonk/vanishing/prover.rs
@@ -74,8 +74,8 @@ impl<C: CurveAffine> Committed<C> {
     ) -> Result<Constructed<C>, Error> {
         // Evaluate the h(X) polynomial's constraint system expressions for the constraints provided
         let h_poly = gate_expressions.fold(domain.empty_extended(), |h_poly, v| h_poly * *y + &v);
-        // All gates are multiplied by (1 - l_cover(X))
-        let h_poly = h_poly * &Polynomial::one_minus(pk.l_cover.clone());
+        // All gates are multiplied by (1 - (l_cover(X) + l_last(X)))
+        let h_poly = h_poly * &Polynomial::one_minus(pk.l_cover.clone() + &pk.l_last);
         let h_poly = custom_expressions.fold(h_poly, |h_poly, v| h_poly * *y + &v);
 
         // Divide by t(X) = X^{params.n} - 1.

--- a/src/plonk/vanishing/verifier.rs
+++ b/src/plonk/vanishing/verifier.rs
@@ -1,10 +1,11 @@
 use ff::Field;
+use group::{Curve, Group};
 
 use crate::{
     arithmetic::CurveAffine,
     plonk::{ChallengeX, ChallengeY, Error, VerifyingKey},
     poly::multiopen::VerifierQuery,
-    transcript::{read_n_points, read_n_scalars, TranscriptRead},
+    transcript::{read_n_points, TranscriptRead},
 };
 
 use super::Argument;
@@ -14,8 +15,8 @@ pub struct Committed<C: CurveAffine> {
 }
 
 pub struct Evaluated<C: CurveAffine> {
-    h_commitments: Vec<C>,
-    h_evals: Vec<C::Scalar>,
+    h_commitment: C,
+    expected_h_eval: C::Scalar,
 }
 
 impl<C: CurveAffine> Argument<C> {
@@ -32,55 +33,41 @@ impl<C: CurveAffine> Argument<C> {
 }
 
 impl<C: CurveAffine> Committed<C> {
-    pub(in crate::plonk) fn evaluate<T: TranscriptRead<C>>(
+    pub(in crate::plonk) fn verify(
         self,
-        transcript: &mut T,
+        expressions: impl Iterator<Item = C::Scalar>,
+        y: ChallengeY<C>,
+        xn: C::Scalar,
     ) -> Result<Evaluated<C>, Error> {
-        let h_evals = read_n_scalars(transcript, self.h_commitments.len())
-            .map_err(|_| Error::TranscriptError)?;
+        let expected_h_eval = expressions.fold(C::Scalar::zero(), |h_eval, v| h_eval * &*y + &v);
+        let expected_h_eval = expected_h_eval * ((xn - C::Scalar::one()).invert().unwrap());
+
+        let h_commitment = self
+            .h_commitments
+            .iter()
+            .rev()
+            .fold(C::CurveExt::identity(), |acc, eval| {
+                acc * xn + eval.to_curve()
+            })
+            .to_affine();
 
         Ok(Evaluated {
-            h_commitments: self.h_commitments,
-            h_evals,
+            expected_h_eval,
+            h_commitment,
         })
     }
 }
 
 impl<C: CurveAffine> Evaluated<C> {
-    pub(in crate::plonk) fn verify(
-        &self,
-        expressions: impl Iterator<Item = C::Scalar>,
-        y: ChallengeY<C>,
-        xn: C::Scalar,
-    ) -> Result<(), Error> {
-        let expected_h_eval = expressions.fold(C::Scalar::zero(), |h_eval, v| h_eval * &*y + &v);
-
-        // Compute h(x) from the prover
-        let h_eval = self
-            .h_evals
-            .iter()
-            .rev()
-            .fold(C::Scalar::zero(), |acc, eval| acc * &xn + eval);
-
-        // Did the prover commit to the correct polynomial?
-        if expected_h_eval != (h_eval * &(xn - &C::Scalar::one())) {
-            return Err(Error::ConstraintSystemFailure);
-        }
-
-        Ok(())
-    }
-
     pub(in crate::plonk) fn queries(
         &self,
         x: ChallengeX<C>,
     ) -> impl Iterator<Item = VerifierQuery<'_, C>> + Clone {
-        self.h_commitments
-            .iter()
-            .zip(self.h_evals.iter())
-            .map(move |(commitment, &eval)| VerifierQuery {
-                point: *x,
-                commitment,
-                eval,
-            })
+        Some(VerifierQuery {
+            point: *x,
+            commitment: &self.h_commitment,
+            eval: self.expected_h_eval,
+        })
+        .into_iter()
     }
 }

--- a/src/plonk/vanishing/verifier.rs
+++ b/src/plonk/vanishing/verifier.rs
@@ -1,10 +1,12 @@
 use ff::Field;
-use group::{Curve, Group};
 
 use crate::{
     arithmetic::CurveAffine,
     plonk::{ChallengeX, ChallengeY, Error, VerifyingKey},
-    poly::multiopen::VerifierQuery,
+    poly::{
+        commitment::{Params, MSM},
+        multiopen::VerifierQuery,
+    },
     transcript::{read_n_points, TranscriptRead},
 };
 
@@ -14,8 +16,8 @@ pub struct Committed<C: CurveAffine> {
     h_commitments: Vec<C>,
 }
 
-pub struct Evaluated<C: CurveAffine> {
-    h_commitment: C,
+pub struct Evaluated<'params, C: CurveAffine> {
+    h_commitment: MSM<'params, C>,
     expected_h_eval: C::Scalar,
 }
 
@@ -33,23 +35,25 @@ impl<C: CurveAffine> Argument<C> {
 }
 
 impl<C: CurveAffine> Committed<C> {
-    pub(in crate::plonk) fn verify(
+    pub(in crate::plonk) fn verify<'params>(
         self,
+        params: &'params Params<C>,
         expressions: impl Iterator<Item = C::Scalar>,
         y: ChallengeY<C>,
         xn: C::Scalar,
-    ) -> Result<Evaluated<C>, Error> {
+    ) -> Result<Evaluated<'params, C>, Error> {
         let expected_h_eval = expressions.fold(C::Scalar::zero(), |h_eval, v| h_eval * &*y + &v);
         let expected_h_eval = expected_h_eval * ((xn - C::Scalar::one()).invert().unwrap());
 
-        let h_commitment = self
-            .h_commitments
-            .iter()
-            .rev()
-            .fold(C::CurveExt::identity(), |acc, eval| {
-                acc * xn + eval.to_curve()
-            })
-            .to_affine();
+        let h_commitment =
+            self.h_commitments
+                .iter()
+                .rev()
+                .fold(params.empty_msm(), |mut acc, commitment| {
+                    acc.scale(xn);
+                    acc.append_term(C::Scalar::one(), *commitment);
+                    acc
+                });
 
         Ok(Evaluated {
             expected_h_eval,
@@ -58,16 +62,19 @@ impl<C: CurveAffine> Committed<C> {
     }
 }
 
-impl<C: CurveAffine> Evaluated<C> {
-    pub(in crate::plonk) fn queries(
-        &self,
+impl<'params, C: CurveAffine> Evaluated<'params, C> {
+    pub(in crate::plonk) fn queries<'r>(
+        &'r self,
         x: ChallengeX<C>,
-    ) -> impl Iterator<Item = VerifierQuery<'_, C>> + Clone {
-        Some(VerifierQuery {
-            point: *x,
-            commitment: &self.h_commitment,
-            eval: self.expected_h_eval,
-        })
+    ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone
+    where
+        'params: 'r,
+    {
+        Some(VerifierQuery::new_msm(
+            &self.h_commitment,
+            *x,
+            self.expected_h_eval,
+        ))
         .into_iter()
     }
 }

--- a/src/plonk/vanishing/verifier.rs
+++ b/src/plonk/vanishing/verifier.rs
@@ -35,13 +35,13 @@ impl<C: CurveAffine> Argument<C> {
 }
 
 impl<C: CurveAffine> Committed<C> {
-    pub(in crate::plonk) fn verify<'params>(
+    pub(in crate::plonk) fn verify(
         self,
-        params: &'params Params<C>,
+        params: &Params<C>,
         expressions: impl Iterator<Item = C::Scalar>,
         y: ChallengeY<C>,
         xn: C::Scalar,
-    ) -> Result<Evaluated<'params, C>, Error> {
+    ) -> Evaluated<C> {
         let expected_h_eval = expressions.fold(C::Scalar::zero(), |h_eval, v| h_eval * &*y + &v);
         let expected_h_eval = expected_h_eval * ((xn - C::Scalar::one()).invert().unwrap());
 
@@ -55,10 +55,10 @@ impl<C: CurveAffine> Committed<C> {
                     acc
                 });
 
-        Ok(Evaluated {
+        Evaluated {
             expected_h_eval,
             h_commitment,
-        })
+        }
     }
 }
 

--- a/src/plonk/vanishing/verifier.rs
+++ b/src/plonk/vanishing/verifier.rs
@@ -88,6 +88,7 @@ impl<C: CurveAffine> PartiallyEvaluated<C> {
     pub(in crate::plonk) fn verify(
         self,
         params: &Params<C>,
+        l_cover: C::Scalar,
         gate_expressions: impl Iterator<Item = C::Scalar>,
         custom_expressions: impl Iterator<Item = C::Scalar>,
         y: ChallengeY<C>,
@@ -95,6 +96,8 @@ impl<C: CurveAffine> PartiallyEvaluated<C> {
     ) -> Evaluated<C> {
         let expected_h_eval =
             gate_expressions.fold(C::Scalar::zero(), |h_eval, v| h_eval * &*y + &v);
+        // All gates are multiplied by (1 - l_cover(X))
+        let expected_h_eval = expected_h_eval * (C::Scalar::one() - l_cover);
         let expected_h_eval =
             custom_expressions.fold(expected_h_eval, |h_eval, v| h_eval * &*y + &v);
         let expected_h_eval = expected_h_eval * ((xn - C::Scalar::one()).invert().unwrap());

--- a/src/plonk/vanishing/verifier.rs
+++ b/src/plonk/vanishing/verifier.rs
@@ -89,6 +89,7 @@ impl<C: CurveAffine> PartiallyEvaluated<C> {
         self,
         params: &Params<C>,
         l_cover: C::Scalar,
+        l_last: C::Scalar,
         gate_expressions: impl Iterator<Item = C::Scalar>,
         custom_expressions: impl Iterator<Item = C::Scalar>,
         y: ChallengeY<C>,
@@ -96,8 +97,8 @@ impl<C: CurveAffine> PartiallyEvaluated<C> {
     ) -> Evaluated<C> {
         let expected_h_eval =
             gate_expressions.fold(C::Scalar::zero(), |h_eval, v| h_eval * &*y + &v);
-        // All gates are multiplied by (1 - l_cover(X))
-        let expected_h_eval = expected_h_eval * (C::Scalar::one() - l_cover);
+        // All gates are multiplied by (1 - (l_cover(X) + l_last(X)))
+        let expected_h_eval = expected_h_eval * (C::Scalar::one() - (l_cover + l_last));
         let expected_h_eval =
             custom_expressions.fold(expected_h_eval, |h_eval, v| h_eval * &*y + &v);
         let expected_h_eval = expected_h_eval * ((xn - C::Scalar::one()).invert().unwrap());

--- a/src/plonk/vanishing/verifier.rs
+++ b/src/plonk/vanishing/verifier.rs
@@ -88,11 +88,15 @@ impl<C: CurveAffine> PartiallyEvaluated<C> {
     pub(in crate::plonk) fn verify(
         self,
         params: &Params<C>,
-        expressions: impl Iterator<Item = C::Scalar>,
+        gate_expressions: impl Iterator<Item = C::Scalar>,
+        custom_expressions: impl Iterator<Item = C::Scalar>,
         y: ChallengeY<C>,
         xn: C::Scalar,
     ) -> Evaluated<C> {
-        let expected_h_eval = expressions.fold(C::Scalar::zero(), |h_eval, v| h_eval * &*y + &v);
+        let expected_h_eval =
+            gate_expressions.fold(C::Scalar::zero(), |h_eval, v| h_eval * &*y + &v);
+        let expected_h_eval =
+            custom_expressions.fold(expected_h_eval, |h_eval, v| h_eval * &*y + &v);
         let expected_h_eval = expected_h_eval * ((xn - C::Scalar::one()).invert().unwrap());
 
         let h_commitment =

--- a/src/plonk/vanishing/verifier.rs
+++ b/src/plonk/vanishing/verifier.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use ff::Field;
 
 use crate::{
@@ -13,28 +15,76 @@ use crate::{
 use super::Argument;
 
 pub struct Committed<C: CurveAffine> {
+    random_poly_commitment: C,
+}
+
+pub struct Constructed<C: CurveAffine> {
     h_commitments: Vec<C>,
+    random_poly_commitment: C,
+}
+
+pub struct PartiallyEvaluated<C: CurveAffine> {
+    h_commitments: Vec<C>,
+    random_poly_commitment: C,
+    random_eval: C::Scalar,
 }
 
 pub struct Evaluated<'params, C: CurveAffine> {
     h_commitment: MSM<'params, C>,
+    random_poly_commitment: C,
     expected_h_eval: C::Scalar,
+    random_eval: C::Scalar,
 }
 
 impl<C: CurveAffine> Argument<C> {
-    pub(in crate::plonk) fn read_commitments<T: TranscriptRead<C>>(
-        vk: &VerifyingKey<C>,
+    pub(in crate::plonk) fn read_commitments_before_y<T: TranscriptRead<C>>(
         transcript: &mut T,
     ) -> Result<Committed<C>, Error> {
-        // Obtain a commitment to h(X) in the form of multiple pieces of degree n - 1
-        let h_commitments = read_n_points(transcript, vk.domain.get_quotient_poly_degree())
+        let random_poly_commitment = transcript
+            .read_point()
             .map_err(|_| Error::TranscriptError)?;
 
-        Ok(Committed { h_commitments })
+        Ok(Committed {
+            random_poly_commitment,
+        })
     }
 }
 
 impl<C: CurveAffine> Committed<C> {
+    pub(in crate::plonk) fn read_commitments_after_y<T: TranscriptRead<C>>(
+        self,
+        vk: &VerifyingKey<C>,
+        transcript: &mut T,
+    ) -> Result<Constructed<C>, Error> {
+        // Obtain a commitment to h(X) in the form of multiple pieces of degree n - 1
+        let h_commitments = read_n_points(transcript, vk.domain.get_quotient_poly_degree())
+            .map_err(|_| Error::TranscriptError)?;
+
+        Ok(Constructed {
+            h_commitments,
+            random_poly_commitment: self.random_poly_commitment,
+        })
+    }
+}
+
+impl<C: CurveAffine> Constructed<C> {
+    pub(in crate::plonk) fn evaluate_after_x<T: TranscriptRead<C>>(
+        self,
+        transcript: &mut T,
+    ) -> Result<PartiallyEvaluated<C>, Error> {
+        let random_eval = transcript
+            .read_scalar()
+            .map_err(|_| Error::TranscriptError)?;
+
+        Ok(PartiallyEvaluated {
+            h_commitments: self.h_commitments,
+            random_poly_commitment: self.random_poly_commitment,
+            random_eval,
+        })
+    }
+}
+
+impl<C: CurveAffine> PartiallyEvaluated<C> {
     pub(in crate::plonk) fn verify(
         self,
         params: &Params<C>,
@@ -58,6 +108,8 @@ impl<C: CurveAffine> Committed<C> {
         Evaluated {
             expected_h_eval,
             h_commitment,
+            random_poly_commitment: self.random_poly_commitment,
+            random_eval: self.random_eval,
         }
     }
 }
@@ -70,11 +122,16 @@ impl<'params, C: CurveAffine> Evaluated<'params, C> {
     where
         'params: 'r,
     {
-        Some(VerifierQuery::new_msm(
-            &self.h_commitment,
-            *x,
-            self.expected_h_eval,
-        ))
-        .into_iter()
+        iter::empty()
+            .chain(Some(VerifierQuery::new_msm(
+                &self.h_commitment,
+                *x,
+                self.expected_h_eval,
+            )))
+            .chain(Some(VerifierQuery::new_commitment(
+                &self.random_poly_commitment,
+                *x,
+                self.random_eval,
+            )))
     }
 }

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -13,13 +13,13 @@ use crate::poly::{
 use crate::transcript::{read_n_points, read_n_scalars, TranscriptRead};
 
 /// Returns a boolean indicating whether or not the proof is valid
-pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
-    params: &'a Params<C>,
+pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
+    params: &'params Params<C>,
     vk: &VerifyingKey<C>,
-    msm: MSM<'a, C>,
+    msm: MSM<'params, C>,
     instance_commitments: &[&[C]],
     transcript: &mut T,
-) -> Result<Guard<'a, C>, Error> {
+) -> Result<Guard<'params, C>, Error> {
     // Check that instance_commitments matches the expected number of instance columns
     for instance_commitments in instance_commitments.iter() {
         if instance_commitments.len() != vk.cs.num_instance_columns {
@@ -215,7 +215,7 @@ pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
                 },
             );
 
-        vanishing.verify(expressions, y, xn)?
+        vanishing.verify(params, expressions, y, xn)?
     };
 
     let queries = instance_commitments
@@ -235,17 +235,21 @@ pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
             )| {
                 iter::empty()
                     .chain(vk.cs.instance_queries.iter().enumerate().map(
-                        move |(query_index, &(column, at))| VerifierQuery {
-                            point: vk.domain.rotate_omega(*x, at),
-                            commitment: &instance_commitments[column.index()],
-                            eval: instance_evals[query_index],
+                        move |(query_index, &(column, at))| {
+                            VerifierQuery::new_commitment(
+                                &instance_commitments[column.index()],
+                                vk.domain.rotate_omega(*x, at),
+                                instance_evals[query_index],
+                            )
                         },
                     ))
                     .chain(vk.cs.advice_queries.iter().enumerate().map(
-                        move |(query_index, &(column, at))| VerifierQuery {
-                            point: vk.domain.rotate_omega(*x, at),
-                            commitment: &advice_commitments[column.index()],
-                            eval: advice_evals[query_index],
+                        move |(query_index, &(column, at))| {
+                            VerifierQuery::new_commitment(
+                                &advice_commitments[column.index()],
+                                vk.domain.rotate_omega(*x, at),
+                                advice_evals[query_index],
+                            )
                         },
                     ))
                     .chain(
@@ -268,10 +272,12 @@ pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
                 .fixed_queries
                 .iter()
                 .enumerate()
-                .map(|(query_index, &(column, at))| VerifierQuery {
-                    point: vk.domain.rotate_omega(*x, at),
-                    commitment: &vk.fixed_commitments[column.index()],
-                    eval: fixed_evals[query_index],
+                .map(|(query_index, &(column, at))| {
+                    VerifierQuery::new_commitment(
+                        &vk.fixed_commitments[column.index()],
+                        vk.domain.rotate_omega(*x, at),
+                        fixed_evals[query_index],
+                    )
                 }),
         )
         .chain(vanishing.queries(x));

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -215,7 +215,7 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
                 },
             );
 
-        vanishing.verify(params, expressions, y, xn)?
+        vanishing.verify(params, expressions, y, xn)
     };
 
     let queries = instance_commitments

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -117,8 +117,6 @@ pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
     let fixed_evals = read_n_scalars(transcript, vk.cs.fixed_queries.len())
         .map_err(|_| Error::TranscriptError)?;
 
-    let vanishing = vanishing.evaluate(transcript)?;
-
     let permutations_evaluated = permutations_committed
         .into_iter()
         .map(|permutations| -> Result<Vec<_>, _> {
@@ -142,7 +140,7 @@ pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
 
     // This check ensures the circuit is satisfied so long as the polynomial
     // commitments open to the correct values.
-    {
+    let vanishing = {
         // x^n
         let xn = x.pow(&[params.n as u64, 0, 0, 0]);
 
@@ -217,8 +215,8 @@ pub fn verify_proof<'a, C: CurveAffine, T: TranscriptRead<C>>(
                 },
             );
 
-        vanishing.verify(expressions, y, xn)?;
-    }
+        vanishing.verify(expressions, y, xn)?
+    };
 
     let queries = instance_commitments
         .iter()

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -156,8 +156,7 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
         let l_last = l_evals[0];
         let l_cover: C::Scalar = l_evals[1..(1 + blinding_factors)]
             .iter()
-            .fold(C::Scalar::zero(), |acc, eval| acc + eval)
-            + l_last;
+            .fold(C::Scalar::zero(), |acc, eval| acc + eval);
         let l_0 = l_evals[1 + blinding_factors];
 
         // Compute the expected value of h(x)
@@ -227,7 +226,15 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
                 },
             );
 
-        vanishing.verify(params, l_cover, gate_expressions, custom_expressions, y, xn)
+        vanishing.verify(
+            params,
+            l_cover,
+            l_last,
+            gate_expressions,
+            custom_expressions,
+            y,
+            xn,
+        )
     };
 
     let queries = instance_commitments

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -90,10 +90,12 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
         })
         .collect::<Result<Vec<_>, _>>()?;
 
+    let vanishing = vanishing::Argument::read_commitments_before_y(transcript)?;
+
     // Sample y challenge, which keeps the gates linearly independent.
     let y = ChallengeY::get(transcript);
 
-    let vanishing = vanishing::Argument::read_commitments(vk, transcript)?;
+    let vanishing = vanishing.read_commitments_after_y(vk, transcript)?;
 
     // Sample x challenge, which is used to ensure the circuit is
     // satisfied with high probability.
@@ -115,6 +117,8 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
 
     let fixed_evals = read_n_scalars(transcript, vk.cs.fixed_queries.len())
         .map_err(|_| Error::TranscriptError)?;
+
+    let vanishing = vanishing.evaluate_after_x(transcript)?;
 
     let permutations_evaluated = permutations_committed
         .into_iter()

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -214,6 +214,8 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
                                 .flat_map(move |(p, argument)| {
                                     p.expressions(
                                         l_0,
+                                        l_last,
+                                        l_cover,
                                         argument,
                                         theta,
                                         beta,

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -154,10 +154,7 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
             .zip(lookups_evaluated.iter())
             .flat_map(
                 |(((advice_evals, instance_evals), permutations), lookups)| {
-                    let fixed_evals = fixed_evals.clone();
-                    let fixed_evals_copy = fixed_evals.clone();
-                    let fixed_evals_copy_copy = fixed_evals.clone();
-
+                    let fixed_evals = &fixed_evals;
                     std::iter::empty()
                         // Evaluate the circuit using the custom gates provided
                         .chain(vk.cs.gates.iter().map(move |(_, poly)| {
@@ -180,7 +177,7 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
                                         vk,
                                         argument,
                                         &advice_evals,
-                                        &fixed_evals_copy,
+                                        &fixed_evals,
                                         &instance_evals,
                                         l_0,
                                         beta,
@@ -202,7 +199,7 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
                                         beta,
                                         gamma,
                                         &advice_evals,
-                                        &fixed_evals_copy_copy,
+                                        &fixed_evals,
                                         &instance_evals,
                                     )
                                 })

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -198,6 +198,8 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
                                         &fixed_evals,
                                         &instance_evals,
                                         l_0,
+                                        l_last,
+                                        l_cover,
                                         beta,
                                         gamma,
                                         x,

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -1,4 +1,3 @@
-use ff::Field;
 use std::iter;
 
 use super::{
@@ -144,11 +143,8 @@ pub fn verify_proof<'params, C: CurveAffine, T: TranscriptRead<C>>(
         // x^n
         let xn = x.pow(&[params.n as u64, 0, 0, 0]);
 
-        // TODO: bubble this error up
         // l_0(x)
-        let l_0 = (*x - &C::Scalar::one()).invert().unwrap() // 1 / (x - 1)
-            * &(xn - &C::Scalar::one()) // (x^n - 1) / (x - 1)
-            * &vk.domain.get_barycentric_weight(); // l_0(x)
+        let l_0 = vk.domain.l_i_range(*x, xn, 0..=0)[0];
 
         // Compute the expected value of h(x)
         let expressions = advice_evals

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -140,8 +140,6 @@ impl<'a, F: Field, B: Basis> Add<&'a Polynomial<F, B>> for Polynomial<F, B> {
     type Output = Polynomial<F, B>;
 
     fn add(mut self, rhs: &'a Polynomial<F, B>) -> Polynomial<F, B> {
-        assert_eq!(self.active, self.values.len());
-        assert_eq!(rhs.active, rhs.values.len());
         parallelize(&mut self.values, |lhs, start| {
             for (lhs, rhs) in lhs.iter_mut().zip(rhs.values[start..].iter()) {
                 *lhs += *rhs;
@@ -156,8 +154,6 @@ impl<'a, F: Field, B: Basis> Sub<&'a Polynomial<F, B>> for Polynomial<F, B> {
     type Output = Polynomial<F, B>;
 
     fn sub(mut self, rhs: &'a Polynomial<F, B>) -> Polynomial<F, B> {
-        assert_eq!(self.active, self.values.len());
-        assert_eq!(rhs.active, rhs.values.len());
         parallelize(&mut self.values, |lhs, start| {
             for (lhs, rhs) in lhs.iter_mut().zip(rhs.values[start..].iter()) {
                 *lhs -= *rhs;
@@ -177,8 +173,6 @@ impl<'a, F: Field> Mul<&'a Polynomial<F, ExtendedLagrangeCoeff>>
         mut self,
         rhs: &'a Polynomial<F, ExtendedLagrangeCoeff>,
     ) -> Polynomial<F, ExtendedLagrangeCoeff> {
-        assert_eq!(self.active, self.values.len());
-        assert_eq!(rhs.active, rhs.values.len());
         parallelize(&mut self.values, |lhs, start| {
             for (lhs, rhs) in lhs.iter_mut().zip(rhs.values[start..].iter()) {
                 *lhs *= *rhs;
@@ -228,8 +222,6 @@ impl<'a, F: Field, B: Basis> Mul<F> for Polynomial<F, B> {
     type Output = Polynomial<F, B>;
 
     fn mul(mut self, rhs: F) -> Polynomial<F, B> {
-        assert_eq!(self.active, self.values.len());
-
         parallelize(&mut self.values, |lhs, _| {
             for lhs in lhs.iter_mut() {
                 *lhs *= rhs;

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -215,6 +215,13 @@ impl<'a, F: Field> Polynomial<F, LagrangeCoeff> {
     pub fn inactive_mut(&mut self) -> &mut [F] {
         &mut self.values[self.active..]
     }
+
+    /// Set all of the inactive coefficients to zero.
+    pub fn clear_inactive(&mut self) {
+        for e in &mut self.values[self.active..] {
+            *e = F::zero();
+        }
+    }
 }
 
 impl<'a, F: Field, B: Basis> Mul<F> for Polynomial<F, B> {

--- a/src/poly/commitment.rs
+++ b/src/poly/commitment.rs
@@ -121,7 +121,7 @@ impl<C: CurveAffine> Params<C> {
         let mut tmp_scalars = Vec::with_capacity(poly.len() + 1);
         let mut tmp_bases = Vec::with_capacity(poly.len() + 1);
 
-        tmp_scalars.extend(poly.iter());
+        tmp_scalars.extend(poly.values.iter());
         tmp_scalars.push(r.0);
 
         tmp_bases.extend(self.g.iter());
@@ -141,7 +141,7 @@ impl<C: CurveAffine> Params<C> {
         let mut tmp_scalars = Vec::with_capacity(poly.len() + 1);
         let mut tmp_bases = Vec::with_capacity(poly.len() + 1);
 
-        tmp_scalars.extend(poly.iter());
+        tmp_scalars.extend(poly.values.iter());
         tmp_scalars.push(r.0);
 
         tmp_bases.extend(self.g_lagrange.iter());

--- a/src/poly/commitment.rs
+++ b/src/poly/commitment.rs
@@ -259,7 +259,7 @@ fn test_commit_lagrange_epaffine() {
     let params = Params::<EpAffine>::new(K);
     let domain = super::EvaluationDomain::new(1, K);
 
-    let mut a = domain.empty_lagrange();
+    let mut a = domain.empty_lagrange(0);
 
     for (i, a) in a.iter_mut().enumerate() {
         *a = Fq::from(i as u64);
@@ -280,7 +280,7 @@ fn test_commit_lagrange_eqaffine() {
     let params = Params::<EqAffine>::new(K);
     let domain = super::EvaluationDomain::new(1, K);
 
-    let mut a = domain.empty_lagrange();
+    let mut a = domain.empty_lagrange(0);
 
     for (i, a) in a.iter_mut().enumerate() {
         *a = Fp::from(i as u64);

--- a/src/poly/domain.rs
+++ b/src/poly/domain.rs
@@ -372,18 +372,71 @@ impl<G: Group> EvaluationDomain<G> {
     pub fn rotate_omega(&self, value: G::Scalar, rotation: Rotation) -> G::Scalar {
         let mut point = value;
         if rotation.0 >= 0 {
-            point *= &self.get_omega().pow(&[rotation.0 as u64, 0, 0, 0]);
+            point *= &self.get_omega().pow_vartime(&[rotation.0 as u64]);
         } else {
             point *= &self
                 .get_omega_inv()
-                .pow(&[rotation.0.abs() as u64, 0, 0, 0]);
+                .pow_vartime(&[(rotation.0 as i64).abs() as u64]);
         }
         point
     }
 
-    /// Gets the barycentric weight of $1$ over the $2^k$ size domain.
-    pub fn get_barycentric_weight(&self) -> G::Scalar {
-        self.barycentric_weight
+    /// Computes evaluations (at the point `x`, where `xn = x^n`) of Lagrange
+    /// basis polynomials `l_i(X)` defined such that `l_i(omega^i) = 1` and
+    /// `l_i(omega^j) = 0` for all `j != i` at each provided rotation `i`.
+    pub fn l_i_range<I: IntoIterator<Item = i32> + Clone>(
+        &self,
+        x: G::Scalar,
+        xn: G::Scalar,
+        rotations: I,
+    ) -> Vec<G::Scalar> {
+        // The polynomial
+        // \prod_{j=0,j \neq i}^{n - 1} (X - omega^j)
+        // has a root at all points in the domain except omega^i, where it evaluates to
+        // \prod_{j=0,j \neq i}^{n - 1} (omega^i - omega^j)
+        // and so we divide that polynomial by this value to obtain l_i(X).
+        // Since \prod_{j=0,j \neq i}^{n - 1} (X - omega^j)
+        //       = (X^n - 1) / (X - omega^i)
+        // Then l_i(x) for some x is evaluated as
+        // ((x^n - 1) / (x - omega^i)) * (1 / \prod_{j=0,j \neq i}^{n - 1} (omega^i - omega^j))
+        // We refer to
+        // (1 / \prod_{j=0,j \neq i}^{n - 1} (omega^i - omega^j))
+        // as the barycentric weight of omega^i.
+        // We know that for i = 0
+        // (1 / \prod_{j=0,j \neq i}^{n - 1} (omega^i - omega^j))
+        // = (1 / n)
+        // If we multiply (1 / n) by (omega^{i})^-1 then we obtain
+        // (1 / \prod_{j=0,j \neq 0}^{n - 1} (omega^{i + 1} - omega^{j + 1}))
+        // = (1 / \prod_{j=0,j \neq -i}^{n - 1} (omega^i - omega^j))
+        // which is the barycentric weight of omega^{-i}
+
+        let mut results;
+        {
+            let rotations = rotations.clone().into_iter();
+            results = Vec::with_capacity(rotations.size_hint().1.unwrap_or(0));
+            for rotation in rotations {
+                let rotation = Rotation(rotation);
+                let result = x - self.rotate_omega(G::Scalar::one(), rotation);
+                results.push(result);
+            }
+            results.iter_mut().batch_invert();
+        }
+
+        let common = (xn - G::Scalar::one()) * self.barycentric_weight;
+        for (rotation, result) in rotations.into_iter().zip(results.iter_mut()) {
+            let rotation = Rotation(rotation);
+            *result *= common;
+
+            if rotation.0 >= 0 {
+                *result *= self.get_omega().pow_vartime(&[rotation.0 as u64]);
+            } else {
+                *result *= self
+                    .get_omega_inv()
+                    .pow_vartime(&[(rotation.0 as i64).abs() as u64]);
+            }
+        }
+
+        results
     }
 
     /// Gets the quotient polynomial's degree (as a multiple of n)
@@ -446,4 +499,32 @@ fn test_rotate() {
         eval_polynomial(&poly[..], x * domain.omega_inv),
         eval_polynomial(&poly_rotated_prev[..], x)
     );
+}
+
+#[test]
+fn test_l_i() {
+    use crate::arithmetic::{eval_polynomial, lagrange_interpolate};
+    use crate::pasta::pallas::Scalar;
+    let domain = EvaluationDomain::<Scalar>::new(1, 3);
+
+    let mut l = vec![];
+    let mut points = vec![];
+    for i in 0..8 {
+        points.push(domain.omega.pow(&[i, 0, 0, 0]));
+    }
+    for i in 0..8 {
+        let mut l_i = vec![Scalar::zero(); 8];
+        l_i[i] = Scalar::one();
+        let l_i = lagrange_interpolate(&points[..], &l_i[..]);
+        l.push(l_i);
+    }
+
+    let x = Scalar::rand();
+    let xn = x.pow(&[8, 0, 0, 0]);
+
+    let evaluations = domain.l_i_range(x, xn, -7..=7);
+    for i in 0..8 {
+        assert_eq!(eval_polynomial(&l[i][..], x), evaluations[7 + i]);
+        assert_eq!(eval_polynomial(&l[(8 - i) % 8][..], x), evaluations[7 - i]);
+    }
 }

--- a/src/poly/domain.rs
+++ b/src/poly/domain.rs
@@ -164,6 +164,7 @@ impl<G: Group> EvaluationDomain<G> {
     where
         G: FieldExt,
     {
+        assert!(inactive < (self.n as usize));
         let active = (self.n as usize) - inactive;
 
         let mut values = vec![G::group_zero(); self.n as usize];
@@ -179,10 +180,11 @@ impl<G: Group> EvaluationDomain<G> {
     }
 
     /// Returns a constant polynomial in the Lagrange coefficient basis
-    pub fn constant_lagrange(&self, scalar: G) -> Polynomial<G, LagrangeCoeff> {
+    pub fn constant_lagrange(&self, scalar: G, inactive: usize) -> Polynomial<G, LagrangeCoeff> {
+        assert!(inactive < (self.n as usize));
         Polynomial {
             values: vec![scalar; self.n as usize],
-            active: self.n as usize,
+            active: (self.n as usize) - inactive,
             _marker: PhantomData,
         }
     }

--- a/src/poly/multiopen.rs
+++ b/src/poly/multiopen.rs
@@ -51,13 +51,55 @@ pub struct ProverQuery<'a, C: CurveAffine> {
 
 /// A polynomial query at a point
 #[derive(Debug, Clone)]
-pub struct VerifierQuery<'a, C: CurveAffine> {
+pub struct VerifierQuery<'r, 'params: 'r, C: CurveAffine> {
     /// point at which polynomial is queried
-    pub point: C::Scalar,
+    point: C::Scalar,
     /// commitment to polynomial
-    pub commitment: &'a C,
+    commitment: CommitmentReference<'r, 'params, C>,
     /// evaluation of polynomial at query point
-    pub eval: C::Scalar,
+    eval: C::Scalar,
+}
+
+impl<'r, 'params: 'r, C: CurveAffine> VerifierQuery<'r, 'params, C> {
+    /// Create a new verifier query based on a commitment
+    pub fn new_commitment(commitment: &'r C, point: C::Scalar, eval: C::Scalar) -> Self {
+        VerifierQuery {
+            point,
+            eval,
+            commitment: CommitmentReference::Commitment(commitment),
+        }
+    }
+
+    /// Create a new verifier query based on a linear combination of commitments
+    pub fn new_msm(
+        msm: &'r commitment::MSM<'params, C>,
+        point: C::Scalar,
+        eval: C::Scalar,
+    ) -> Self {
+        VerifierQuery {
+            point,
+            eval,
+            commitment: CommitmentReference::MSM(msm),
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+enum CommitmentReference<'r, 'params: 'r, C: CurveAffine> {
+    Commitment(&'r C),
+    MSM(&'r commitment::MSM<'params, C>),
+}
+
+impl<'r, 'params: 'r, C: CurveAffine> PartialEq for CommitmentReference<'r, 'params, C> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (&CommitmentReference::Commitment(a), &CommitmentReference::Commitment(b)) => {
+                std::ptr::eq(a, b)
+            }
+            (&CommitmentReference::MSM(a), &CommitmentReference::MSM(b)) => std::ptr::eq(a, b),
+            _ => false,
+        }
+    }
 }
 
 struct CommitmentData<F, T: PartialEq> {
@@ -277,21 +319,9 @@ fn test_roundtrip() {
             &params,
             &mut transcript,
             std::iter::empty()
-                .chain(Some(VerifierQuery {
-                    point: x,
-                    commitment: &a,
-                    eval: avx,
-                }))
-                .chain(Some(VerifierQuery {
-                    point: x,
-                    commitment: &b,
-                    eval: avx, // NB: wrong!
-                }))
-                .chain(Some(VerifierQuery {
-                    point: y,
-                    commitment: &c,
-                    eval: cvy,
-                })),
+                .chain(Some(VerifierQuery::new_commitment(&a, x, avx)))
+                .chain(Some(VerifierQuery::new_commitment(&b, x, avx))) // NB: wrong!
+                .chain(Some(VerifierQuery::new_commitment(&c, y, cvy))),
             msm,
         )
         .unwrap();
@@ -310,21 +340,9 @@ fn test_roundtrip() {
             &params,
             &mut transcript,
             std::iter::empty()
-                .chain(Some(VerifierQuery {
-                    point: x,
-                    commitment: &a,
-                    eval: avx,
-                }))
-                .chain(Some(VerifierQuery {
-                    point: x,
-                    commitment: &b,
-                    eval: bvx,
-                }))
-                .chain(Some(VerifierQuery {
-                    point: y,
-                    commitment: &c,
-                    eval: cvy,
-                })),
+                .chain(Some(VerifierQuery::new_commitment(&a, x, avx)))
+                .chain(Some(VerifierQuery::new_commitment(&b, x, bvx)))
+                .chain(Some(VerifierQuery::new_commitment(&c, y, cvy))),
             msm,
         )
         .unwrap();

--- a/src/poly/multiopen/prover.rs
+++ b/src/poly/multiopen/prover.rs
@@ -75,6 +75,7 @@ where
             poly.resize(params.n as usize, C::Scalar::zero());
             let poly = Polynomial {
                 values: poly,
+                active: params.n as usize,
                 _marker: PhantomData,
             };
 

--- a/src/poly/multiopen/verifier.rs
+++ b/src/poly/multiopen/verifier.rs
@@ -5,8 +5,8 @@ use super::super::{
     Error,
 };
 use super::{
-    construct_intermediate_sets, ChallengeX1, ChallengeX2, ChallengeX3, ChallengeX4, Query,
-    VerifierQuery,
+    construct_intermediate_sets, ChallengeX1, ChallengeX2, ChallengeX3, ChallengeX4,
+    CommitmentReference, Query, VerifierQuery,
 };
 use crate::arithmetic::{eval_polynomial, lagrange_interpolate, CurveAffine, FieldExt};
 use crate::transcript::TranscriptRead;
@@ -18,14 +18,14 @@ struct CommitmentData<C: CurveAffine> {
 }
 
 /// Verify a multi-opening proof
-pub fn verify_proof<'b, 'a: 'b, I, C: CurveAffine, T: TranscriptRead<C>>(
-    params: &'a Params<C>,
+pub fn verify_proof<'r, 'params: 'r, I, C: CurveAffine, T: TranscriptRead<C>>(
+    params: &'params Params<C>,
     transcript: &mut T,
     queries: I,
-    mut msm: MSM<'a, C>,
-) -> Result<Guard<'a, C>, Error>
+    mut msm: MSM<'params, C>,
+) -> Result<Guard<'params, C>, Error>
 where
-    I: IntoIterator<Item = VerifierQuery<'b, C>> + Clone,
+    I: IntoIterator<Item = VerifierQuery<'r, 'params, C>> + Clone,
 {
     // Scale the MSM by a random factor to ensure that if the existing MSM
     // has is_zero() == false then this argument won't be able to interfere
@@ -54,7 +54,14 @@ where
     {
         let mut accumulate = |set_idx: usize, new_commitment, evals: Vec<C::Scalar>| {
             q_commitments[set_idx].scale(*x_1);
-            q_commitments[set_idx].append_term(C::Scalar::one(), new_commitment);
+            match new_commitment {
+                CommitmentReference::Commitment(c) => {
+                    q_commitments[set_idx].append_term(C::Scalar::one(), *c);
+                }
+                CommitmentReference::MSM(msm) => {
+                    q_commitments[set_idx].add_msm(msm);
+                }
+            }
             for (eval, set_eval) in evals.iter().zip(q_eval_sets[set_idx].iter_mut()) {
                 *set_eval *= &(*x_1);
                 *set_eval += eval;
@@ -65,9 +72,9 @@ where
         // For each set, we collapse each commitment's evals pointwise.
         for commitment_data in commitment_map.into_iter() {
             accumulate(
-                commitment_data.set_index,     // set_idx,
-                *commitment_data.commitment.0, // commitment,
-                commitment_data.evals,         // evals
+                commitment_data.set_index,  // set_idx,
+                commitment_data.commitment, // commitment,
+                commitment_data.evals,      // evals
             );
         }
     }
@@ -121,18 +128,8 @@ where
     super::commitment::verify_proof(params, msm, transcript, *x_3, msm_eval)
 }
 
-#[doc(hidden)]
-#[derive(Copy, Clone)]
-pub struct CommitmentPointer<'a, C>(&'a C);
-
-impl<'a, C> PartialEq for CommitmentPointer<'a, C> {
-    fn eq(&self, other: &Self) -> bool {
-        std::ptr::eq(self.0, other.0)
-    }
-}
-
-impl<'a, C: CurveAffine> Query<C::Scalar> for VerifierQuery<'a, C> {
-    type Commitment = CommitmentPointer<'a, C>;
+impl<'a, 'b, C: CurveAffine> Query<C::Scalar> for VerifierQuery<'a, 'b, C> {
+    type Commitment = CommitmentReference<'a, 'b, C>;
     type Eval = C::Scalar;
 
     fn get_point(&self) -> C::Scalar {
@@ -142,6 +139,6 @@ impl<'a, C: CurveAffine> Query<C::Scalar> for VerifierQuery<'a, C> {
         self.eval
     }
     fn get_commitment(&self) -> Self::Commitment {
-        CommitmentPointer(self.commitment)
+        self.commitment
     }
 }

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -281,8 +281,8 @@ fn plonk_api() {
             let b_ = meta.query_any(b.into(), Rotation::cur());
             let sl_ = meta.query_any(sl.into(), Rotation::cur());
             let sl2_ = meta.query_any(sl2.into(), Rotation::cur());
-            //meta.lookup(&[a_.clone()], &[sl_.clone()]);
-            //meta.lookup(&[a_ * b_], &[sl_ * sl2_]);
+            meta.lookup(&[a_.clone()], &[sl_.clone()]);
+            meta.lookup(&[a_ * b_], &[sl_ * sl2_]);
 
             meta.create_gate("Combined add-mult", |meta| {
                 let d = meta.query_advice(d, Rotation::next());
@@ -458,6 +458,7 @@ fn plonk_api() {
 
     // Check that the verification key has not changed unexpectedly
     {
+        // panic!("{:#?}", pk.get_vk().pinned());
         assert_eq!(
             format!("{:#?}", pk.get_vk().pinned()),
             r#####"PinnedVerificationKey {
@@ -465,7 +466,7 @@ fn plonk_api() {
     scalar_modulus: "0x40000000000000000000000000000000224698fc094cf91b992d30ed00000001",
     domain: PinnedEvaluationDomain {
         k: 5,
-        extended_k: 7,
+        extended_k: 8,
         omega: 0x0cc3380dc616f2e1daf29ad1560833ed3baea3393eceb7bc8fa36376929b78cc,
     },
     cs: PinnedConstraintSystem {
@@ -717,7 +718,42 @@ fn plonk_api() {
                 ],
             },
         ],
-        lookups: [],
+        lookups: [
+            Argument {
+                input_expressions: [
+                    Advice(
+                        0,
+                    ),
+                ],
+                table_expressions: [
+                    Fixed(
+                        0,
+                    ),
+                ],
+            },
+            Argument {
+                input_expressions: [
+                    Product(
+                        Advice(
+                            0,
+                        ),
+                        Advice(
+                            1,
+                        ),
+                    ),
+                ],
+                table_expressions: [
+                    Product(
+                        Fixed(
+                            0,
+                        ),
+                        Fixed(
+                            1,
+                        ),
+                    ),
+                ],
+            },
+        ],
     },
     fixed_commitments: [
         (0x046711bb0579a337420e33de9d54438e7c3a9cc47b6728b873d1fd0214d7eb58, 0x2416b30fadfacd828cf76891a2a5f0fe90d7ae0e5a8df947e98660ffbebf72e4),

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -403,7 +403,7 @@ fn plonk_api() {
             &params,
             &pk,
             &[circuit.clone(), circuit.clone()],
-            &[&[pubinputs.clone()], &[pubinputs.clone()]],
+            &[&[&[instance]], &[&[instance]]],
             &mut transcript,
         )
         .expect("proof generation should not fail");

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -281,8 +281,8 @@ fn plonk_api() {
             let b_ = meta.query_any(b.into(), Rotation::cur());
             let sl_ = meta.query_any(sl.into(), Rotation::cur());
             let sl2_ = meta.query_any(sl2.into(), Rotation::cur());
-            meta.lookup(&[a_.clone()], &[sl_.clone()]);
-            meta.lookup(&[a_ * b_], &[sl_ * sl2_]);
+            //meta.lookup(&[a_.clone()], &[sl_.clone()]);
+            //meta.lookup(&[a_ * b_], &[sl_ * sl2_]);
 
             meta.create_gate("Combined add-mult", |meta| {
                 let d = meta.query_advice(d, Rotation::next());
@@ -717,42 +717,7 @@ fn plonk_api() {
                 ],
             },
         ],
-        lookups: [
-            Argument {
-                input_expressions: [
-                    Advice(
-                        0,
-                    ),
-                ],
-                table_expressions: [
-                    Fixed(
-                        0,
-                    ),
-                ],
-            },
-            Argument {
-                input_expressions: [
-                    Product(
-                        Advice(
-                            0,
-                        ),
-                        Advice(
-                            1,
-                        ),
-                    ),
-                ],
-                table_expressions: [
-                    Product(
-                        Fixed(
-                            0,
-                        ),
-                        Fixed(
-                            1,
-                        ),
-                    ),
-                ],
-            },
-        ],
+        lookups: [],
     },
     fixed_commitments: [
         (0x046711bb0579a337420e33de9d54438e7c3a9cc47b6728b873d1fd0214d7eb58, 0x2416b30fadfacd828cf76891a2a5f0fe90d7ae0e5a8df947e98660ffbebf72e4),
@@ -767,16 +732,16 @@ fn plonk_api() {
     permutations: [
         VerifyingKey {
             commitments: [
-                (0x02d8dce08483e705f124b2e3db76a8065bfd8d893a1de76fd4ba586acb8e2cd0, 0x1456b7e28d96b5f90f885d21fde2ed00d1774cdebc358a95383b95302a87e09d),
-                (0x1d8a9751a63cbdf4c87787424b9c4a347483d5138943470dd1a73e1d1fd336b1, 0x2b1f6a54bff445799b6abf5bb0ed734d1cabdb46b4966556e753097ed87cef1b),
-                (0x1592b59a2a90b155420abde2bcf6fb822d80a11e1b44306dc07fc45025f214e5, 0x3802666ef284d7db51cbd2f9be20014e19f0f6a22e1a4d3a0db124b7bdd7fa1b),
+                (0x05360712179da3234af5603101f5255af539ba2ca95f146b9f50282ac09c1f32, 0x1364dece20ae5425d798dcb721d5d1afa54718e0571c4ff253ff792c3c97089a),
+                (0x25d47eafa58c801384aad6fd02c32dee03d7abe277b4cd8342330c52b411df9a, 0x21c9106c39e36cc057cce58e184bfab7d93ab415990bb06b6e7ab92aaa0478eb),
+                (0x0173bd68e141ad0e1e308e1a7cdea197dcc834e0ef0198771c269da45cc3a5e9, 0x3f8ae37634ac1202bb40d005ee58363dae9a6ab07d80268eea2ca05063912d9b),
             ],
         },
         VerifyingKey {
             commitments: [
-                (0x02d8dce08483e705f124b2e3db76a8065bfd8d893a1de76fd4ba586acb8e2cd0, 0x1456b7e28d96b5f90f885d21fde2ed00d1774cdebc358a95383b95302a87e09d),
-                (0x1d8a9751a63cbdf4c87787424b9c4a347483d5138943470dd1a73e1d1fd336b1, 0x2b1f6a54bff445799b6abf5bb0ed734d1cabdb46b4966556e753097ed87cef1b),
-                (0x1592b59a2a90b155420abde2bcf6fb822d80a11e1b44306dc07fc45025f214e5, 0x3802666ef284d7db51cbd2f9be20014e19f0f6a22e1a4d3a0db124b7bdd7fa1b),
+                (0x05360712179da3234af5603101f5255af539ba2ca95f146b9f50282ac09c1f32, 0x1364dece20ae5425d798dcb721d5d1afa54718e0571c4ff253ff792c3c97089a),
+                (0x25d47eafa58c801384aad6fd02c32dee03d7abe277b4cd8342330c52b411df9a, 0x21c9106c39e36cc057cce58e184bfab7d93ab415990bb06b6e7ab92aaa0478eb),
+                (0x0173bd68e141ad0e1e308e1a7cdea197dcc834e0ef0198771c269da45cc3a5e9, 0x3f8ae37634ac1202bb40d005ee58363dae9a6ab07d80268eea2ca05063912d9b),
             ],
         },
     ],

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -383,7 +383,7 @@ fn plonk_api() {
     let vk = keygen_vk(&params, &empty_circuit).expect("keygen_vk should not fail");
     let pk = keygen_pk(&params, vk, &empty_circuit).expect("keygen_pk should not fail");
 
-    let mut pubinputs = pk.get_vk().get_domain().empty_lagrange();
+    let mut pubinputs = pk.get_vk().get_domain().empty_lagrange(0);
     pubinputs[0] = instance;
     let pubinput = params
         .commit_lagrange(&pubinputs, Blind::default())


### PR DESCRIPTION
Closes #63

**Change 1:**

Currently, the prover commits to the "chunks" of `h(X)` by committing to `h_0(X), h_1(X), ..., h_d(X)` such that `h(X) = h_0(X) + x^n h_1(X) + ... + x^{dn} h_d(X)`. Then after `x` is sampled the prover commits to `h_0(x)` etc. The verifier checks that `h(x)` is as expected, and opens each of the commitments at `x` to check if the prover's committed evaluations are correct.

The problem is that `h_0(x), h_1(x), ..., h_d(x)` are not always uniformly distributed. It's not clear that blinding factors in the polynomial alone can resolve this.

The alternative is to compute a linear combination of the prover's commitments (with powers of `x^n`) and open that commitment. This is actually more efficient (smaller proofs) but the reason we were not doing this originally was because it's _not_ as efficient inside the recursive circuit; x^n is a large arbitrary scalar in the current protocol. We can find a simpler option another time though.

**Change 2:**

The prover will now always commit to a random polynomial that is opened at `x` along with `h(X)`. This ensures that during multiopen the verifier will not learn `h(x_3)`.

**Change 3:**

The `Polynomial` structure now is used to delineate between "active" evaluations (in Lagrange form, these are available cells) and "inactive" evaluations which consist of: 1 extra row that is sometimes used (in permutation/lookup argument) to store stuff, and the remaining rows are just blinding factors.

All of the prover's commitments have random blinding factors added.

**Change 4:**

In order to compensate for the fewer rows available, the permutation and lookup arguments are modified slightly. All of the custom (user) gates are disabled on the "inactive" rows.