### PR TITLE
Enable annotating individual constraints within gates

### DIFF
--- a/examples/simple-example.rs
+++ b/examples/simple-example.rs
@@ -364,6 +364,7 @@ fn main() {
             gate_index: 1,
             gate_name: "public input",
             constraint_index: 0,
+            constraint_name: "",
             row: 6,
         }])
     );

--- a/examples/two-chip.rs
+++ b/examples/two-chip.rs
@@ -631,6 +631,7 @@ fn main() {
             gate_index: 0,
             gate_name: "public input",
             constraint_index: 0,
+            constraint_name: "",
             row: 7,
         }])
     );

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -59,7 +59,7 @@ pub enum VerifyFailure {
         /// `Circuit::configure`.
         constraint_index: usize,
         /// The name of the unsatisfied constraint. This is specified by the gate creator
-        /// (such as a chip implementation), and may not be unique.
+        /// (such as a chip implementation), and is not enforced to be unique.
         constraint_name: &'static str,
         /// The row on which this constraint is not satisfied.
         row: usize,


### PR DESCRIPTION
The closure passed to `ConstraintSystem::create_gate` can now return:

- Tuples of `(&'static str, Expression<F>)`
- Anything implementing `IntoIterator` (e.g. `Some(Expression<F>)`)