### PR TITLE
Remove rotations from Selectors

### DIFF
--- a/examples/simple-example.rs
+++ b/examples/simple-example.rs
@@ -108,7 +108,7 @@ impl<F: FieldExt> FieldChip<F> {
             let lhs = meta.query_advice(advice[0], Rotation::cur());
             let rhs = meta.query_advice(advice[1], Rotation::cur());
             let out = meta.query_advice(advice[0], Rotation::next());
-            let s_mul = meta.query_selector(s_mul, Rotation::cur());
+            let s_mul = meta.query_selector(s_mul);
 
             // Finally, we return the polynomial expressions that constrain this gate.
             // For our multiplication gate, we only need a single polynomial constraint.
@@ -127,7 +127,7 @@ impl<F: FieldExt> FieldChip<F> {
             // column for exposing numbers as public inputs.
             let a = meta.query_advice(advice[1], Rotation::cur());
             let p = meta.query_instance(instance, Rotation::cur());
-            let s = meta.query_selector(s_pub, Rotation::cur());
+            let s = meta.query_selector(s_pub);
 
             // We simply constrain the advice cell to be equal to the instance cell,
             // when the selector is enabled.

--- a/examples/two-chip.rs
+++ b/examples/two-chip.rs
@@ -179,7 +179,7 @@ impl<F: FieldExt> AddChip<F> {
             let lhs = meta.query_advice(advice[0], Rotation::cur());
             let rhs = meta.query_advice(advice[1], Rotation::cur());
             let out = meta.query_advice(advice[0], Rotation::next());
-            let s_add = meta.query_selector(s_add, Rotation::cur());
+            let s_add = meta.query_selector(s_add);
 
             vec![s_add * (lhs + rhs + out * -F::one())]
         });
@@ -317,7 +317,7 @@ impl<F: FieldExt> MulChip<F> {
             let lhs = meta.query_advice(advice[0], Rotation::cur());
             let rhs = meta.query_advice(advice[1], Rotation::cur());
             let out = meta.query_advice(advice[0], Rotation::next());
-            let s_mul = meta.query_selector(s_mul, Rotation::cur());
+            let s_mul = meta.query_selector(s_mul);
 
             // The polynomial expression returned from `create_gate` will be
             // constrained by the proving system to equal zero. Our expression
@@ -455,7 +455,7 @@ impl<F: FieldExt> FieldChip<F> {
             // column for exposing numbers as public inputs.
             let a = meta.query_advice(advice[1], Rotation::cur());
             let p = meta.query_instance(instance, Rotation::cur());
-            let s = meta.query_selector(s_pub, Rotation::cur());
+            let s = meta.query_selector(s_pub);
 
             // We simply constrain the advice cell to be equal to the instance cell,
             // when the selector is enabled.

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -1,7 +1,6 @@
 //! Tools for developing circuits.
 
 use std::collections::HashMap;
-use std::convert::TryInto;
 use std::fmt;
 use std::iter;
 
@@ -403,7 +402,6 @@ impl<F: FieldExt> MockProver<F> {
             .flat_map(|(gate_index, gate)| {
                 gate.queried_selectors()
                     .iter()
-                    .map(|vc| (Selector(vc.column.try_into().unwrap()), vc.rotation))
                     // Assume that if a queried selector is enabled, the user wants to use the
                     // corresponding gate in some way.
                     //
@@ -411,14 +409,11 @@ impl<F: FieldExt> MockProver<F> {
                     // un-enabled keeps a gate enabled. We could alternatively require that
                     // every selector is explicitly enabled or disabled on every row? But that
                     // seems messy and confusing.
-                    .filter_map(|(s, rotation)| {
-                        self.enabled_selectors.get(&s).map(|at| (at, rotation))
-                    })
-                    .flat_map(move |(at, rotation)| {
+                    .filter_map(|s| self.enabled_selectors.get(&s))
+                    .flat_map(move |at| {
                         at.iter().flat_map(move |selector_row| {
-                            // Determine the gate instance's logical row from the selector's
-                            // concrete row and its rotation in the gate.
-                            let gate_row = (*selector_row as i32 + n - rotation.0) % n;
+                            // Selectors are queried with no rotation.
+                            let gate_row = *selector_row as i32;
 
                             gate.queried_cells().iter().filter_map(move |cell| {
                                 // Determine where this cell should have been assigned.
@@ -668,7 +663,7 @@ mod tests {
                 meta.create_gate("Equality check", |cells| {
                     let a = cells.query_advice(a, Rotation::prev());
                     let b = cells.query_advice(b, Rotation::cur());
-                    let q = cells.query_selector(q, Rotation::cur());
+                    let q = cells.query_selector(q);
 
                     // If q is enabled, a and b must be assigned to.
                     vec![q * (a - b)]


### PR DESCRIPTION
Enabling selectors to be used in gates at non-zero rotations leads to
confusing gates, and inhibits our ability to create visualizations of
circuits. In most cases, a gate can be rearranged so that the selectors
have no rotation; in cases where cross-gate selector optimisations are
required, these can still be implemented using fixed columns.