### PR TITLE
CI: Build book with latest mdbook

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@v1
         with:
-          mdbook-version: '0.4.5'
+          mdbook-version: 'latest'
 
       - name: Install mdbook-katex
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
`mdbook-katex` is installed from crates.io, and if it doesn't use the same version of `mdbook` it can cause build issues.