### PR TITLE
examples: Add cost model

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,6 @@ publish = false
 all-features = true
 rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 
-[dev-dependencies]
-criterion = "0.3"
-
 [[bench]]
 name = "arithmetic"
 harness = false
@@ -57,6 +54,10 @@ tabbycat = { version = "0.1", features = ["attributes"], optional = true }
 [dependencies.pasta_curves]
 git = "https://github.com/zcash/pasta_curves.git"
 rev = "b55a6960dfafd7f767e2820ddf1adaa499322f98"
+
+[dev-dependencies]
+criterion = "0.3"
+gumdrop = "0.8"
 
 [features]
 dev-graph = ["plotters", "tabbycat"]

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -8,6 +8,7 @@
   - [Chips](concepts/chips.md)
   - [Gadgets](concepts/gadgets.md)
 - [User Documentation](user.md)
+  - [Developer tools](user/dev-tools.md)
   - [A simple example](user/simple-example.md)
   - [Lookup tables](user/lookup-tables.md)
   - [Gadgets](user/gadgets.md)

--- a/book/src/user/dev-tools.md
+++ b/book/src/user/dev-tools.md
@@ -1,0 +1,80 @@
+# Developer tools
+
+The `halo2` crate includes several utilities to help you design and implement your
+circuits.
+
+## Mock prover
+
+`halo2::dev::MockProver` is a tool for debugging circuits, as well as cheaply verifying
+their correctness in unit tests. The private and public inputs to the circuit are
+constructed as would normally be done to create a proof, but `MockProver::run` instead
+creates an object that will test every constraint in the circuit directly. It returns
+granular error messages that indicate which specific constraint (if any) is not satisfied.
+
+## Circuit visualizations
+
+The `dev-graph` feature flag exposes several helper methods for creating graphical
+representations of circuits.
+
+`halo2::dev::circuit_layout` renders the circuit layout as a grid:
+
+- Columns are layed out from left to right as advice, instance, and fixed. The order of
+  columns is otherwise without meaning.
+  - Advice columns have a red background.
+  - Instance columns have a white background.
+  - Fixed columns have a blue background.
+- Regions are shown as labelled green boxes (overlaying the background colour). A region
+  may appear as multiple boxes if some of its columns happen to not be adjacent.
+- Cells that have been assigned to by the circuit will be shaded in grey. If any cells are
+  assigned to more than once (which is usually a mistake), they will be shaded darker than
+  the surrounding cells.
+
+`halo2::dev::circuit_dot_graph` builds a [DOT graph string] representing the given
+circuit, which can then be rendered witha variety of [layout programs]. The graph is built
+from calls to `Layouter::namespace` both within the circuit, and inside the gadgets and
+chips that it uses.
+
+[DOT graph string]: https://graphviz.org/doc/info/lang.html
+[layout programs]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)#Layout_programs
+
+## Cost estimator
+
+The `cost-model` binary takes high-level parameters for a circuit design, and estimates
+the verification cost, as well as resulting proof size.
+
+```
+Usage: cargo run --example cost-model -- [OPTIONS] k
+
+Positional arguments:
+  k                       2^K bound on the number of rows.
+
+Optional arguments:
+  -h, --help              Print this message.
+  -a, --advice R[,R..]    An advice column with the given rotations. May be repeated.
+  -i, --instance R[,R..]  An instance column with the given rotations. May be repeated.
+  -f, --fixed R[,R..]     A fixed column with the given rotations. May be repeated.
+  -g, --gate-degree D     Maximum degree of the custom gates.
+  -l, --lookup N,I,T      A lookup over N columns with max input degree I and max table degree T. May be repeated.
+  -p, --permutation N     A permutation over N columns. May be repeated.
+```
+
+For example, to estimate the cost of a circuit with three advice columns and one fixed
+column (with various rotations), and a maximum gate degree of 4:
+
+```shell
+$ cargo run --example cost-model -- -a 0,1 -a 0 -a-0,-1,1 -f 0 -g 4 11
+    Finished dev [unoptimized + debuginfo] target(s) in 0.03s
+     Running `target/debug/examples/cost-model -a 0,1 -a 0 -a 0,-1,1 -f 0 -g 4 11`
+Circuit {
+    k: 11,
+    max_deg: 4,
+    advice_columns: 3,
+    lookups: 0,
+    permutations: [],
+    column_queries: 7,
+    point_sets: 3,
+    estimator: Estimator,
+}
+Proof size: 1440 bytes
+Verification: at least 81.689ms
+```

--- a/examples/cost-model.rs
+++ b/examples/cost-model.rs
@@ -1,0 +1,234 @@
+use std::{cmp, iter, num::ParseIntError, str::FromStr};
+
+use gumdrop::Options;
+
+#[derive(Debug, Options)]
+struct CostOptions {
+    #[options(help = "Print this message.")]
+    help: bool,
+
+    #[options(
+        help = "An advice column with the given rotations. May be repeated.",
+        meta = "R[,R..]"
+    )]
+    advice: Vec<Poly>,
+
+    #[options(
+        help = "An instance column with the given rotations. May be repeated.",
+        meta = "R[,R..]"
+    )]
+    instance: Vec<Poly>,
+
+    #[options(
+        help = "A fixed column with the given rotations. May be repeated.",
+        meta = "R[,R..]"
+    )]
+    fixed: Vec<Poly>,
+
+    #[options(help = "Maximum degree of the custom gates.", meta = "D")]
+    gate_degree: usize,
+
+    #[options(
+        help = "A lookup over N columns with max input degree I and max table degree T. May be repeated.",
+        meta = "N,I,T"
+    )]
+    lookup: Vec<Lookup>,
+
+    #[options(help = "A permutation over N columns. May be repeated.", meta = "N")]
+    permutation: Vec<Permutation>,
+
+    #[options(free, required, help = "2^K bound on the number of rows.")]
+    k: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct Poly {
+    rotations: Vec<isize>,
+}
+
+impl FromStr for Poly {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut rotations: Vec<isize> =
+            s.split(',').map(|r| r.parse()).collect::<Result<_, _>>()?;
+        rotations.sort_unstable();
+        Ok(Poly { rotations })
+    }
+}
+
+#[derive(Debug)]
+struct Lookup {
+    columns: usize,
+    input_deg: usize,
+    table_deg: usize,
+}
+
+impl FromStr for Lookup {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let mut parts = s.split(',');
+        let columns = parts.next().unwrap().parse()?;
+        let input_deg = parts.next().unwrap().parse()?;
+        let table_deg = parts.next().unwrap().parse()?;
+        Ok(Lookup {
+            columns,
+            input_deg,
+            table_deg,
+        })
+    }
+}
+
+impl Lookup {
+    fn required_degree(&self) -> usize {
+        1 + cmp::max(1, self.input_deg) + cmp::max(1, self.table_deg)
+    }
+
+    fn queries(&self) -> impl Iterator<Item = Poly> {
+        // - product commitments at x and x_inv
+        // - input commitments at x and x_inv
+        // - table commitments at x
+        let product = "0,-1".parse().unwrap();
+        let input = "0,-1".parse().unwrap();
+        let table = "0".parse().unwrap();
+
+        iter::empty()
+            .chain(Some(product))
+            .chain(Some(input))
+            .chain(Some(table))
+    }
+}
+
+#[derive(Debug)]
+struct Permutation {
+    columns: usize,
+}
+
+impl FromStr for Permutation {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(Permutation {
+            columns: s.parse()?,
+        })
+    }
+}
+
+impl Permutation {
+    fn required_degree(&self) -> usize {
+        cmp::max(self.columns + 1, 2)
+    }
+
+    fn queries(&self) -> impl Iterator<Item = Poly> {
+        // - product commitments at x and x_inv
+        // - polynomial commitments at x
+        let product = "0,-1".parse().unwrap();
+        let poly = "0".parse().unwrap();
+
+        iter::empty()
+            .chain(Some(product))
+            .chain(iter::repeat(poly).take(self.columns))
+    }
+}
+
+#[derive(Debug)]
+struct Circuit {
+    /// Power-of-2 bound on the number of rows in the circuit.
+    k: usize,
+    /// Maximum degree of the circuit.
+    max_deg: usize,
+    /// Number of advice columns.
+    advice_columns: usize,
+    /// Number of lookup arguments.
+    lookups: usize,
+    /// Equality constraint permutation arguments.
+    permutations: Vec<Permutation>,
+    /// Number of distinct column queries across all gates.
+    column_queries: usize,
+    /// Number of distinct sets of points in the multiopening argument.
+    point_sets: usize,
+}
+
+impl From<CostOptions> for Circuit {
+    fn from(opts: CostOptions) -> Self {
+        let max_deg = [1, opts.gate_degree]
+            .iter()
+            .cloned()
+            .chain(opts.lookup.iter().map(|l| l.required_degree()))
+            .chain(opts.permutation.iter().map(|p| p.required_degree()))
+            .max()
+            .unwrap();
+
+        let mut queries: Vec<_> = iter::empty()
+            .chain(opts.advice.iter())
+            .chain(opts.instance.iter())
+            .chain(opts.fixed.iter())
+            .cloned()
+            .chain(opts.lookup.iter().map(|l| l.queries()).flatten())
+            .chain(opts.permutation.iter().map(|p| p.queries()).flatten())
+            .chain(iter::repeat("0".parse().unwrap()).take(max_deg - 1))
+            .collect();
+
+        let column_queries = queries.len();
+        queries.sort_unstable();
+        queries.dedup();
+        let point_sets = queries.len();
+
+        Circuit {
+            k: opts.k,
+            max_deg,
+            advice_columns: opts.advice.len(),
+            lookups: opts.lookup.len(),
+            permutations: opts.permutation,
+            column_queries,
+            point_sets,
+        }
+    }
+}
+
+impl Circuit {
+    fn proof_size(&self) -> usize {
+        let size = |points: usize, scalars: usize| points * 32 + scalars * 32;
+
+        // PLONK:
+        // - 32 bytes (commitment) per advice column
+        // - 3 * 32 bytes (commitments) + 5 * 32 bytes (evals) per lookup argument
+        // - 32 bytes (commitment) + 2 * 32 bytes (evals) per permutation argument
+        // - 32 bytes (eval) per column per permutation argument
+        let plonk = size(1, 0) * self.advice_columns
+            + size(3, 5) * self.lookups
+            + self
+                .permutations
+                .iter()
+                .map(|p| size(1, 2 + p.columns))
+                .sum::<usize>();
+
+        // Vanishing argument:
+        // - (max_deg - 1) * 32 bytes (commitments) + (max_deg - 1) * 32 bytes (h_evals)
+        //   for quotient polynomial
+        // - 32 bytes (eval) per column query
+        let vanishing = size(self.max_deg - 1, self.max_deg - 1) + size(0, self.column_queries);
+
+        // Multiopening argument:
+        // - f_commitment (32 bytes)
+        // - 32 bytes (evals) per set of points in multiopen argument
+        let multiopen = size(1, self.point_sets);
+
+        // Polycommit:
+        // - s_poly commitment (32 bytes)
+        // - inner product argument (k rounds * 2 * 32 bytes)
+        // - a (32 bytes)
+        // - xi (32 bytes)
+        let polycomm = size(1 + 2 * self.k, 2);
+
+        plonk + vanishing + multiopen + polycomm
+    }
+}
+
+fn main() {
+    let opts = CostOptions::parse_args_default_or_exit();
+    let c = Circuit::from(opts);
+    println!("{:#?}", c);
+    println!("Proof size: {} bytes", c.proof_size());
+}


### PR DESCRIPTION
Usage: `cargo run --example cost-model -- --help`

Closes #47.