### PR TITLE
[MockProver] Handle query rotations in lookups

### DIFF
--- a/src/dev.rs
+++ b/src/dev.rs
@@ -339,21 +339,21 @@ impl<F: FieldExt> MockProver<F> {
                         &|index| {
                             let query = self.cs.fixed_queries[index];
                             let column_index = query.0.index();
-                            let rotation = query.1 .0;
+                            let rotation = query.1.0;
                             self.fixed[column_index]
                                 [(row as i32 + n + rotation) as usize % n as usize]
                         },
                         &|index| {
                             let query = self.cs.advice_queries[index];
                             let column_index = query.0.index();
-                            let rotation = query.1 .0;
+                            let rotation = query.1.0;
                             self.advice[column_index]
                                 [(row as i32 + n + rotation) as usize % n as usize]
                         },
                         &|index| {
                             let query = self.cs.instance_queries[index];
                             let column_index = query.0.index();
-                            let rotation = query.1 .0;
+                            let rotation = query.1.0;
                             self.instance[column_index]
                                 [(row as i32 + n + rotation) as usize % n as usize]
                         },

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -337,16 +337,25 @@ impl<F: FieldExt> MockProver<F> {
                     expression.evaluate(
                         &|scalar| scalar,
                         &|index| {
-                            let column_index = self.cs.fixed_queries[index].0.index();
-                            self.fixed[column_index][row as usize]
+                            let query = self.cs.fixed_queries[index];
+                            let column_index = query.0.index();
+                            let rotation = query.1 .0;
+                            self.fixed[column_index]
+                                [(row as i32 + n + rotation) as usize % n as usize]
                         },
                         &|index| {
-                            let column_index = self.cs.advice_queries[index].0.index();
-                            self.advice[column_index][row as usize]
+                            let query = self.cs.advice_queries[index];
+                            let column_index = query.0.index();
+                            let rotation = query.1 .0;
+                            self.advice[column_index]
+                                [(row as i32 + n + rotation) as usize % n as usize]
                         },
                         &|index| {
-                            let column_index = self.cs.instance_queries[index].0.index();
-                            self.instance[column_index][row as usize]
+                            let query = self.cs.instance_queries[index];
+                            let column_index = query.0.index();
+                            let rotation = query.1 .0;
+                            self.instance[column_index]
+                                [(row as i32 + n + rotation) as usize % n as usize]
                         },
                         &|a, b| a + b,
                         &|a, b| a * b,


### PR DESCRIPTION
The `MockProver` should handle query rotations for lookups, like the real prover does (https://github.com/zcash/halo2/blob/main/src/plonk/lookup/prover.rs#L100)