### PR TITLE
Typos

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,6 @@
   - [Polynomials](background/polynomials.md)
   - [Cryptographic groups](background/groups.md)
   - [Elliptic curves](background/curves.md)
-  - [UltraPLONK arithmetisation](background/upa.md)
+  - [UltraPLONK arithmetization](background/upa.md)
   - [Polynomial commitment using inner product argument](background/pc-ipa.md)
   - [Recursion](background/recursion.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -3,7 +3,7 @@
 [halo2](README.md)
 - [Concepts](concepts.md)
   - [Proof systems](concepts/proofs.md)
-  - [UltraPLONK Arithmetization](concepts/arithmetization.md)
+  - [UltraPLONK arithmetization](concepts/arithmetization.md)
   - [Cores](concepts/cores.md)
   - [Chips](concepts/chips.md)
   - [Gadgets](concepts/gadgets.md)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -31,6 +31,6 @@
   - [Polynomials](background/polynomials.md)
   - [Cryptographic groups](background/groups.md)
   - [Elliptic curves](background/curves.md)
-  - [UltraPLONK arithmetization](background/upa.md)
+  - [UltraPLONK Arithmetization](background/upa.md)
   - [Polynomial commitment using inner product argument](background/pc-ipa.md)
   - [Recursion](background/recursion.md)

--- a/book/src/background/fields.md
+++ b/book/src/background/fields.md
@@ -3,8 +3,7 @@
 A fundamental component of many cryptographic protocols is the algebraic structure known
 as a [field]. Fields are sets of objects (usually numbers) with two associated binary
 operators $+$ and $\times$ such that various [field axioms][field-axioms] hold. The real
-numbers $\mathbb{R}$ are an example of a field with an uncountable number of
-elements.
+numbers $\mathbb{R}$ are an example of a field with uncountably many elements.
 
 [field]: https://en.wikipedia.org/wiki/Field_(mathematics)
 [field-axioms]: https://en.wikipedia.org/wiki/Field_(mathematics)#Classic_definition

--- a/book/src/background/fields.md
+++ b/book/src/background/fields.md
@@ -3,7 +3,7 @@
 A fundamental component of many cryptographic protocols is the algebraic structure known
 as a [field]. Fields are sets of objects (usually numbers) with two associated binary
 operators $+$ and $\times$ such that various [field axioms][field-axioms] hold. The real
-numbers $\mathbb{R}$ are an example of a field with an uncountably infinite number of
+numbers $\mathbb{R}$ are an example of a field with an uncountable number of
 elements.
 
 [field]: https://en.wikipedia.org/wiki/Field_(mathematics)

--- a/book/src/background/pc-ipa.md
+++ b/book/src/background/pc-ipa.md
@@ -40,7 +40,7 @@ intermediate rounds. (Refer to Section 3 in the [Halo] paper for a full explanat
 
 [Halo]: https://eprint.iacr.org/2019/1021.pdf
 
-Before beginning the argment, the verifier selects a random group element $U$ and sends it
+Before beginning the argument, the verifier selects a random group element $U$ and sends it
 to the prover. We initialise the argument at round $k,$ with the vectors
 $\mathbf{a}^{(k)} := \mathbf{a},$ $\mathbf{G}^{(k)} := \mathbf{G}$ and
 $\mathbf{b}^{(k)} := \mathbf{b}.$ In each round $j = k, k-1, \cdots, 1$:

--- a/book/src/background/pc-ipa.md
+++ b/book/src/background/pc-ipa.md
@@ -41,7 +41,7 @@ intermediate rounds. (Refer to Section 3 in the [Halo] paper for a full explanat
 [Halo]: https://eprint.iacr.org/2019/1021.pdf
 
 Before beginning the argument, the verifier selects a random group element $U$ and sends it
-to the prover. We initialise the argument at round $k,$ with the vectors
+to the prover. We initialize the argument at round $k,$ with the vectors
 $\mathbf{a}^{(k)} := \mathbf{a},$ $\mathbf{G}^{(k)} := \mathbf{G}$ and
 $\mathbf{b}^{(k)} := \mathbf{b}.$ In each round $j = k, k-1, \cdots, 1$:
 

--- a/book/src/background/upa.md
+++ b/book/src/background/upa.md
@@ -1,4 +1,4 @@
-# [WIP] UltraPLONK arithmetisation
+# [WIP] UltraPLONK arithmetization
 
 We call the field over which the circuit is defined $\mathbb{F} = \mathbb{F}_p$.
 

--- a/book/src/concepts/arithmetization.md
+++ b/book/src/concepts/arithmetization.md
@@ -1,4 +1,4 @@
-# UltraPLONK Arithmetization
+# UltraPLONK arithmetization
 
 The arithmetization used by Halo 2 comes from [PLONK](https://eprint.iacr.org/2019/953), or
 more precisely its extension UltraPLONK that supports custom gates and lookup arguments. We'll

--- a/book/src/design/gadgets/sha256/table16.md
+++ b/book/src/design/gadgets/sha256/table16.md
@@ -84,7 +84,7 @@ $Maj$ can be done in $4$ lookups: $2\; \mathtt{spread} * 2$ chunks
 > $2$.
 
 ### Ch function
-> TODO: can probably be optimised to $4$ or $5$ lookups using an additional table.
+> TODO: can probably be optimized to $4$ or $5$ lookups using an additional table.
 >
 $Ch$ can be done in $8$ lookups: $4\; \mathtt{spread} * 2$ chunks
 

--- a/book/src/design/proving-system/circuit-commitments.md
+++ b/book/src/design/proving-system/circuit-commitments.md
@@ -92,7 +92,7 @@ while keeping them independent. We can reuse $\beta$ and $\gamma$ from the equal
 constraint permutation here because they serve the same purpose in both places, and we
 aren't trying to combine the lookup and equality constraint permutation arguments. The
 important thing here is that the verifier samples $\beta$ and $\gamma$ after the prover
-has created $\mathbf{A}$, $\mathbf{F}$, and $\mathbf{L}$ (and thus commited to all the
+has created $\mathbf{A}$, $\mathbf{F}$, and $\mathbf{L}$ (and thus committed to all the
 cell values used in lookup columns, as well as $A'(X)$ and $S'(X)$ for each lookup).
 
 As before, the prover creates blinding commitments to each $Z_L$ polynomial:

--- a/book/src/design/proving-system/multipoint-opening.md
+++ b/book/src/design/proving-system/multipoint-opening.md
@@ -22,9 +22,9 @@ $$
 For each of these groups, we combine them into a polynomial set, and create a single $Q$
 for that set, which we open at each rotation.
 
-## Optimisation steps
+## Optimization steps
 
-The multipoint opening optimisation takes as input:
+The multipoint opening optimization takes as input:
 
 - A random $x$ sampled by the verifier, at which we evaluate $a(X), b(X), c(X), d(X)$.
 - Evaluations of each polynomial at each point of interest, provided by the prover:
@@ -32,7 +32,7 @@ The multipoint opening optimisation takes as input:
 
 These are the outputs of the [vanishing argument](vanishing.md#evaluating-the-polynomials).
 
-The multipoint opening optimisation proceeds as such:
+The multipoint opening optimization proceeds as such:
 
 1. Sample random $x_1$, to keep $a, b, c, d$ linearly independent.
 2. Accumulate polynomials and their corresponding evaluations according

--- a/book/src/design/proving-system/permutation.md
+++ b/book/src/design/proving-system/permutation.md
@@ -16,7 +16,7 @@ each cycle).
 
 We sometimes use [cycle notation](https://en.wikipedia.org/wiki/Permutation#Cycle_notation)
 to write permutations. Let $(a\ b\ c)$ denote a cycle where $a$ maps to $b$, $b$ maps to
-$c$, and $c$ maps to $a$ (with the obvious generalisation to arbitrary-sized cycles).
+$c$, and $c$ maps to $a$ (with the obvious generalization to arbitrary-sized cycles).
 Writing two or more cycles next to each other denotes a composition of the corresponding
 permutations. For example, $(a\ b)\ (c\ d)$ denotes the permutation that maps $a$ to $b$,
 $b$ to $a$, $c$ to $d$, and $d$ to $c$.


### PR DESCRIPTION
In some places, s was being used and in others z. This PR changes the spelling to be consistent and corrects a few typos. 

If the spelling change is not needed, I can cherry-pick these commits out.