### PR TITLE
Fix sha-256 example to use new `create_gate()` API

### DIFF
--- a/examples/sha256/main.rs
+++ b/examples/sha256/main.rs
@@ -2,7 +2,6 @@
 //!
 //! [SHA-256]: https://tools.ietf.org/html/rfc6234
 
-/*
 use std::cmp::min;
 use std::convert::TryInto;
 use std::fmt;
@@ -169,6 +168,5 @@ impl<F: FieldExt, Sha256Chip: Sha256Instructions<F>> Sha256<F, Sha256Chip> {
         hasher.finalize(layouter.namespace(|| "finalize"))
     }
 }
-*/
 
 fn main() {}

--- a/examples/sha256/table16.rs
+++ b/examples/sha256/table16.rs
@@ -14,7 +14,6 @@ mod spread_table;
 mod util;
 
 use compression::*;
-use gates::*;
 use message_schedule::*;
 use spread_table::*;
 

--- a/examples/sha256/table16/compression.rs
+++ b/examples/sha256/table16/compression.rs
@@ -15,7 +15,7 @@ mod subregion_digest;
 mod subregion_initial;
 mod subregion_main;
 
-use compression_gates::CompressionGate;
+use compression_gates as gate;
 
 /// A variable that represents the `[A,B,C,D]` words of the SHA-256 internal state.
 ///
@@ -318,7 +318,7 @@ impl CompressionConfig {
             let word_hi = meta.query_advice(a_7, Rotation::next());
             let spread_word_hi = meta.query_advice(a_8, Rotation::next());
 
-            CompressionGate::s_decompose_abcd(
+            gate::s_decompose_abcd(
                 s_decompose_abcd,
                 a,
                 spread_a,
@@ -339,7 +339,6 @@ impl CompressionConfig {
                 word_hi,
                 spread_word_hi,
             )
-            .0
         });
 
         // Decompose `E,F,G,H` words into (6, 5, 14, 7)-bit chunks.
@@ -366,7 +365,7 @@ impl CompressionConfig {
             let word_hi = meta.query_advice(a_7, Rotation::next());
             let spread_word_hi = meta.query_advice(a_8, Rotation::next());
 
-            CompressionGate::s_decompose_efgh(
+            gate::s_decompose_efgh(
                 s_decompose_efgh,
                 a_lo,
                 spread_a_lo,
@@ -387,7 +386,6 @@ impl CompressionConfig {
                 word_hi,
                 spread_word_hi,
             )
-            .0
         });
 
         // s_upper_sigma_0 on abcd words
@@ -406,7 +404,7 @@ impl CompressionConfig {
             let spread_c_hi = meta.query_advice(a_4, Rotation::next());
             let spread_d = meta.query_advice(a_4, Rotation::cur());
 
-            CompressionGate::s_upper_sigma_0(
+            gate::s_upper_sigma_0(
                 s_upper_sigma_0,
                 spread_r0_even,
                 spread_r0_odd,
@@ -419,7 +417,6 @@ impl CompressionConfig {
                 spread_c_hi,
                 spread_d,
             )
-            .0
         });
 
         // s_upper_sigma_1 on efgh words
@@ -437,7 +434,7 @@ impl CompressionConfig {
             let spread_c = meta.query_advice(a_5, Rotation::cur());
             let spread_d = meta.query_advice(a_4, Rotation::cur());
 
-            CompressionGate::s_upper_sigma_1(
+            gate::s_upper_sigma_1(
                 s_upper_sigma_1,
                 spread_r0_even,
                 spread_r0_odd,
@@ -450,7 +447,6 @@ impl CompressionConfig {
                 spread_c,
                 spread_d,
             )
-            .0
         });
 
         // s_ch on efgh words
@@ -466,7 +462,7 @@ impl CompressionConfig {
             let spread_f_lo = meta.query_advice(a_3, Rotation::next());
             let spread_f_hi = meta.query_advice(a_4, Rotation::next());
 
-            CompressionGate::s_ch(
+            gate::s_ch(
                 s_ch,
                 spread_p0_even,
                 spread_p0_odd,
@@ -477,7 +473,6 @@ impl CompressionConfig {
                 spread_f_lo,
                 spread_f_hi,
             )
-            .0
         });
 
         // s_ch_neg on efgh words
@@ -495,7 +490,7 @@ impl CompressionConfig {
             let spread_g_lo = meta.query_advice(a_3, Rotation::next());
             let spread_g_hi = meta.query_advice(a_4, Rotation::next());
 
-            CompressionGate::s_ch_neg(
+            gate::s_ch_neg(
                 s_ch_neg,
                 spread_q0_even,
                 spread_q0_odd,
@@ -508,7 +503,6 @@ impl CompressionConfig {
                 spread_g_lo,
                 spread_g_hi,
             )
-            .0
         });
 
         // s_maj on abcd words
@@ -525,7 +519,7 @@ impl CompressionConfig {
             let spread_c_lo = meta.query_advice(a_4, Rotation::next());
             let spread_c_hi = meta.query_advice(a_5, Rotation::next());
 
-            CompressionGate::s_maj(
+            gate::s_maj(
                 s_maj,
                 spread_m0_even,
                 spread_m0_odd,
@@ -538,7 +532,6 @@ impl CompressionConfig {
                 spread_c_lo,
                 spread_c_hi,
             )
-            .0
         });
 
         // s_h_prime to compute H' = H + Ch(E, F, G) + s_upper_sigma_1(E) + K + W
@@ -560,7 +553,7 @@ impl CompressionConfig {
             let w_lo = meta.query_advice(a_8, Rotation::prev());
             let w_hi = meta.query_advice(a_8, Rotation::cur());
 
-            CompressionGate::s_h_prime(
+            gate::s_h_prime(
                 s_h_prime,
                 h_prime_lo,
                 h_prime_hi,
@@ -578,7 +571,6 @@ impl CompressionConfig {
                 w_lo,
                 w_hi,
             )
-            .0
         });
 
         // s_a_new
@@ -594,7 +586,7 @@ impl CompressionConfig {
             let h_prime_lo = meta.query_advice(a_7, Rotation::prev());
             let h_prime_hi = meta.query_advice(a_8, Rotation::prev());
 
-            CompressionGate::s_a_new(
+            gate::s_a_new(
                 s_a_new,
                 a_new_lo,
                 a_new_hi,
@@ -606,7 +598,6 @@ impl CompressionConfig {
                 h_prime_lo,
                 h_prime_hi,
             )
-            .0
         });
 
         // s_e_new
@@ -620,7 +611,7 @@ impl CompressionConfig {
             let h_prime_lo = meta.query_advice(a_7, Rotation::prev());
             let h_prime_hi = meta.query_advice(a_8, Rotation::prev());
 
-            CompressionGate::s_e_new(
+            gate::s_e_new(
                 s_e_new,
                 e_new_lo,
                 e_new_hi,
@@ -630,7 +621,6 @@ impl CompressionConfig {
                 h_prime_lo,
                 h_prime_hi,
             )
-            .0
         });
 
         // s_digest for final round
@@ -649,11 +639,10 @@ impl CompressionConfig {
             let hi_3 = meta.query_advice(a_7, Rotation::next());
             let word_3 = meta.query_advice(a_8, Rotation::next());
 
-            CompressionGate::s_digest(
+            gate::s_digest(
                 s_digest, lo_0, hi_0, word_0, lo_1, hi_1, word_1, lo_2, hi_2, word_2, lo_3, hi_3,
                 word_3,
             )
-            .0
         });
 
         CompressionConfig {

--- a/examples/sha256/table16/compression/compression_gates.rs
+++ b/examples/sha256/table16/compression/compression_gates.rs
@@ -1,422 +1,416 @@
-use super::super::{util::*, Gate};
+use super::super::{gates, util::*};
 use halo2::{arithmetic::FieldExt, plonk::Expression};
 
-pub struct CompressionGate<F: FieldExt>(pub Expression<F>);
+// Decompose `A,B,C,D` words
+// (2, 11, 9, 10)-bit chunks
+#[allow(clippy::too_many_arguments)]
+pub fn s_decompose_abcd<F: FieldExt>(
+    s_decompose_abcd: Expression<F>,
+    a: Expression<F>,
+    spread_a: Expression<F>,
+    b: Expression<F>,
+    spread_b: Expression<F>,
+    tag_b: Expression<F>,
+    c_lo: Expression<F>,
+    spread_c_lo: Expression<F>,
+    c_mid: Expression<F>,
+    spread_c_mid: Expression<F>,
+    c_hi: Expression<F>,
+    spread_c_hi: Expression<F>,
+    d: Expression<F>,
+    spread_d: Expression<F>,
+    tag_d: Expression<F>,
+    word_lo: Expression<F>,
+    spread_word_lo: Expression<F>,
+    word_hi: Expression<F>,
+    spread_word_hi: Expression<F>,
+) -> Vec<Expression<F>> {
+    let range_check_tag_b = gates::range_check(tag_b, 0, 2);
+    let range_check_tag_d = gates::range_check(tag_d, 0, 1);
+    let dense_check = a.clone()
+        + b.clone() * F::from_u64(1 << 2)
+        + c_lo.clone() * F::from_u64(1 << 13)
+        + c_mid.clone() * F::from_u64(1 << 16)
+        + c_hi.clone() * F::from_u64(1 << 19)
+        + d.clone() * F::from_u64(1 << 22)
+        + word_lo * (-F::one())
+        + word_hi * F::from_u64(1 << 16) * (-F::one());
+    let spread_check = spread_a.clone()
+        + spread_b.clone() * F::from_u64(1 << 4)
+        + spread_c_lo.clone() * F::from_u64(1 << 26)
+        + spread_c_mid.clone() * F::from_u64(1 << 32)
+        + spread_c_hi.clone() * F::from_u64(1 << 38)
+        + spread_d.clone() * F::from_u64(1 << 44)
+        + spread_word_lo * (-F::one())
+        + spread_word_hi * F::from_u64(1 << 32) * (-F::one());
 
-impl<F: FieldExt> CompressionGate<F> {
-    fn ones() -> Expression<F> {
-        Expression::Constant(F::one())
-    }
+    [
+        range_check_tag_b,
+        range_check_tag_d,
+        dense_check,
+        spread_check,
+    ]
+    .iter()
+    .chain(gates::three_bit_spread_and_range(c_lo, spread_c_lo).iter())
+    .chain(gates::three_bit_spread_and_range(c_mid, spread_c_mid).iter())
+    .chain(gates::three_bit_spread_and_range(c_hi, spread_c_hi).iter())
+    .chain(gates::two_bit_spread_and_range(a, spread_a).iter())
+    .map(|expr| s_decompose_abcd.clone() * expr.clone())
+    .collect()
+}
 
-    // Decompose `A,B,C,D` words
-    // (2, 11, 9, 10)-bit chunks
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_decompose_abcd(
-        s_decompose_abcd: Expression<F>,
-        a: Expression<F>,
-        spread_a: Expression<F>,
-        b: Expression<F>,
-        spread_b: Expression<F>,
-        tag_b: Expression<F>,
-        c_lo: Expression<F>,
-        spread_c_lo: Expression<F>,
-        c_mid: Expression<F>,
-        spread_c_mid: Expression<F>,
-        c_hi: Expression<F>,
-        spread_c_hi: Expression<F>,
-        d: Expression<F>,
-        spread_d: Expression<F>,
-        tag_d: Expression<F>,
-        word_lo: Expression<F>,
-        spread_word_lo: Expression<F>,
-        word_hi: Expression<F>,
-        spread_word_hi: Expression<F>,
-    ) -> Self {
-        let check_spread_and_range =
-            Gate::three_bit_spread_and_range(c_lo.clone(), spread_c_lo.clone())
-                + Gate::three_bit_spread_and_range(c_mid.clone(), spread_c_mid.clone())
-                + Gate::three_bit_spread_and_range(c_hi.clone(), spread_c_hi.clone())
-                + Gate::two_bit_spread_and_range(a.clone(), spread_a.clone());
-        let range_check_tag_b = Gate::range_check(tag_b, 0, 2);
-        let range_check_tag_d = Gate::range_check(tag_d, 0, 1);
-        let dense_check = a
-            + b * F::from_u64(1 << 2)
-            + c_lo * F::from_u64(1 << 13)
-            + c_mid * F::from_u64(1 << 16)
-            + c_hi * F::from_u64(1 << 19)
-            + d * F::from_u64(1 << 22)
-            + word_lo * (-F::one())
-            + word_hi * F::from_u64(1 << 16) * (-F::one());
-        let spread_check = spread_a
-            + spread_b * F::from_u64(1 << 4)
-            + spread_c_lo * F::from_u64(1 << 26)
-            + spread_c_mid * F::from_u64(1 << 32)
-            + spread_c_hi * F::from_u64(1 << 38)
-            + spread_d * F::from_u64(1 << 44)
-            + spread_word_lo * (-F::one())
-            + spread_word_hi * F::from_u64(1 << 32) * (-F::one());
+// Decompose `E,F,G,H` words
+// (6, 5, 14, 7)-bit chunks
+#[allow(clippy::too_many_arguments)]
+pub fn s_decompose_efgh<F: FieldExt>(
+    s_decompose_efgh: Expression<F>,
+    a_lo: Expression<F>,
+    spread_a_lo: Expression<F>,
+    a_hi: Expression<F>,
+    spread_a_hi: Expression<F>,
+    b_lo: Expression<F>,
+    spread_b_lo: Expression<F>,
+    b_hi: Expression<F>,
+    spread_b_hi: Expression<F>,
+    c: Expression<F>,
+    spread_c: Expression<F>,
+    tag_c: Expression<F>,
+    d: Expression<F>,
+    spread_d: Expression<F>,
+    tag_d: Expression<F>,
+    word_lo: Expression<F>,
+    spread_word_lo: Expression<F>,
+    word_hi: Expression<F>,
+    spread_word_hi: Expression<F>,
+) -> Vec<Expression<F>> {
+    let range_check_tag_c = gates::range_check(tag_c, 0, 4);
+    let range_check_tag_d = gates::range_check(tag_d, 0, 0);
+    let dense_check = a_lo.clone()
+        + a_hi.clone() * F::from_u64(1 << 3)
+        + b_lo.clone() * F::from_u64(1 << 6)
+        + b_hi.clone() * F::from_u64(1 << 8)
+        + c.clone() * F::from_u64(1 << 11)
+        + d.clone() * F::from_u64(1 << 25)
+        + word_lo * (-F::one())
+        + word_hi * F::from_u64(1 << 16) * (-F::one());
+    let spread_check = spread_a_lo.clone()
+        + spread_a_hi.clone() * F::from_u64(1 << 6)
+        + spread_b_lo.clone() * F::from_u64(1 << 12)
+        + spread_b_hi.clone() * F::from_u64(1 << 16)
+        + spread_c.clone() * F::from_u64(1 << 22)
+        + spread_d.clone() * F::from_u64(1 << 50)
+        + spread_word_lo * (-F::one())
+        + spread_word_hi * F::from_u64(1 << 32) * (-F::one());
 
-        CompressionGate(
-            s_decompose_abcd
-                * (range_check_tag_b
-                    + range_check_tag_d
-                    + dense_check
-                    + spread_check
-                    + check_spread_and_range),
-        )
-    }
+    [
+        range_check_tag_c,
+        range_check_tag_d,
+        dense_check,
+        spread_check,
+    ]
+    .iter()
+    .chain(gates::three_bit_spread_and_range(a_lo, spread_a_lo).iter())
+    .chain(gates::three_bit_spread_and_range(a_hi, spread_a_hi).iter())
+    .chain(gates::three_bit_spread_and_range(b_hi, spread_b_hi).iter())
+    .chain(gates::two_bit_spread_and_range(b_lo, spread_b_lo).iter())
+    .map(|expr| s_decompose_efgh.clone() * expr.clone())
+    .collect()
+}
 
-    // Decompose `E,F,G,H` words
-    // (6, 5, 14, 7)-bit chunks
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_decompose_efgh(
-        s_decompose_efgh: Expression<F>,
-        a_lo: Expression<F>,
-        spread_a_lo: Expression<F>,
-        a_hi: Expression<F>,
-        spread_a_hi: Expression<F>,
-        b_lo: Expression<F>,
-        spread_b_lo: Expression<F>,
-        b_hi: Expression<F>,
-        spread_b_hi: Expression<F>,
-        c: Expression<F>,
-        spread_c: Expression<F>,
-        tag_c: Expression<F>,
-        d: Expression<F>,
-        spread_d: Expression<F>,
-        tag_d: Expression<F>,
-        word_lo: Expression<F>,
-        spread_word_lo: Expression<F>,
-        word_hi: Expression<F>,
-        spread_word_hi: Expression<F>,
-    ) -> Self {
-        let check_spread_and_range =
-            Gate::three_bit_spread_and_range(a_lo.clone(), spread_a_lo.clone())
-                + Gate::three_bit_spread_and_range(a_hi.clone(), spread_a_hi.clone())
-                + Gate::three_bit_spread_and_range(b_hi.clone(), spread_b_hi.clone())
-                + Gate::two_bit_spread_and_range(b_lo.clone(), spread_b_lo.clone());
-        let range_check_tag_c = Gate::range_check(tag_c, 0, 4);
-        let range_check_tag_d = Gate::range_check(tag_d, 0, 0);
-        let dense_check = a_lo
-            + a_hi * F::from_u64(1 << 3)
-            + b_lo * F::from_u64(1 << 6)
-            + b_hi * F::from_u64(1 << 8)
-            + c * F::from_u64(1 << 11)
-            + d * F::from_u64(1 << 25)
-            + word_lo * (-F::one())
-            + word_hi * F::from_u64(1 << 16) * (-F::one());
-        let spread_check = spread_a_lo
-            + spread_a_hi * F::from_u64(1 << 6)
-            + spread_b_lo * F::from_u64(1 << 12)
-            + spread_b_hi * F::from_u64(1 << 16)
-            + spread_c * F::from_u64(1 << 22)
-            + spread_d * F::from_u64(1 << 50)
-            + spread_word_lo * (-F::one())
-            + spread_word_hi * F::from_u64(1 << 32) * (-F::one());
+// s_upper_sigma_0 on abcd words
+// (2, 11, 9, 10)-bit chunks
+#[allow(clippy::too_many_arguments)]
+pub fn s_upper_sigma_0<F: FieldExt>(
+    s_upper_sigma_0: Expression<F>,
+    spread_r0_even: Expression<F>,
+    spread_r0_odd: Expression<F>,
+    spread_r1_even: Expression<F>,
+    spread_r1_odd: Expression<F>,
+    spread_a: Expression<F>,
+    spread_b: Expression<F>,
+    spread_c_lo: Expression<F>,
+    spread_c_mid: Expression<F>,
+    spread_c_hi: Expression<F>,
+    spread_d: Expression<F>,
+) -> Vec<Expression<F>> {
+    let spread_witness = spread_r0_even
+        + spread_r0_odd * F::from_u64(2)
+        + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
+    let xor_0 = spread_b.clone()
+        + spread_c_lo.clone() * F::from_u64(1 << 22)
+        + spread_c_mid.clone() * F::from_u64(1 << 28)
+        + spread_c_hi.clone() * F::from_u64(1 << 34)
+        + spread_d.clone() * F::from_u64(1 << 40)
+        + spread_a.clone() * F::from_u64(1 << 60);
+    let xor_1 = spread_c_lo.clone()
+        + spread_c_mid.clone() * F::from_u64(1 << 6)
+        + spread_c_hi.clone() * F::from_u64(1 << 12)
+        + spread_d.clone() * F::from_u64(1 << 18)
+        + spread_a.clone() * F::from_u64(1 << 38)
+        + spread_b.clone() * F::from_u64(1 << 42);
+    let xor_2 = spread_d
+        + spread_a * F::from_u64(1 << 20)
+        + spread_b * F::from_u64(1 << 24)
+        + spread_c_lo * F::from_u64(1 << 46)
+        + spread_c_mid * F::from_u64(1 << 52)
+        + spread_c_hi * F::from_u64(1 << 58);
+    let xor = xor_0 + xor_1 + xor_2;
 
-        CompressionGate(
-            s_decompose_efgh
-                * (range_check_tag_c
-                    + range_check_tag_d
-                    + dense_check
-                    + spread_check
-                    + check_spread_and_range),
-        )
-    }
+    vec![s_upper_sigma_0 * (spread_witness + (xor * -F::one()))]
+}
 
-    // s_upper_sigma_0 on abcd words
-    // (2, 11, 9, 10)-bit chunks
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_upper_sigma_0(
-        s_upper_sigma_0: Expression<F>,
-        spread_r0_even: Expression<F>,
-        spread_r0_odd: Expression<F>,
-        spread_r1_even: Expression<F>,
-        spread_r1_odd: Expression<F>,
-        spread_a: Expression<F>,
-        spread_b: Expression<F>,
-        spread_c_lo: Expression<F>,
-        spread_c_mid: Expression<F>,
-        spread_c_hi: Expression<F>,
-        spread_d: Expression<F>,
-    ) -> Self {
-        let spread_witness = spread_r0_even
-            + spread_r0_odd * F::from_u64(2)
-            + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
-        let xor_0 = spread_b.clone()
-            + spread_c_lo.clone() * F::from_u64(1 << 22)
-            + spread_c_mid.clone() * F::from_u64(1 << 28)
-            + spread_c_hi.clone() * F::from_u64(1 << 34)
-            + spread_d.clone() * F::from_u64(1 << 40)
-            + spread_a.clone() * F::from_u64(1 << 60);
-        let xor_1 = spread_c_lo.clone()
-            + spread_c_mid.clone() * F::from_u64(1 << 6)
-            + spread_c_hi.clone() * F::from_u64(1 << 12)
-            + spread_d.clone() * F::from_u64(1 << 18)
-            + spread_a.clone() * F::from_u64(1 << 38)
-            + spread_b.clone() * F::from_u64(1 << 42);
-        let xor_2 = spread_d
-            + spread_a * F::from_u64(1 << 20)
-            + spread_b * F::from_u64(1 << 24)
-            + spread_c_lo * F::from_u64(1 << 46)
-            + spread_c_mid * F::from_u64(1 << 52)
-            + spread_c_hi * F::from_u64(1 << 58);
-        let xor = xor_0 + xor_1 + xor_2;
+// s_upper_sigma_1 on efgh words
+// (6, 5, 14, 7)-bit chunks
+#[allow(clippy::too_many_arguments)]
+pub fn s_upper_sigma_1<F: FieldExt>(
+    s_upper_sigma_1: Expression<F>,
+    spread_r0_even: Expression<F>,
+    spread_r0_odd: Expression<F>,
+    spread_r1_even: Expression<F>,
+    spread_r1_odd: Expression<F>,
+    spread_a_lo: Expression<F>,
+    spread_a_hi: Expression<F>,
+    spread_b_lo: Expression<F>,
+    spread_b_hi: Expression<F>,
+    spread_c: Expression<F>,
+    spread_d: Expression<F>,
+) -> Vec<Expression<F>> {
+    let spread_witness = spread_r0_even
+        + spread_r0_odd * F::from_u64(2)
+        + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
 
-        CompressionGate(s_upper_sigma_0 * (spread_witness + (xor * -F::one())))
-    }
+    let xor_0 = spread_b_lo.clone()
+        + spread_b_hi.clone() * F::from_u64(1 << 4)
+        + spread_c.clone() * F::from_u64(1 << 10)
+        + spread_d.clone() * F::from_u64(1 << 38)
+        + spread_a_lo.clone() * F::from_u64(1 << 52)
+        + spread_a_hi.clone() * F::from_u64(1 << 58);
+    let xor_1 = spread_c.clone()
+        + spread_d.clone() * F::from_u64(1 << 28)
+        + spread_a_lo.clone() * F::from_u64(1 << 42)
+        + spread_a_hi.clone() * F::from_u64(1 << 48)
+        + spread_b_lo.clone() * F::from_u64(1 << 54)
+        + spread_b_hi.clone() * F::from_u64(1 << 58);
+    let xor_2 = spread_d
+        + spread_a_lo * F::from_u64(1 << 14)
+        + spread_a_hi * F::from_u64(1 << 20)
+        + spread_b_lo * F::from_u64(1 << 26)
+        + spread_b_hi * F::from_u64(1 << 30)
+        + spread_c * F::from_u64(1 << 36);
+    let xor = xor_0 + xor_1 + xor_2;
 
-    // s_upper_sigma_1 on efgh words
-    // (6, 5, 14, 7)-bit chunks
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_upper_sigma_1(
-        s_upper_sigma_1: Expression<F>,
-        spread_r0_even: Expression<F>,
-        spread_r0_odd: Expression<F>,
-        spread_r1_even: Expression<F>,
-        spread_r1_odd: Expression<F>,
-        spread_a_lo: Expression<F>,
-        spread_a_hi: Expression<F>,
-        spread_b_lo: Expression<F>,
-        spread_b_hi: Expression<F>,
-        spread_c: Expression<F>,
-        spread_d: Expression<F>,
-    ) -> Self {
-        let spread_witness = spread_r0_even
-            + spread_r0_odd * F::from_u64(2)
-            + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
+    vec![s_upper_sigma_1 * (spread_witness + (xor * -F::one()))]
+}
 
-        let xor_0 = spread_b_lo.clone()
-            + spread_b_hi.clone() * F::from_u64(1 << 4)
-            + spread_c.clone() * F::from_u64(1 << 10)
-            + spread_d.clone() * F::from_u64(1 << 38)
-            + spread_a_lo.clone() * F::from_u64(1 << 52)
-            + spread_a_hi.clone() * F::from_u64(1 << 58);
-        let xor_1 = spread_c.clone()
-            + spread_d.clone() * F::from_u64(1 << 28)
-            + spread_a_lo.clone() * F::from_u64(1 << 42)
-            + spread_a_hi.clone() * F::from_u64(1 << 48)
-            + spread_b_lo.clone() * F::from_u64(1 << 54)
-            + spread_b_hi.clone() * F::from_u64(1 << 58);
-        let xor_2 = spread_d
-            + spread_a_lo * F::from_u64(1 << 14)
-            + spread_a_hi * F::from_u64(1 << 20)
-            + spread_b_lo * F::from_u64(1 << 26)
-            + spread_b_hi * F::from_u64(1 << 30)
-            + spread_c * F::from_u64(1 << 36);
-        let xor = xor_0 + xor_1 + xor_2;
+// First part of choice gate on (E, F, G), E ∧ F
+#[allow(clippy::too_many_arguments)]
+pub fn s_ch<F: FieldExt>(
+    s_ch: Expression<F>,
+    spread_p0_even: Expression<F>,
+    spread_p0_odd: Expression<F>,
+    spread_p1_even: Expression<F>,
+    spread_p1_odd: Expression<F>,
+    spread_e_lo: Expression<F>,
+    spread_e_hi: Expression<F>,
+    spread_f_lo: Expression<F>,
+    spread_f_hi: Expression<F>,
+) -> Vec<Expression<F>> {
+    let lhs_lo = spread_e_lo + spread_f_lo;
+    let lhs_hi = spread_e_hi + spread_f_hi;
+    let lhs = lhs_lo + lhs_hi * F::from_u64(1 << 32);
 
-        CompressionGate(s_upper_sigma_1 * (spread_witness + (xor * -F::one())))
-    }
+    let rhs_even = spread_p0_even + spread_p1_even * F::from_u64(1 << 32);
+    let rhs_odd = spread_p0_odd + spread_p1_odd * F::from_u64(1 << 32);
+    let rhs = rhs_even + rhs_odd * F::from_u64(2);
 
-    // First part of choice gate on (E, F, G), E ∧ F
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_ch(
-        s_ch: Expression<F>,
-        spread_p0_even: Expression<F>,
-        spread_p0_odd: Expression<F>,
-        spread_p1_even: Expression<F>,
-        spread_p1_odd: Expression<F>,
-        spread_e_lo: Expression<F>,
-        spread_e_hi: Expression<F>,
-        spread_f_lo: Expression<F>,
-        spread_f_hi: Expression<F>,
-    ) -> Self {
-        let lhs_lo = spread_e_lo + spread_f_lo;
-        let lhs_hi = spread_e_hi + spread_f_hi;
-        let lhs = lhs_lo + lhs_hi * F::from_u64(1 << 32);
+    vec![s_ch * (lhs + rhs * -F::one())]
+}
 
-        let rhs_even = spread_p0_even + spread_p1_even * F::from_u64(1 << 32);
-        let rhs_odd = spread_p0_odd + spread_p1_odd * F::from_u64(1 << 32);
-        let rhs = rhs_even + rhs_odd * F::from_u64(2);
+// Second part of Choice gate on (E, F, G), ¬E ∧ G
+#[allow(clippy::too_many_arguments)]
+pub fn s_ch_neg<F: FieldExt>(
+    s_ch_neg: Expression<F>,
+    spread_q0_even: Expression<F>,
+    spread_q0_odd: Expression<F>,
+    spread_q1_even: Expression<F>,
+    spread_q1_odd: Expression<F>,
+    spread_e_lo: Expression<F>,
+    spread_e_hi: Expression<F>,
+    spread_e_neg_lo: Expression<F>,
+    spread_e_neg_hi: Expression<F>,
+    spread_g_lo: Expression<F>,
+    spread_g_hi: Expression<F>,
+) -> Vec<Expression<F>> {
+    let neg_check = neg_check(
+        spread_e_lo,
+        spread_e_hi,
+        spread_e_neg_lo.clone(),
+        spread_e_neg_hi.clone(),
+    );
+    let lhs_lo = spread_e_neg_lo + spread_g_lo;
+    let lhs_hi = spread_e_neg_hi + spread_g_hi;
+    let lhs = lhs_lo + lhs_hi * F::from_u64(1 << 32);
 
-        CompressionGate(s_ch * (lhs + rhs * -F::one()))
-    }
+    let rhs_even = spread_q0_even + spread_q1_even * F::from_u64(1 << 32);
+    let rhs_odd = spread_q0_odd + spread_q1_odd * F::from_u64(1 << 32);
+    let rhs = rhs_even + rhs_odd * F::from_u64(2);
 
-    // Second part of Choice gate on (E, F, G), ¬E ∧ G
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_ch_neg(
-        s_ch_neg: Expression<F>,
-        spread_q0_even: Expression<F>,
-        spread_q0_odd: Expression<F>,
-        spread_q1_even: Expression<F>,
-        spread_q1_odd: Expression<F>,
-        spread_e_lo: Expression<F>,
-        spread_e_hi: Expression<F>,
-        spread_e_neg_lo: Expression<F>,
-        spread_e_neg_hi: Expression<F>,
-        spread_g_lo: Expression<F>,
-        spread_g_hi: Expression<F>,
-    ) -> Self {
-        let neg_check = Self::neg_check(
-            spread_e_lo,
-            spread_e_hi,
-            spread_e_neg_lo.clone(),
-            spread_e_neg_hi.clone(),
-        );
-        let lhs_lo = spread_e_neg_lo + spread_g_lo;
-        let lhs_hi = spread_e_neg_hi + spread_g_hi;
-        let lhs = lhs_lo + lhs_hi * F::from_u64(1 << 32);
+    neg_check
+        .iter()
+        .chain([lhs + rhs * -F::one()].iter())
+        .map(|expr| s_ch_neg.clone() * expr.clone())
+        .collect()
+}
 
-        let rhs_even = spread_q0_even + spread_q1_even * F::from_u64(1 << 32);
-        let rhs_odd = spread_q0_odd + spread_q1_odd * F::from_u64(1 << 32);
-        let rhs = rhs_even + rhs_odd * F::from_u64(2);
+// Majority gate on (A, B, C)
+#[allow(clippy::too_many_arguments)]
+pub fn s_maj<F: FieldExt>(
+    s_maj: Expression<F>,
+    spread_m_0_even: Expression<F>,
+    spread_m_0_odd: Expression<F>,
+    spread_m_1_even: Expression<F>,
+    spread_m_1_odd: Expression<F>,
+    spread_a_lo: Expression<F>,
+    spread_a_hi: Expression<F>,
+    spread_b_lo: Expression<F>,
+    spread_b_hi: Expression<F>,
+    spread_c_lo: Expression<F>,
+    spread_c_hi: Expression<F>,
+) -> Vec<Expression<F>> {
+    let maj_even = spread_m_0_even + spread_m_1_even * F::from_u64(1 << 32);
+    let maj_odd = spread_m_0_odd + spread_m_1_odd * F::from_u64(1 << 32);
+    let maj = maj_even + maj_odd * F::from_u64(2);
 
-        CompressionGate(s_ch_neg * (neg_check + lhs + rhs * -F::one()))
-    }
+    let a = spread_a_lo + spread_a_hi * F::from_u64(1 << 32);
+    let b = spread_b_lo + spread_b_hi * F::from_u64(1 << 32);
+    let c = spread_c_lo + spread_c_hi * F::from_u64(1 << 32);
+    let sum = a + b + c;
 
-    // Majority gate on (A, B, C)
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_maj(
-        s_maj: Expression<F>,
-        spread_m_0_even: Expression<F>,
-        spread_m_0_odd: Expression<F>,
-        spread_m_1_even: Expression<F>,
-        spread_m_1_odd: Expression<F>,
-        spread_a_lo: Expression<F>,
-        spread_a_hi: Expression<F>,
-        spread_b_lo: Expression<F>,
-        spread_b_hi: Expression<F>,
-        spread_c_lo: Expression<F>,
-        spread_c_hi: Expression<F>,
-    ) -> Self {
-        let maj_even = spread_m_0_even + spread_m_1_even * F::from_u64(1 << 32);
-        let maj_odd = spread_m_0_odd + spread_m_1_odd * F::from_u64(1 << 32);
-        let maj = maj_even + maj_odd * F::from_u64(2);
+    vec![s_maj * (sum + maj * -F::one())]
+}
 
-        let a = spread_a_lo + spread_a_hi * F::from_u64(1 << 32);
-        let b = spread_b_lo + spread_b_hi * F::from_u64(1 << 32);
-        let c = spread_c_lo + spread_c_hi * F::from_u64(1 << 32);
-        let sum = a + b + c;
+// Negation gate, used in second part of Choice gate
+fn neg_check<F: FieldExt>(
+    word_lo: Expression<F>,
+    word_hi: Expression<F>,
+    neg_word_lo: Expression<F>,
+    neg_word_hi: Expression<F>,
+) -> [Expression<F>; 2] {
+    let evens = Expression::Constant(F::from_u64(MASK_EVEN_32 as u64));
+    // evens - word_lo = neg_word_lo
+    let lo_check = neg_word_lo + word_lo + (evens.clone() * (-F::one()));
+    // evens - word_hi = neg_word_hi
+    let hi_check = neg_word_hi + word_hi + (evens * (-F::one()));
 
-        CompressionGate(s_maj * (sum + maj * -F::one()))
-    }
+    [lo_check, hi_check]
+}
 
-    // Negation gate, used in second part of Choice gate
-    fn neg_check(
-        word_lo: Expression<F>,
-        word_hi: Expression<F>,
-        neg_word_lo: Expression<F>,
-        neg_word_hi: Expression<F>,
-    ) -> Expression<F> {
-        let evens = Self::ones() * F::from_u64(MASK_EVEN_32 as u64);
-        // evens - word_lo = neg_word_lo
-        let lo_check = neg_word_lo + word_lo + (evens.clone() * (-F::one()));
-        // evens - word_hi = neg_word_hi
-        let hi_check = neg_word_hi + word_hi + (evens * (-F::one()));
+// s_h_prime to get H' = H + Ch(E, F, G) + s_upper_sigma_1(E) + K + W
+#[allow(clippy::too_many_arguments)]
+pub fn s_h_prime<F: FieldExt>(
+    s_h_prime: Expression<F>,
+    h_prime_lo: Expression<F>,
+    h_prime_hi: Expression<F>,
+    h_prime_carry: Expression<F>,
+    sigma_e_lo: Expression<F>,
+    sigma_e_hi: Expression<F>,
+    ch_lo: Expression<F>,
+    ch_hi: Expression<F>,
+    ch_neg_lo: Expression<F>,
+    ch_neg_hi: Expression<F>,
+    h_lo: Expression<F>,
+    h_hi: Expression<F>,
+    k_lo: Expression<F>,
+    k_hi: Expression<F>,
+    w_lo: Expression<F>,
+    w_hi: Expression<F>,
+) -> Vec<Expression<F>> {
+    let lo = h_lo + ch_lo + ch_neg_lo + sigma_e_lo + k_lo + w_lo;
+    let hi = h_hi + ch_hi + ch_neg_hi + sigma_e_hi + k_hi + w_hi;
 
-        lo_check + hi_check
-    }
+    let sum = lo + hi * F::from_u64(1 << 16);
+    let h_prime = h_prime_lo + h_prime_hi * F::from_u64(1 << 16);
 
-    // s_h_prime to get H' = H + Ch(E, F, G) + s_upper_sigma_1(E) + K + W
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_h_prime(
-        s_h_prime: Expression<F>,
-        h_prime_lo: Expression<F>,
-        h_prime_hi: Expression<F>,
-        h_prime_carry: Expression<F>,
-        sigma_e_lo: Expression<F>,
-        sigma_e_hi: Expression<F>,
-        ch_lo: Expression<F>,
-        ch_hi: Expression<F>,
-        ch_neg_lo: Expression<F>,
-        ch_neg_hi: Expression<F>,
-        h_lo: Expression<F>,
-        h_hi: Expression<F>,
-        k_lo: Expression<F>,
-        k_hi: Expression<F>,
-        w_lo: Expression<F>,
-        w_hi: Expression<F>,
-    ) -> Self {
-        let lo = h_lo + ch_lo + ch_neg_lo + sigma_e_lo + k_lo + w_lo;
-        let hi = h_hi + ch_hi + ch_neg_hi + sigma_e_hi + k_hi + w_hi;
+    vec![
+        s_h_prime
+            * (sum + h_prime_carry * F::from_u64(1 << 32) * (-F::one()) + h_prime * (-F::one())),
+    ]
+}
 
-        let sum = lo + hi * F::from_u64(1 << 16);
-        let h_prime = h_prime_lo + h_prime_hi * F::from_u64(1 << 16);
+// s_a_new to get A_new = H' + Maj(A, B, C) + s_upper_sigma_0(A)
+#[allow(clippy::too_many_arguments)]
+pub fn s_a_new<F: FieldExt>(
+    s_a_new: Expression<F>,
+    a_new_lo: Expression<F>,
+    a_new_hi: Expression<F>,
+    a_new_carry: Expression<F>,
+    sigma_a_lo: Expression<F>,
+    sigma_a_hi: Expression<F>,
+    maj_abc_lo: Expression<F>,
+    maj_abc_hi: Expression<F>,
+    h_prime_lo: Expression<F>,
+    h_prime_hi: Expression<F>,
+) -> Vec<Expression<F>> {
+    let lo = sigma_a_lo + maj_abc_lo + h_prime_lo;
+    let hi = sigma_a_hi + maj_abc_hi + h_prime_hi;
+    let sum = lo + hi * F::from_u64(1 << 16);
+    let a_new = a_new_lo + a_new_hi * F::from_u64(1 << 16);
 
-        CompressionGate(
-            s_h_prime
-                * (sum
-                    + h_prime_carry * F::from_u64(1 << 32) * (-F::one())
-                    + h_prime * (-F::one())),
-        )
-    }
+    vec![s_a_new * (sum + a_new_carry * F::from_u64(1 << 32) * (-F::one()) + a_new * (-F::one()))]
+}
 
-    // s_a_new to get A_new = H' + Maj(A, B, C) + s_upper_sigma_0(A)
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_a_new(
-        s_a_new: Expression<F>,
-        a_new_lo: Expression<F>,
-        a_new_hi: Expression<F>,
-        a_new_carry: Expression<F>,
-        sigma_a_lo: Expression<F>,
-        sigma_a_hi: Expression<F>,
-        maj_abc_lo: Expression<F>,
-        maj_abc_hi: Expression<F>,
-        h_prime_lo: Expression<F>,
-        h_prime_hi: Expression<F>,
-    ) -> Self {
-        let lo = sigma_a_lo + maj_abc_lo + h_prime_lo;
-        let hi = sigma_a_hi + maj_abc_hi + h_prime_hi;
-        let sum = lo + hi * F::from_u64(1 << 16);
-        let a_new = a_new_lo + a_new_hi * F::from_u64(1 << 16);
+// s_e_new to get E_new = H' + D
+#[allow(clippy::too_many_arguments)]
+pub fn s_e_new<F: FieldExt>(
+    s_e_new: Expression<F>,
+    e_new_lo: Expression<F>,
+    e_new_hi: Expression<F>,
+    e_new_carry: Expression<F>,
+    d_lo: Expression<F>,
+    d_hi: Expression<F>,
+    h_prime_lo: Expression<F>,
+    h_prime_hi: Expression<F>,
+) -> Vec<Expression<F>> {
+    let lo = h_prime_lo + d_lo;
+    let hi = h_prime_hi + d_hi;
+    let sum = lo + hi * F::from_u64(1 << 16);
+    let e_new = e_new_lo + e_new_hi * F::from_u64(1 << 16);
 
-        CompressionGate(
-            s_a_new
-                * (sum + a_new_carry * F::from_u64(1 << 32) * (-F::one()) + a_new * (-F::one())),
-        )
-    }
+    vec![s_e_new * (sum + e_new_carry * F::from_u64(1 << 32) * (-F::one()) + e_new * (-F::one()))]
+}
 
-    // s_e_new to get E_new = H' + D
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_e_new(
-        s_e_new: Expression<F>,
-        e_new_lo: Expression<F>,
-        e_new_hi: Expression<F>,
-        e_new_carry: Expression<F>,
-        d_lo: Expression<F>,
-        d_hi: Expression<F>,
-        h_prime_lo: Expression<F>,
-        h_prime_hi: Expression<F>,
-    ) -> Self {
-        let lo = h_prime_lo + d_lo;
-        let hi = h_prime_hi + d_hi;
-        let sum = lo + hi * F::from_u64(1 << 16);
-        let e_new = e_new_lo + e_new_hi * F::from_u64(1 << 16);
+fn check_lo_hi<F: FieldExt>(
+    lo: Expression<F>,
+    hi: Expression<F>,
+    word: Expression<F>,
+) -> Expression<F> {
+    lo + hi * F::from_u64(1 << 16) + (word * (-F::one()))
+}
 
-        CompressionGate(
-            s_e_new
-                * (sum + e_new_carry * F::from_u64(1 << 32) * (-F::one()) + e_new * (-F::one())),
-        )
-    }
-
-    fn check_lo_hi(lo: Expression<F>, hi: Expression<F>, word: Expression<F>) -> Expression<F> {
-        lo + hi * F::from_u64(1 << 16) + (word * (-F::one()))
-    }
-
-    // s_digest on final round
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_digest(
-        s_digest: Expression<F>,
-        lo_0: Expression<F>,
-        hi_0: Expression<F>,
-        word_0: Expression<F>,
-        lo_1: Expression<F>,
-        hi_1: Expression<F>,
-        word_1: Expression<F>,
-        lo_2: Expression<F>,
-        hi_2: Expression<F>,
-        word_2: Expression<F>,
-        lo_3: Expression<F>,
-        hi_3: Expression<F>,
-        word_3: Expression<F>,
-    ) -> Self {
-        CompressionGate(
-            s_digest
-                * (Self::check_lo_hi(lo_0, hi_0, word_0)
-                    + Self::check_lo_hi(lo_1, hi_1, word_1)
-                    + Self::check_lo_hi(lo_2, hi_2, word_2)
-                    + Self::check_lo_hi(lo_3, hi_3, word_3)),
-        )
-    }
+// s_digest on final round
+#[allow(clippy::too_many_arguments)]
+pub fn s_digest<F: FieldExt>(
+    s_digest: Expression<F>,
+    lo_0: Expression<F>,
+    hi_0: Expression<F>,
+    word_0: Expression<F>,
+    lo_1: Expression<F>,
+    hi_1: Expression<F>,
+    word_1: Expression<F>,
+    lo_2: Expression<F>,
+    hi_2: Expression<F>,
+    word_2: Expression<F>,
+    lo_3: Expression<F>,
+    hi_3: Expression<F>,
+    word_3: Expression<F>,
+) -> Vec<Expression<F>> {
+    [
+        check_lo_hi(lo_0, hi_0, word_0),
+        check_lo_hi(lo_1, hi_1, word_1),
+        check_lo_hi(lo_2, hi_2, word_2),
+        check_lo_hi(lo_3, hi_3, word_3),
+    ]
+    .iter()
+    .map(|expr| s_digest.clone() * expr.clone())
+    .collect()
 }

--- a/examples/sha256/table16/gates.rs
+++ b/examples/sha256/table16/gates.rs
@@ -1,117 +1,126 @@
 use halo2::{arithmetic::FieldExt, plonk::Expression};
 
-pub struct Gate<F: FieldExt>(pub Expression<F>);
+fn ones<F: FieldExt>() -> Expression<F> {
+    Expression::Constant(F::one())
+}
 
-impl<F: FieldExt> Gate<F> {
-    fn ones() -> Expression<F> {
-        Expression::Constant(F::one())
+// Helper gates
+fn lagrange_interpolate<F: FieldExt>(
+    var: Expression<F>,
+    points: Vec<u16>,
+    evals: Vec<u32>,
+) -> (F, Expression<F>) {
+    assert_eq!(points.len(), evals.len());
+    let deg = points.len();
+
+    fn factorial<F: FieldExt>(n: u64) -> u64 {
+        if n < 2 {
+            1
+        } else {
+            n * factorial::<F>(n - 1)
+        }
     }
 
-    // Helper gates
-    fn lagrange_interpolate(
-        var: Expression<F>,
-        points: Vec<u16>,
-        evals: Vec<u32>,
-    ) -> (F, Expression<F>) {
-        assert_eq!(points.len(), evals.len());
-        let deg = points.len();
+    // Scale the whole expression by factor to avoid divisions
+    let factor = factorial::<F>((deg - 1) as u64);
 
-        fn factorial(n: u64) -> u64 {
-            if n < 2 {
-                1
-            } else {
-                n * factorial(n - 1)
+    let numerator = |var: Expression<F>, eval: u32, idx: u64| {
+        let mut expr = ones();
+        for i in 0..deg {
+            let i = i as u64;
+            if i != idx {
+                expr = expr * (ones() * (-F::one()) * F::from_u64(i) + var.clone());
             }
         }
-
-        // Scale the whole expression by factor to avoid divisions
-        let factor = factorial((deg - 1) as u64);
-
-        let numerator = |var: Expression<F>, eval: u32, idx: u64| {
-            let mut expr = Self::ones();
-            for i in 0..deg {
-                let i = i as u64;
-                if i != idx {
-                    expr = expr * (Self::ones() * (-F::one()) * F::from_u64(i) + var.clone());
-                }
+        expr * F::from_u64(eval.into())
+    };
+    let denominator = |idx: i32| {
+        let mut denom: i32 = 1;
+        for i in 0..deg {
+            let i = i as i32;
+            if i != idx {
+                denom *= idx - i
             }
-            expr * F::from_u64(eval.into())
-        };
-        let denominator = |idx: i32| {
-            let mut denom: i32 = 1;
-            for i in 0..deg {
-                let i = i as i32;
-                if i != idx {
-                    denom *= idx - i
-                }
-            }
-            if denom < 0 {
-                -F::one() * F::from_u64(factor / (-denom as u64))
-            } else {
-                F::from_u64(factor / (denom as u64))
-            }
-        };
-
-        let mut expr = Self::ones() * F::zero();
-        for ((idx, _), eval) in points.iter().enumerate().zip(evals.iter()) {
-            expr = expr + numerator(var.clone(), *eval, idx as u64) * denominator(idx as i32)
         }
-
-        (F::from_u64(factor), expr)
-    }
-
-    pub fn range_check(value: Expression<F>, lower_range: u64, upper_range: u64) -> Expression<F> {
-        let mut expr = Self::ones();
-        for i in lower_range..(upper_range + 1) {
-            expr = expr * (Self::ones() * (-F::one()) * F::from_u64(i) + value.clone())
+        if denom < 0 {
+            -F::one() * F::from_u64(factor / (-denom as u64))
+        } else {
+            F::from_u64(factor / (denom as u64))
         }
-        expr
+    };
+
+    let mut expr = ones() * F::zero();
+    for ((idx, _), eval) in points.iter().enumerate().zip(evals.iter()) {
+        expr = expr + numerator(var.clone(), *eval, idx as u64) * denominator(idx as i32)
     }
 
-    // 2-bit range check
-    fn two_bit_range_check(value: Expression<F>) -> Expression<F> {
-        Self::range_check(value, 0, (1 << 2) - 1)
+    (F::from_u64(factor), expr)
+}
+
+pub fn range_check<F: FieldExt>(
+    value: Expression<F>,
+    lower_range: u64,
+    upper_range: u64,
+) -> Expression<F> {
+    let mut expr = ones();
+    for i in lower_range..(upper_range + 1) {
+        expr = expr * (ones() * (-F::one()) * F::from_u64(i) + value.clone())
     }
+    expr
+}
 
-    // 2-bit spread interpolation
-    fn two_bit_spread(dense: Expression<F>, spread: Expression<F>) -> Expression<F> {
-        let (factor, lagrange_poly) = Self::lagrange_interpolate(
-            dense,
-            vec![0b00, 0b01, 0b10, 0b11],
-            vec![0b0000, 0b0001, 0b0100, 0b0101],
-        );
+// 2-bit range check
+pub fn two_bit_range_check<F: FieldExt>(value: Expression<F>) -> Expression<F> {
+    range_check(value, 0, (1 << 2) - 1)
+}
 
-        lagrange_poly + (spread * factor * (-F::one()))
-    }
+// 2-bit spread interpolation
+pub fn two_bit_spread<F: FieldExt>(dense: Expression<F>, spread: Expression<F>) -> Expression<F> {
+    let (factor, lagrange_poly) = lagrange_interpolate(
+        dense,
+        vec![0b00, 0b01, 0b10, 0b11],
+        vec![0b0000, 0b0001, 0b0100, 0b0101],
+    );
 
-    // 3-bit range check
-    fn three_bit_range_check(value: Expression<F>) -> Expression<F> {
-        Self::range_check(value, 0, (1 << 3) - 1)
-    }
+    lagrange_poly + (spread * factor * (-F::one()))
+}
 
-    // 3-bit spread
-    fn three_bit_spread(dense: Expression<F>, spread: Expression<F>) -> Expression<F> {
-        let (factor, lagrange_poly) = Self::lagrange_interpolate(
-            dense,
-            vec![0b000, 0b001, 0b010, 0b011, 0b100, 0b101, 0b110, 0b111],
-            vec![
-                0b000000, 0b000001, 0b000100, 0b000101, 0b010000, 0b010001, 0b010100, 0b010101,
-            ],
-        );
+// 3-bit range check
+pub fn three_bit_range_check<F: FieldExt>(value: Expression<F>) -> Expression<F> {
+    range_check(value, 0, (1 << 3) - 1)
+}
 
-        lagrange_poly + (spread * factor * (-F::one()))
-    }
+// 3-bit spread
+pub fn three_bit_spread<F: FieldExt>(dense: Expression<F>, spread: Expression<F>) -> Expression<F> {
+    let (factor, lagrange_poly) = lagrange_interpolate(
+        dense,
+        vec![0b000, 0b001, 0b010, 0b011, 0b100, 0b101, 0b110, 0b111],
+        vec![
+            0b000000, 0b000001, 0b000100, 0b000101, 0b010000, 0b010001, 0b010100, 0b010101,
+        ],
+    );
 
-    /// Spread and range check on 2-bit word
-    pub fn two_bit_spread_and_range(dense: Expression<F>, spread: Expression<F>) -> Expression<F> {
-        Self::two_bit_range_check(dense.clone()) + Self::two_bit_spread(dense, spread)
-    }
+    lagrange_poly + (spread * factor * (-F::one()))
+}
 
-    /// Spread and range check on 3-bit word
-    pub fn three_bit_spread_and_range(
-        dense: Expression<F>,
-        spread: Expression<F>,
-    ) -> Expression<F> {
-        Self::three_bit_range_check(dense.clone()) + Self::three_bit_spread(dense, spread)
-    }
+/// Spread and range check on 2-bit word
+pub fn two_bit_spread_and_range<F: FieldExt>(
+    dense: Expression<F>,
+    spread: Expression<F>,
+) -> Vec<Expression<F>> {
+    vec![
+        two_bit_range_check(dense.clone()),
+        two_bit_spread(dense, spread),
+    ]
+}
+
+/// Spread and range check on 3-bit word
+pub fn three_bit_spread_and_range<F: FieldExt>(
+    dense: Expression<F>,
+    spread: Expression<F>,
+) -> Vec<Expression<F>> {
+    vec![
+        three_bit_range_check(dense.clone()),
+        three_bit_spread(dense, spread),
+    ]
 }

--- a/examples/sha256/table16/message_schedule.rs
+++ b/examples/sha256/table16/message_schedule.rs
@@ -14,7 +14,7 @@ mod subregion1;
 mod subregion2;
 mod subregion3;
 
-use schedule_gates::ScheduleGate;
+use schedule_gates as gate;
 use schedule_util::*;
 
 #[cfg(test)]
@@ -115,7 +115,7 @@ impl MessageScheduleConfig {
             let word = meta.query_advice(a_5, Rotation::cur());
             let carry = meta.query_advice(a_9, Rotation::cur());
 
-            ScheduleGate::s_word(
+            gate::s_word(
                 s_word,
                 sigma_0_lo,
                 sigma_0_hi,
@@ -128,7 +128,6 @@ impl MessageScheduleConfig {
                 word,
                 carry,
             )
-            .0
         });
 
         // s_decompose_0 for all words
@@ -138,7 +137,7 @@ impl MessageScheduleConfig {
             let hi = meta.query_advice(a_4, Rotation::cur());
             let word = meta.query_advice(a_5, Rotation::cur());
 
-            ScheduleGate::s_decompose_0(s_decompose_0, lo, hi, word).0
+            gate::s_decompose_0(s_decompose_0, lo, hi, word)
         });
 
         // s_decompose_1 for W_[1..14]
@@ -153,7 +152,7 @@ impl MessageScheduleConfig {
             let tag_d = meta.query_advice(a_0, Rotation::cur());
             let word = meta.query_advice(a_5, Rotation::cur());
 
-            ScheduleGate::s_decompose_1(s_decompose_1, a, b, c, tag_c, d, tag_d, word).0
+            gate::s_decompose_1(s_decompose_1, a, b, c, tag_c, d, tag_d, word)
         });
 
         // s_decompose_2 for W_[14..49]
@@ -171,7 +170,7 @@ impl MessageScheduleConfig {
             let tag_g = meta.query_advice(a_0, Rotation::prev());
             let word = meta.query_advice(a_5, Rotation::cur());
 
-            ScheduleGate::s_decompose_2(s_decompose_2, a, b, c, d, tag_d, e, f, g, tag_g, word).0
+            gate::s_decompose_2(s_decompose_2, a, b, c, d, tag_d, e, f, g, tag_g, word)
         });
 
         // s_decompose_3 for W_49 to W_61
@@ -186,13 +185,13 @@ impl MessageScheduleConfig {
             let tag_d = meta.query_advice(a_0, Rotation::cur());
             let word = meta.query_advice(a_5, Rotation::cur());
 
-            ScheduleGate::s_decompose_3(s_decompose_3, a, tag_a, b, c, d, tag_d, word).0
+            gate::s_decompose_3(s_decompose_3, a, tag_a, b, c, d, tag_d, word)
         });
 
         // sigma_0 v1 on W_[1..14]
         // (3, 4, 11, 14)-bit chunks
         meta.create_gate("sigma_0 v1", |meta| {
-            ScheduleGate::s_lower_sigma_0(
+            gate::s_lower_sigma_0(
                 meta.query_fixed(s_lower_sigma_0, Rotation::cur()), // s_lower_sigma_0
                 meta.query_advice(a_2, Rotation::prev()),           // spread_r0_even
                 meta.query_advice(a_2, Rotation::cur()),            // spread_r0_odd
@@ -208,13 +207,12 @@ impl MessageScheduleConfig {
                 meta.query_advice(a_4, Rotation::cur()),            // spread_c
                 meta.query_advice(a_5, Rotation::cur()),            // spread_d
             )
-            .0
         });
 
         // sigma_0 v2 on W_[14..49]
         // (3, 4, 3, 7, 1, 1, 13)-bit chunks
         meta.create_gate("sigma_0 v2", |meta| {
-            ScheduleGate::s_lower_sigma_0_v2(
+            gate::s_lower_sigma_0_v2(
                 meta.query_fixed(s_lower_sigma_0_v2, Rotation::cur()), // s_lower_sigma_0_v2
                 meta.query_advice(a_2, Rotation::prev()),              // spread_r0_even
                 meta.query_advice(a_2, Rotation::cur()),               // spread_r0_odd
@@ -234,13 +232,12 @@ impl MessageScheduleConfig {
                 meta.query_advice(a_7, Rotation::next()),              // spread_f
                 meta.query_advice(a_5, Rotation::cur()),               // spread_g
             )
-            .0
         });
 
         // sigma_1 v2 on W_14 to W_48
         // (3, 4, 3, 7, 1, 1, 13)-bit chunks
         meta.create_gate("sigma_1 v2", |meta| {
-            ScheduleGate::s_lower_sigma_1_v2(
+            gate::s_lower_sigma_1_v2(
                 meta.query_fixed(s_lower_sigma_1_v2, Rotation::cur()), // s_lower_sigma_1_v2
                 meta.query_advice(a_2, Rotation::prev()),              // spread_r0_even
                 meta.query_advice(a_2, Rotation::cur()),               // spread_r0_odd
@@ -260,13 +257,12 @@ impl MessageScheduleConfig {
                 meta.query_advice(a_7, Rotation::next()),              // spread_f
                 meta.query_advice(a_5, Rotation::cur()),               // spread_g
             )
-            .0
         });
 
         // sigma_1 v1 on W_49 to W_61
         // (10, 7, 2, 13)-bit chunks
         meta.create_gate("sigma_1 v1", |meta| {
-            ScheduleGate::s_lower_sigma_1(
+            gate::s_lower_sigma_1(
                 meta.query_fixed(s_lower_sigma_1, Rotation::cur()), // s_lower_sigma_1
                 meta.query_advice(a_2, Rotation::prev()),           // spread_r0_even
                 meta.query_advice(a_2, Rotation::cur()),            // spread_r0_odd
@@ -284,7 +280,6 @@ impl MessageScheduleConfig {
                 meta.query_advice(a_4, Rotation::next()),           // spread_c
                 meta.query_advice(a_5, Rotation::cur()),            // spread_d
             )
-            .0
         });
 
         MessageScheduleConfig {

--- a/examples/sha256/table16/message_schedule/schedule_gates.rs
+++ b/examples/sha256/table16/message_schedule/schedule_gates.rs
@@ -1,364 +1,374 @@
-use super::super::Gate;
+use super::super::gates;
 use halo2::{arithmetic::FieldExt, plonk::Expression};
 
-pub struct ScheduleGate<F: FieldExt>(pub Expression<F>);
+/// s_word for W_16 to W_63
+#[allow(clippy::too_many_arguments)]
+pub fn s_word<F: FieldExt>(
+    s_word: Expression<F>,
+    sigma_0_lo: Expression<F>,
+    sigma_0_hi: Expression<F>,
+    sigma_1_lo: Expression<F>,
+    sigma_1_hi: Expression<F>,
+    w_minus_9_lo: Expression<F>,
+    w_minus_9_hi: Expression<F>,
+    w_minus_16_lo: Expression<F>,
+    w_minus_16_hi: Expression<F>,
+    word: Expression<F>,
+    carry: Expression<F>,
+) -> Vec<Expression<F>> {
+    let lo = sigma_0_lo + sigma_1_lo + w_minus_9_lo + w_minus_16_lo;
+    let hi = sigma_0_hi + sigma_1_hi + w_minus_9_hi + w_minus_16_hi;
 
-impl<F: FieldExt> ScheduleGate<F> {
-    /// s_word for W_16 to W_63
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_word(
-        s_word: Expression<F>,
-        sigma_0_lo: Expression<F>,
-        sigma_0_hi: Expression<F>,
-        sigma_1_lo: Expression<F>,
-        sigma_1_hi: Expression<F>,
-        w_minus_9_lo: Expression<F>,
-        w_minus_9_hi: Expression<F>,
-        w_minus_16_lo: Expression<F>,
-        w_minus_16_hi: Expression<F>,
-        word: Expression<F>,
-        carry: Expression<F>,
-    ) -> Self {
-        let lo = sigma_0_lo + sigma_1_lo + w_minus_9_lo + w_minus_16_lo;
-        let hi = sigma_0_hi + sigma_1_hi + w_minus_9_hi + w_minus_16_hi;
+    let word_check = lo
+        + hi * F::from_u64(1 << 16)
+        + (carry.clone() * F::from_u64(1 << 32) * (-F::one()))
+        + (word * (-F::one()));
+    let carry_check = gates::range_check(carry, 0, 3);
 
-        let word_check = lo
-            + hi * F::from_u64(1 << 16)
-            + (carry.clone() * F::from_u64(1 << 32) * (-F::one()))
-            + (word * (-F::one()));
-        let carry_check = Gate::range_check(carry, 0, 3);
+    [word_check, carry_check]
+        .iter()
+        .map(|expr| s_word.clone() * expr.clone())
+        .collect()
+}
 
-        ScheduleGate(s_word * (word_check + carry_check))
-    }
+/// s_decompose_0 for all words
+pub fn s_decompose_0<F: FieldExt>(
+    s_decompose_0: Expression<F>,
+    lo: Expression<F>,
+    hi: Expression<F>,
+    word: Expression<F>,
+) -> Vec<Expression<F>> {
+    vec![s_decompose_0 * (lo + hi * F::from_u64(1 << 16) + word * (-F::one()))]
+}
 
-    /// s_decompose_0 for all words
-    pub fn s_decompose_0(
-        s_decompose_0: Expression<F>,
-        lo: Expression<F>,
-        hi: Expression<F>,
-        word: Expression<F>,
-    ) -> Self {
-        ScheduleGate(s_decompose_0 * (lo + hi * F::from_u64(1 << 16) + word * (-F::one())))
-    }
+/// s_decompose_1 for W_1 to W_13
+/// (3, 4, 11, 14)-bit chunks
+#[allow(clippy::too_many_arguments)]
+pub fn s_decompose_1<F: FieldExt>(
+    s_decompose_1: Expression<F>,
+    a: Expression<F>,
+    b: Expression<F>,
+    c: Expression<F>,
+    tag_c: Expression<F>,
+    d: Expression<F>,
+    tag_d: Expression<F>,
+    word: Expression<F>,
+) -> Vec<Expression<F>> {
+    let decompose_check = a
+        + b * F::from_u64(1 << 3)
+        + c * F::from_u64(1 << 7)
+        + d * F::from_u64(1 << 18)
+        + word * (-F::one());
+    let range_check_tag_c = gates::range_check(tag_c, 0, 2);
+    let range_check_tag_d = gates::range_check(tag_d, 0, 4);
 
-    /// s_decompose_1 for W_1 to W_13
-    /// (3, 4, 11, 14)-bit chunks
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_decompose_1(
-        s_decompose_1: Expression<F>,
-        a: Expression<F>,
-        b: Expression<F>,
-        c: Expression<F>,
-        tag_c: Expression<F>,
-        d: Expression<F>,
-        tag_d: Expression<F>,
-        word: Expression<F>,
-    ) -> Self {
-        let decompose_check = a
-            + b * F::from_u64(1 << 3)
-            + c * F::from_u64(1 << 7)
-            + d * F::from_u64(1 << 18)
-            + word * (-F::one());
-        let range_check_tag_c = Gate::range_check(tag_c, 0, 2);
-        let range_check_tag_d = Gate::range_check(tag_d, 0, 4);
-        ScheduleGate(s_decompose_1 * (decompose_check + range_check_tag_c + range_check_tag_d))
-    }
+    [decompose_check, range_check_tag_c, range_check_tag_d]
+        .iter()
+        .map(|expr| s_decompose_1.clone() * expr.clone())
+        .collect()
+}
 
-    /// s_decompose_2 for W_14 to W_48
-    /// (3, 4, 3, 7, 1, 1, 13)-bit chunks
-    #[allow(clippy::many_single_char_names)]
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_decompose_2(
-        s_decompose_2: Expression<F>,
-        a: Expression<F>,
-        b: Expression<F>,
-        c: Expression<F>,
-        d: Expression<F>,
-        tag_d: Expression<F>,
-        e: Expression<F>,
-        f: Expression<F>,
-        g: Expression<F>,
-        tag_g: Expression<F>,
-        word: Expression<F>,
-    ) -> Self {
-        let decompose_check = a
-            + b * F::from_u64(1 << 3)
-            + c * F::from_u64(1 << 7)
-            + d * F::from_u64(1 << 10)
-            + e * F::from_u64(1 << 17)
-            + f * F::from_u64(1 << 18)
-            + g * F::from_u64(1 << 19)
-            + word * (-F::one());
-        let range_check_tag_d = Gate::range_check(tag_d, 0, 0);
-        let range_check_tag_g = Gate::range_check(tag_g, 0, 3);
-        ScheduleGate(s_decompose_2 * (decompose_check + range_check_tag_g + range_check_tag_d))
-    }
+/// s_decompose_2 for W_14 to W_48
+/// (3, 4, 3, 7, 1, 1, 13)-bit chunks
+#[allow(clippy::many_single_char_names)]
+#[allow(clippy::too_many_arguments)]
+pub fn s_decompose_2<F: FieldExt>(
+    s_decompose_2: Expression<F>,
+    a: Expression<F>,
+    b: Expression<F>,
+    c: Expression<F>,
+    d: Expression<F>,
+    tag_d: Expression<F>,
+    e: Expression<F>,
+    f: Expression<F>,
+    g: Expression<F>,
+    tag_g: Expression<F>,
+    word: Expression<F>,
+) -> Vec<Expression<F>> {
+    let decompose_check = a
+        + b * F::from_u64(1 << 3)
+        + c * F::from_u64(1 << 7)
+        + d * F::from_u64(1 << 10)
+        + e * F::from_u64(1 << 17)
+        + f * F::from_u64(1 << 18)
+        + g * F::from_u64(1 << 19)
+        + word * (-F::one());
+    let range_check_tag_d = gates::range_check(tag_d, 0, 0);
+    let range_check_tag_g = gates::range_check(tag_g, 0, 3);
 
-    /// s_decompose_3 for W_49 to W_61
-    /// (10, 7, 2, 13)-bit chunks
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_decompose_3(
-        s_decompose_3: Expression<F>,
-        a: Expression<F>,
-        tag_a: Expression<F>,
-        b: Expression<F>,
-        c: Expression<F>,
-        d: Expression<F>,
-        tag_d: Expression<F>,
-        word: Expression<F>,
-    ) -> Self {
-        let decompose_check = a
-            + b * F::from_u64(1 << 10)
-            + c * F::from_u64(1 << 17)
-            + d * F::from_u64(1 << 19)
-            + word * (-F::one());
-        let range_check_tag_a = Gate::range_check(tag_a, 0, 1);
-        let range_check_tag_d = Gate::range_check(tag_d, 0, 3);
+    [decompose_check, range_check_tag_g, range_check_tag_d]
+        .iter()
+        .map(|expr| s_decompose_2.clone() * expr.clone())
+        .collect()
+}
 
-        ScheduleGate(s_decompose_3 * (decompose_check + range_check_tag_a + range_check_tag_d))
-    }
+/// s_decompose_3 for W_49 to W_61
+/// (10, 7, 2, 13)-bit chunks
+#[allow(clippy::too_many_arguments)]
+pub fn s_decompose_3<F: FieldExt>(
+    s_decompose_3: Expression<F>,
+    a: Expression<F>,
+    tag_a: Expression<F>,
+    b: Expression<F>,
+    c: Expression<F>,
+    d: Expression<F>,
+    tag_d: Expression<F>,
+    word: Expression<F>,
+) -> Vec<Expression<F>> {
+    let decompose_check = a
+        + b * F::from_u64(1 << 10)
+        + c * F::from_u64(1 << 17)
+        + d * F::from_u64(1 << 19)
+        + word * (-F::one());
+    let range_check_tag_a = gates::range_check(tag_a, 0, 1);
+    let range_check_tag_d = gates::range_check(tag_d, 0, 3);
 
-    /// b_lo + 2^2 * b_mid = b, on W_[1..49]
-    fn check_b(b: Expression<F>, b_lo: Expression<F>, b_hi: Expression<F>) -> Expression<F> {
-        let expected_b = b_lo + b_hi * F::from_u64(1 << 2);
-        expected_b + (b * -F::one())
-    }
+    [decompose_check, range_check_tag_a, range_check_tag_d]
+        .iter()
+        .map(|expr| s_decompose_3.clone() * expr.clone())
+        .collect()
+}
 
-    /// b_lo + 2^2 * b_mid + 2^4 * b_hi = b, on W_[49..62]
-    fn check_b1(
-        b: Expression<F>,
-        b_lo: Expression<F>,
-        b_mid: Expression<F>,
-        b_hi: Expression<F>,
-    ) -> Expression<F> {
-        let expected_b = b_lo + b_mid * F::from_u64(1 << 2) + b_hi * F::from_u64(1 << 4);
-        expected_b + (b * -F::one())
-    }
+/// b_lo + 2^2 * b_mid = b, on W_[1..49]
+fn check_b<F: FieldExt>(
+    b: Expression<F>,
+    b_lo: Expression<F>,
+    b_hi: Expression<F>,
+) -> Expression<F> {
+    let expected_b = b_lo + b_hi * F::from_u64(1 << 2);
+    expected_b + (b * -F::one())
+}
 
-    /// sigma_0 v1 on W_1 to W_13
-    /// (3, 4, 11, 14)-bit chunks
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_lower_sigma_0(
-        s_lower_sigma_0: Expression<F>,
-        spread_r0_even: Expression<F>,
-        spread_r0_odd: Expression<F>,
-        spread_r1_even: Expression<F>,
-        spread_r1_odd: Expression<F>,
-        a: Expression<F>,
-        spread_a: Expression<F>,
-        b: Expression<F>,
-        b_lo: Expression<F>,
-        spread_b_lo: Expression<F>,
-        b_hi: Expression<F>,
-        spread_b_hi: Expression<F>,
-        spread_c: Expression<F>,
-        spread_d: Expression<F>,
-    ) -> Self {
-        let check_spread_and_range =
-            Gate::two_bit_spread_and_range(b_lo.clone(), spread_b_lo.clone())
-                + Gate::two_bit_spread_and_range(b_hi.clone(), spread_b_hi.clone())
-                + Gate::three_bit_spread_and_range(a, spread_a.clone());
-        let check_b = Self::check_b(b, b_lo, b_hi);
-        let spread_witness = spread_r0_even
-            + spread_r0_odd * F::from_u64(2)
-            + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
-        let xor_0 = spread_b_lo.clone()
-            + spread_b_hi.clone() * F::from_u64(1 << 4)
-            + spread_c.clone() * F::from_u64(1 << 8)
-            + spread_d.clone() * F::from_u64(1 << 30);
-        let xor_1 = spread_c.clone()
-            + spread_d.clone() * F::from_u64(1 << 22)
-            + spread_a.clone() * F::from_u64(1 << 50)
-            + spread_b_lo.clone() * F::from_u64(1 << 56)
-            + spread_b_hi.clone() * F::from_u64(1 << 60);
-        let xor_2 = spread_d
-            + spread_a * F::from_u64(1 << 28)
-            + spread_b_lo * F::from_u64(1 << 34)
-            + spread_b_hi * F::from_u64(1 << 38)
-            + spread_c * F::from_u64(1 << 42);
-        let xor = xor_0 + xor_1 + xor_2;
+/// b_lo + 2^2 * b_mid + 2^4 * b_hi = b, on W_[49..62]
+fn check_b1<F: FieldExt>(
+    b: Expression<F>,
+    b_lo: Expression<F>,
+    b_mid: Expression<F>,
+    b_hi: Expression<F>,
+) -> Expression<F> {
+    let expected_b = b_lo + b_mid * F::from_u64(1 << 2) + b_hi * F::from_u64(1 << 4);
+    expected_b + (b * -F::one())
+}
 
-        ScheduleGate(
-            s_lower_sigma_0
-                * (check_spread_and_range + check_b + spread_witness + (xor * -F::one())),
-        )
-    }
+/// sigma_0 v1 on W_1 to W_13
+/// (3, 4, 11, 14)-bit chunks
+#[allow(clippy::too_many_arguments)]
+pub fn s_lower_sigma_0<F: FieldExt>(
+    s_lower_sigma_0: Expression<F>,
+    spread_r0_even: Expression<F>,
+    spread_r0_odd: Expression<F>,
+    spread_r1_even: Expression<F>,
+    spread_r1_odd: Expression<F>,
+    a: Expression<F>,
+    spread_a: Expression<F>,
+    b: Expression<F>,
+    b_lo: Expression<F>,
+    spread_b_lo: Expression<F>,
+    b_hi: Expression<F>,
+    spread_b_hi: Expression<F>,
+    spread_c: Expression<F>,
+    spread_d: Expression<F>,
+) -> Vec<Expression<F>> {
+    let check_b = check_b(b, b_lo.clone(), b_hi.clone());
+    let spread_witness = spread_r0_even
+        + spread_r0_odd * F::from_u64(2)
+        + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
+    let xor_0 = spread_b_lo.clone()
+        + spread_b_hi.clone() * F::from_u64(1 << 4)
+        + spread_c.clone() * F::from_u64(1 << 8)
+        + spread_d.clone() * F::from_u64(1 << 30);
+    let xor_1 = spread_c.clone()
+        + spread_d.clone() * F::from_u64(1 << 22)
+        + spread_a.clone() * F::from_u64(1 << 50)
+        + spread_b_lo.clone() * F::from_u64(1 << 56)
+        + spread_b_hi.clone() * F::from_u64(1 << 60);
+    let xor_2 = spread_d
+        + spread_a.clone() * F::from_u64(1 << 28)
+        + spread_b_lo.clone() * F::from_u64(1 << 34)
+        + spread_b_hi.clone() * F::from_u64(1 << 38)
+        + spread_c.clone() * F::from_u64(1 << 42);
+    let xor = xor_0 + xor_1 + xor_2;
 
-    /// sigma_1 v1 on W_49 to W_61
-    /// (10, 7, 2, 13)-bit chunks
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_lower_sigma_1(
-        s_lower_sigma_1: Expression<F>,
-        spread_r0_even: Expression<F>,
-        spread_r0_odd: Expression<F>,
-        spread_r1_even: Expression<F>,
-        spread_r1_odd: Expression<F>,
-        spread_a: Expression<F>,
-        b: Expression<F>,
-        b_lo: Expression<F>,
-        spread_b_lo: Expression<F>,
-        b_mid: Expression<F>,
-        spread_b_mid: Expression<F>,
-        b_hi: Expression<F>,
-        spread_b_hi: Expression<F>,
-        c: Expression<F>,
-        spread_c: Expression<F>,
-        spread_d: Expression<F>,
-    ) -> Self {
-        let check_spread_and_range =
-            Gate::two_bit_spread_and_range(b_lo.clone(), spread_b_lo.clone())
-                + Gate::two_bit_spread_and_range(b_mid.clone(), spread_b_mid.clone())
-                + Gate::two_bit_spread_and_range(c, spread_c.clone())
-                + Gate::three_bit_spread_and_range(b_hi.clone(), spread_b_hi.clone());
-        let check_b1 = Self::check_b1(b, b_lo, b_mid, b_hi);
-        let spread_witness = spread_r0_even
-            + spread_r0_odd * F::from_u64(2)
-            + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
-        let xor_0 = spread_b_lo.clone()
-            + spread_b_mid.clone() * F::from_u64(1 << 4)
-            + spread_b_hi.clone() * F::from_u64(1 << 8)
-            + spread_c.clone() * F::from_u64(1 << 14)
-            + spread_d.clone() * F::from_u64(1 << 18);
-        let xor_1 = spread_c.clone()
-            + spread_d.clone() * F::from_u64(1 << 4)
-            + spread_a.clone() * F::from_u64(1 << 30)
-            + spread_b_lo.clone() * F::from_u64(1 << 50)
-            + spread_b_mid.clone() * F::from_u64(1 << 54)
-            + spread_b_hi.clone() * F::from_u64(1 << 58);
-        let xor_2 = spread_d
-            + spread_a * F::from_u64(1 << 26)
-            + spread_b_lo * F::from_u64(1 << 46)
-            + spread_b_mid * F::from_u64(1 << 50)
-            + spread_b_hi * F::from_u64(1 << 54)
-            + spread_c * F::from_u64(1 << 60);
-        let xor = xor_0 + xor_1 + xor_2;
+    [check_b, spread_witness + (xor * -F::one())]
+        .iter()
+        .chain(gates::two_bit_spread_and_range(b_lo, spread_b_lo).iter())
+        .chain(gates::two_bit_spread_and_range(b_hi, spread_b_hi).iter())
+        .chain(gates::three_bit_spread_and_range(a, spread_a).iter())
+        .map(|expr| s_lower_sigma_0.clone() * expr.clone())
+        .collect()
+}
 
-        ScheduleGate(
-            s_lower_sigma_1
-                * (check_spread_and_range + check_b1 + spread_witness + (xor * -F::one())),
-        )
-    }
+/// sigma_1 v1 on W_49 to W_61
+/// (10, 7, 2, 13)-bit chunks
+#[allow(clippy::too_many_arguments)]
+pub fn s_lower_sigma_1<F: FieldExt>(
+    s_lower_sigma_1: Expression<F>,
+    spread_r0_even: Expression<F>,
+    spread_r0_odd: Expression<F>,
+    spread_r1_even: Expression<F>,
+    spread_r1_odd: Expression<F>,
+    spread_a: Expression<F>,
+    b: Expression<F>,
+    b_lo: Expression<F>,
+    spread_b_lo: Expression<F>,
+    b_mid: Expression<F>,
+    spread_b_mid: Expression<F>,
+    b_hi: Expression<F>,
+    spread_b_hi: Expression<F>,
+    c: Expression<F>,
+    spread_c: Expression<F>,
+    spread_d: Expression<F>,
+) -> Vec<Expression<F>> {
+    let check_b1 = check_b1(b, b_lo.clone(), b_mid.clone(), b_hi.clone());
+    let spread_witness = spread_r0_even
+        + spread_r0_odd * F::from_u64(2)
+        + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
+    let xor_0 = spread_b_lo.clone()
+        + spread_b_mid.clone() * F::from_u64(1 << 4)
+        + spread_b_hi.clone() * F::from_u64(1 << 8)
+        + spread_c.clone() * F::from_u64(1 << 14)
+        + spread_d.clone() * F::from_u64(1 << 18);
+    let xor_1 = spread_c.clone()
+        + spread_d.clone() * F::from_u64(1 << 4)
+        + spread_a.clone() * F::from_u64(1 << 30)
+        + spread_b_lo.clone() * F::from_u64(1 << 50)
+        + spread_b_mid.clone() * F::from_u64(1 << 54)
+        + spread_b_hi.clone() * F::from_u64(1 << 58);
+    let xor_2 = spread_d
+        + spread_a.clone() * F::from_u64(1 << 26)
+        + spread_b_lo.clone() * F::from_u64(1 << 46)
+        + spread_b_mid.clone() * F::from_u64(1 << 50)
+        + spread_b_hi.clone() * F::from_u64(1 << 54)
+        + spread_c.clone() * F::from_u64(1 << 60);
+    let xor = xor_0 + xor_1 + xor_2;
 
-    /// sigma_0 v2 on W_14 to W_48
-    /// (3, 4, 3, 7, 1, 1, 13)-bit chunks
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_lower_sigma_0_v2(
-        s_lower_sigma_0_v2: Expression<F>,
-        spread_r0_even: Expression<F>,
-        spread_r0_odd: Expression<F>,
-        spread_r1_even: Expression<F>,
-        spread_r1_odd: Expression<F>,
-        a: Expression<F>,
-        spread_a: Expression<F>,
-        b: Expression<F>,
-        b_lo: Expression<F>,
-        spread_b_lo: Expression<F>,
-        b_hi: Expression<F>,
-        spread_b_hi: Expression<F>,
-        c: Expression<F>,
-        spread_c: Expression<F>,
-        spread_d: Expression<F>,
-        spread_e: Expression<F>,
-        spread_f: Expression<F>,
-        spread_g: Expression<F>,
-    ) -> Self {
-        let check_spread_and_range =
-            Gate::two_bit_spread_and_range(b_lo.clone(), spread_b_lo.clone())
-                + Gate::two_bit_spread_and_range(b_hi.clone(), spread_b_hi.clone())
-                + Gate::three_bit_spread_and_range(a, spread_a.clone())
-                + Gate::three_bit_spread_and_range(c, spread_c.clone());
-        let check_b = Self::check_b(b, b_lo, b_hi);
-        let spread_witness = spread_r0_even
-            + spread_r0_odd * F::from_u64(2)
-            + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
-        let xor_0 = spread_b_lo.clone()
-            + spread_b_hi.clone() * F::from_u64(1 << 4)
-            + spread_c.clone() * F::from_u64(1 << 8)
-            + spread_d.clone() * F::from_u64(1 << 14)
-            + spread_e.clone() * F::from_u64(1 << 28)
-            + spread_f.clone() * F::from_u64(1 << 30)
-            + spread_g.clone() * F::from_u64(1 << 32);
-        let xor_1 = spread_c.clone()
-            + spread_d.clone() * F::from_u64(1 << 6)
-            + spread_e.clone() * F::from_u64(1 << 20)
-            + spread_f.clone() * F::from_u64(1 << 22)
-            + spread_g.clone() * F::from_u64(1 << 24)
-            + spread_a.clone() * F::from_u64(1 << 50)
-            + spread_b_lo.clone() * F::from_u64(1 << 56)
-            + spread_b_hi.clone() * F::from_u64(1 << 60);
-        let xor_2 = spread_f
-            + spread_g * F::from_u64(1 << 2)
-            + spread_a * F::from_u64(1 << 28)
-            + spread_b_lo * F::from_u64(1 << 34)
-            + spread_b_hi * F::from_u64(1 << 38)
-            + spread_c * F::from_u64(1 << 42)
-            + spread_d * F::from_u64(1 << 48)
-            + spread_e * F::from_u64(1 << 62);
-        let xor = xor_0 + xor_1 + xor_2;
+    [check_b1, spread_witness + (xor * -F::one())]
+        .iter()
+        .chain(gates::two_bit_spread_and_range(b_lo, spread_b_lo).iter())
+        .chain(gates::two_bit_spread_and_range(b_mid, spread_b_mid).iter())
+        .chain(gates::two_bit_spread_and_range(c, spread_c).iter())
+        .chain(gates::three_bit_spread_and_range(b_hi, spread_b_hi).iter())
+        .map(|expr| s_lower_sigma_1.clone() * expr.clone())
+        .collect()
+}
 
-        ScheduleGate(
-            s_lower_sigma_0_v2
-                * (check_spread_and_range + check_b + spread_witness + (xor * -F::one())),
-        )
-    }
+/// sigma_0 v2 on W_14 to W_48
+/// (3, 4, 3, 7, 1, 1, 13)-bit chunks
+#[allow(clippy::too_many_arguments)]
+pub fn s_lower_sigma_0_v2<F: FieldExt>(
+    s_lower_sigma_0_v2: Expression<F>,
+    spread_r0_even: Expression<F>,
+    spread_r0_odd: Expression<F>,
+    spread_r1_even: Expression<F>,
+    spread_r1_odd: Expression<F>,
+    a: Expression<F>,
+    spread_a: Expression<F>,
+    b: Expression<F>,
+    b_lo: Expression<F>,
+    spread_b_lo: Expression<F>,
+    b_hi: Expression<F>,
+    spread_b_hi: Expression<F>,
+    c: Expression<F>,
+    spread_c: Expression<F>,
+    spread_d: Expression<F>,
+    spread_e: Expression<F>,
+    spread_f: Expression<F>,
+    spread_g: Expression<F>,
+) -> Vec<Expression<F>> {
+    let check_b = check_b(b, b_lo.clone(), b_hi.clone());
+    let spread_witness = spread_r0_even
+        + spread_r0_odd * F::from_u64(2)
+        + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
+    let xor_0 = spread_b_lo.clone()
+        + spread_b_hi.clone() * F::from_u64(1 << 4)
+        + spread_c.clone() * F::from_u64(1 << 8)
+        + spread_d.clone() * F::from_u64(1 << 14)
+        + spread_e.clone() * F::from_u64(1 << 28)
+        + spread_f.clone() * F::from_u64(1 << 30)
+        + spread_g.clone() * F::from_u64(1 << 32);
+    let xor_1 = spread_c.clone()
+        + spread_d.clone() * F::from_u64(1 << 6)
+        + spread_e.clone() * F::from_u64(1 << 20)
+        + spread_f.clone() * F::from_u64(1 << 22)
+        + spread_g.clone() * F::from_u64(1 << 24)
+        + spread_a.clone() * F::from_u64(1 << 50)
+        + spread_b_lo.clone() * F::from_u64(1 << 56)
+        + spread_b_hi.clone() * F::from_u64(1 << 60);
+    let xor_2 = spread_f
+        + spread_g * F::from_u64(1 << 2)
+        + spread_a.clone() * F::from_u64(1 << 28)
+        + spread_b_lo.clone() * F::from_u64(1 << 34)
+        + spread_b_hi.clone() * F::from_u64(1 << 38)
+        + spread_c.clone() * F::from_u64(1 << 42)
+        + spread_d * F::from_u64(1 << 48)
+        + spread_e * F::from_u64(1 << 62);
+    let xor = xor_0 + xor_1 + xor_2;
 
-    /// sigma_1 v2 on W_14 to W_48
-    /// (3, 4, 3, 7, 1, 1, 13)-bit chunks
-    #[allow(clippy::too_many_arguments)]
-    pub fn s_lower_sigma_1_v2(
-        s_lower_sigma_1_v2: Expression<F>,
-        spread_r0_even: Expression<F>,
-        spread_r0_odd: Expression<F>,
-        spread_r1_even: Expression<F>,
-        spread_r1_odd: Expression<F>,
-        a: Expression<F>,
-        spread_a: Expression<F>,
-        b: Expression<F>,
-        b_lo: Expression<F>,
-        spread_b_lo: Expression<F>,
-        b_hi: Expression<F>,
-        spread_b_hi: Expression<F>,
-        c: Expression<F>,
-        spread_c: Expression<F>,
-        spread_d: Expression<F>,
-        spread_e: Expression<F>,
-        spread_f: Expression<F>,
-        spread_g: Expression<F>,
-    ) -> Self {
-        let check_spread_and_range =
-            Gate::two_bit_spread_and_range(b_lo.clone(), spread_b_lo.clone())
-                + Gate::two_bit_spread_and_range(b_hi.clone(), spread_b_hi.clone())
-                + Gate::three_bit_spread_and_range(a, spread_a.clone())
-                + Gate::three_bit_spread_and_range(c, spread_c.clone());
-        let check_b = Self::check_b(b, b_lo, b_hi);
-        let spread_witness = spread_r0_even
-            + spread_r0_odd * F::from_u64(2)
-            + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
-        let xor_0 = spread_d.clone()
-            + spread_e.clone() * F::from_u64(1 << 14)
-            + spread_f.clone() * F::from_u64(1 << 16)
-            + spread_g.clone() * F::from_u64(1 << 18);
-        let xor_1 = spread_e.clone()
-            + spread_f.clone() * F::from_u64(1 << 2)
-            + spread_g.clone() * F::from_u64(1 << 4)
-            + spread_a.clone() * F::from_u64(1 << 30)
-            + spread_b_lo.clone() * F::from_u64(1 << 36)
-            + spread_b_hi.clone() * F::from_u64(1 << 40)
-            + spread_c.clone() * F::from_u64(1 << 44)
-            + spread_d.clone() * F::from_u64(1 << 50);
-        let xor_2 = spread_g
-            + spread_a * F::from_u64(1 << 26)
-            + spread_b_lo * F::from_u64(1 << 32)
-            + spread_b_hi * F::from_u64(1 << 36)
-            + spread_c * F::from_u64(1 << 40)
-            + spread_d * F::from_u64(1 << 46)
-            + spread_e * F::from_u64(1 << 60)
-            + spread_f * F::from_u64(1 << 62);
-        let xor = xor_0 + xor_1 + xor_2;
+    [check_b, spread_witness + (xor * -F::one())]
+        .iter()
+        .chain(gates::two_bit_spread_and_range(b_lo, spread_b_lo).iter())
+        .chain(gates::two_bit_spread_and_range(b_hi, spread_b_hi).iter())
+        .chain(gates::three_bit_spread_and_range(a, spread_a).iter())
+        .chain(gates::three_bit_spread_and_range(c, spread_c).iter())
+        .map(|expr| s_lower_sigma_0_v2.clone() * expr.clone())
+        .collect()
+}
 
-        ScheduleGate(
-            s_lower_sigma_1_v2
-                * (check_spread_and_range + check_b + spread_witness + (xor * -F::one())),
-        )
-    }
+/// sigma_1 v2 on W_14 to W_48
+/// (3, 4, 3, 7, 1, 1, 13)-bit chunks
+#[allow(clippy::too_many_arguments)]
+pub fn s_lower_sigma_1_v2<F: FieldExt>(
+    s_lower_sigma_1_v2: Expression<F>,
+    spread_r0_even: Expression<F>,
+    spread_r0_odd: Expression<F>,
+    spread_r1_even: Expression<F>,
+    spread_r1_odd: Expression<F>,
+    a: Expression<F>,
+    spread_a: Expression<F>,
+    b: Expression<F>,
+    b_lo: Expression<F>,
+    spread_b_lo: Expression<F>,
+    b_hi: Expression<F>,
+    spread_b_hi: Expression<F>,
+    c: Expression<F>,
+    spread_c: Expression<F>,
+    spread_d: Expression<F>,
+    spread_e: Expression<F>,
+    spread_f: Expression<F>,
+    spread_g: Expression<F>,
+) -> Vec<Expression<F>> {
+    let check_b = check_b(b, b_lo.clone(), b_hi.clone());
+    let spread_witness = spread_r0_even
+        + spread_r0_odd * F::from_u64(2)
+        + (spread_r1_even + spread_r1_odd * F::from_u64(2)) * F::from_u64(1 << 32);
+    let xor_0 = spread_d.clone()
+        + spread_e.clone() * F::from_u64(1 << 14)
+        + spread_f.clone() * F::from_u64(1 << 16)
+        + spread_g.clone() * F::from_u64(1 << 18);
+    let xor_1 = spread_e.clone()
+        + spread_f.clone() * F::from_u64(1 << 2)
+        + spread_g.clone() * F::from_u64(1 << 4)
+        + spread_a.clone() * F::from_u64(1 << 30)
+        + spread_b_lo.clone() * F::from_u64(1 << 36)
+        + spread_b_hi.clone() * F::from_u64(1 << 40)
+        + spread_c.clone() * F::from_u64(1 << 44)
+        + spread_d.clone() * F::from_u64(1 << 50);
+    let xor_2 = spread_g
+        + spread_a.clone() * F::from_u64(1 << 26)
+        + spread_b_lo.clone() * F::from_u64(1 << 32)
+        + spread_b_hi.clone() * F::from_u64(1 << 36)
+        + spread_c.clone() * F::from_u64(1 << 40)
+        + spread_d * F::from_u64(1 << 46)
+        + spread_e * F::from_u64(1 << 60)
+        + spread_f * F::from_u64(1 << 62);
+    let xor = xor_0 + xor_1 + xor_2;
+
+    [check_b, spread_witness + (xor * -F::one())]
+        .iter()
+        .chain(gates::two_bit_spread_and_range(b_lo, spread_b_lo).iter())
+        .chain(gates::two_bit_spread_and_range(b_hi, spread_b_hi).iter())
+        .chain(gates::three_bit_spread_and_range(a, spread_a).iter())
+        .chain(gates::three_bit_spread_and_range(c, spread_c).iter())
+        .map(|expr| s_lower_sigma_1_v2.clone() * expr.clone())
+        .collect()
 }


### PR DESCRIPTION
This PR adjusts the SHA256 example to use the new `create_gate()` API which returns a vector of expressions (#273).