### PR TITLE
Add support for batched inversion of cell assignments

### DIFF
--- a/src/circuit/layouter.rs
+++ b/src/circuit/layouter.rs
@@ -5,6 +5,7 @@ use std::collections::HashSet;
 use std::fmt;
 
 use super::{Cell, RegionIndex};
+use crate::plonk::Assigned;
 use crate::{
     arithmetic::FieldExt,
     plonk::{Advice, Any, Column, Error, Fixed, Permutation, Selector},
@@ -61,7 +62,7 @@ pub trait RegionLayouter<F: FieldExt>: fmt::Debug {
         annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Advice>,
         offset: usize,
-        to: &'v mut (dyn FnMut() -> Result<F, Error> + 'v),
+        to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
     ) -> Result<Cell, Error>;
 
     /// Assign a fixed value
@@ -70,7 +71,7 @@ pub trait RegionLayouter<F: FieldExt>: fmt::Debug {
         annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Fixed>,
         offset: usize,
-        to: &'v mut (dyn FnMut() -> Result<F, Error> + 'v),
+        to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
     ) -> Result<Cell, Error>;
 
     /// Constraint two cells to have the same value.
@@ -138,7 +139,7 @@ impl<F: FieldExt> RegionLayouter<F> for RegionShape {
         _: &'v (dyn Fn() -> String + 'v),
         column: Column<Advice>,
         offset: usize,
-        _to: &'v mut (dyn FnMut() -> Result<F, Error> + 'v),
+        _to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
     ) -> Result<Cell, Error> {
         self.columns.insert(column.into());
         self.row_count = cmp::max(self.row_count, offset + 1);
@@ -155,7 +156,7 @@ impl<F: FieldExt> RegionLayouter<F> for RegionShape {
         _: &'v (dyn Fn() -> String + 'v),
         column: Column<Fixed>,
         offset: usize,
-        _to: &'v mut (dyn FnMut() -> Result<F, Error> + 'v),
+        _to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
     ) -> Result<Cell, Error> {
         self.columns.insert(column.into());
         self.row_count = cmp::max(self.row_count, offset + 1);

--- a/src/circuit/layouter/single_pass.rs
+++ b/src/circuit/layouter/single_pass.rs
@@ -4,6 +4,7 @@ use std::fmt;
 use std::marker::PhantomData;
 
 use super::{RegionLayouter, RegionShape};
+use crate::plonk::Assigned;
 use crate::{
     arithmetic::FieldExt,
     circuit::{Cell, Layouter, Region, RegionIndex, RegionStart},
@@ -147,7 +148,7 @@ impl<'r, 'a, F: FieldExt, CS: Assignment<F> + 'a> RegionLayouter<F>
         annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Advice>,
         offset: usize,
-        to: &'v mut (dyn FnMut() -> Result<F, Error> + 'v),
+        to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
     ) -> Result<Cell, Error> {
         self.layouter.cs.assign_advice(
             annotation,
@@ -168,7 +169,7 @@ impl<'r, 'a, F: FieldExt, CS: Assignment<F> + 'a> RegionLayouter<F>
         annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Fixed>,
         offset: usize,
-        to: &'v mut (dyn FnMut() -> Result<F, Error> + 'v),
+        to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
     ) -> Result<Cell, Error> {
         self.layouter.cs.assign_fixed(
             annotation,

--- a/src/circuit/layouter/v1.rs
+++ b/src/circuit/layouter/v1.rs
@@ -2,6 +2,7 @@ use std::fmt;
 use std::marker::PhantomData;
 
 use super::{RegionLayouter, RegionShape};
+use crate::plonk::Assigned;
 use crate::{
     arithmetic::FieldExt,
     circuit::{Cell, Layouter, Region, RegionIndex, RegionStart},
@@ -231,7 +232,7 @@ impl<'r, 'a, F: FieldExt, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region
         annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Advice>,
         offset: usize,
-        to: &'v mut (dyn FnMut() -> Result<F, Error> + 'v),
+        to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
     ) -> Result<Cell, Error> {
         self.layouter.cs.assign_advice(
             annotation,
@@ -252,7 +253,7 @@ impl<'r, 'a, F: FieldExt, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region
         annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Fixed>,
         offset: usize,
-        to: &'v mut (dyn FnMut() -> Result<F, Error> + 'v),
+        to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
     ) -> Result<Cell, Error> {
         self.layouter.cs.assign_fixed(
             annotation,

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -6,6 +6,7 @@ use std::iter;
 
 use ff::Field;
 
+use crate::plonk::Assigned;
 use crate::{
     arithmetic::{FieldExt, Group},
     plonk::{
@@ -278,7 +279,7 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         self.assign_fixed(annotation, selector.0, row, || Ok(F::one()))
     }
 
-    fn assign_advice<V, A, AR>(
+    fn assign_advice<V, VR, A, AR>(
         &mut self,
         _: A,
         column: Column<Advice>,
@@ -286,7 +287,8 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         to: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<F, Error>,
+        V: FnOnce() -> Result<VR, Error>,
+        VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
@@ -294,12 +296,12 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
             .advice
             .get_mut(column.index())
             .and_then(|v| v.get_mut(row))
-            .ok_or(Error::BoundsFailure)? = Some(to()?);
+            .ok_or(Error::BoundsFailure)? = Some(to()?.into().evaluate());
 
         Ok(())
     }
 
-    fn assign_fixed<V, A, AR>(
+    fn assign_fixed<V, VR, A, AR>(
         &mut self,
         _: A,
         column: Column<Fixed>,
@@ -307,7 +309,8 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         to: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<F, Error>,
+        V: FnOnce() -> Result<VR, Error>,
+        VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
@@ -315,7 +318,7 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
             .fixed
             .get_mut(column.index())
             .and_then(|v| v.get_mut(row))
-            .ok_or(Error::BoundsFailure)? = Some(to()?);
+            .ok_or(Error::BoundsFailure)? = Some(to()?.into().evaluate());
 
         Ok(())
     }

--- a/src/dev/graph.rs
+++ b/src/dev/graph.rs
@@ -2,7 +2,8 @@ use ff::Field;
 use tabbycat::{AttrList, Edge, GraphBuilder, GraphType, Identity, StmtList};
 
 use crate::plonk::{
-    Advice, Any, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed, Permutation, Selector,
+    Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
+    Permutation, Selector,
 };
 
 pub mod layout;
@@ -95,7 +96,7 @@ impl<F: Field> Assignment<F> for Graph {
         Ok(())
     }
 
-    fn assign_advice<V, A, AR>(
+    fn assign_advice<V, VR, A, AR>(
         &mut self,
         _: A,
         _: Column<Advice>,
@@ -103,7 +104,8 @@ impl<F: Field> Assignment<F> for Graph {
         _: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<F, Error>,
+        V: FnOnce() -> Result<VR, Error>,
+        VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
@@ -111,7 +113,7 @@ impl<F: Field> Assignment<F> for Graph {
         Ok(())
     }
 
-    fn assign_fixed<V, A, AR>(
+    fn assign_fixed<V, VR, A, AR>(
         &mut self,
         _: A,
         _: Column<Fixed>,
@@ -119,7 +121,8 @@ impl<F: Field> Assignment<F> for Graph {
         _: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<F, Error>,
+        V: FnOnce() -> Result<VR, Error>,
+        VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
     {

--- a/src/dev/graph/layout.rs
+++ b/src/dev/graph/layout.rs
@@ -8,7 +8,8 @@ use std::collections::HashSet;
 use std::ops::Range;
 
 use crate::plonk::{
-    Advice, Any, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed, Permutation, Selector,
+    Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
+    Permutation, Selector,
 };
 
 /// Graphical renderer for circuit layouts.
@@ -307,7 +308,7 @@ impl<F: Field> Assignment<F> for Layout {
         self.assign_fixed(annotation, selector.0, row, || Ok(F::one()))
     }
 
-    fn assign_advice<V, A, AR>(
+    fn assign_advice<V, VR, A, AR>(
         &mut self,
         _: A,
         column: Column<Advice>,
@@ -315,7 +316,8 @@ impl<F: Field> Assignment<F> for Layout {
         _: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<F, Error>,
+        V: FnOnce() -> Result<VR, Error>,
+        VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
     {
@@ -323,7 +325,7 @@ impl<F: Field> Assignment<F> for Layout {
         Ok(())
     }
 
-    fn assign_fixed<V, A, AR>(
+    fn assign_fixed<V, VR, A, AR>(
         &mut self,
         _: A,
         column: Column<Fixed>,
@@ -331,7 +333,8 @@ impl<F: Field> Assignment<F> for Layout {
         _: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<F, Error>,
+        V: FnOnce() -> Result<VR, Error>,
+        VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
     {

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -366,6 +366,14 @@ impl<F: Field> Assigned<F> {
         self.denominator
     }
 
+    /// Inverts this assigned value.
+    pub fn invert(&self) -> Self {
+        Assigned {
+            numerator: self.denominator,
+            denominator: self.numerator,
+        }
+    }
+
     /// Evaluates this assigned value directly, performing an unbatched inversion if
     /// necessary.
     ///

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -291,6 +291,70 @@ impl<F: Field> From<(F, F)> for Assigned<F> {
     }
 }
 
+impl<F: Field> Neg for Assigned<F> {
+    type Output = Assigned<F>;
+    fn neg(self) -> Self::Output {
+        Assigned {
+            numerator: -self.numerator,
+            denominator: self.denominator,
+        }
+    }
+}
+
+impl<F: Field> Add for Assigned<F> {
+    type Output = Assigned<F>;
+    fn add(self, rhs: Assigned<F>) -> Assigned<F> {
+        Assigned {
+            numerator: self.numerator * rhs.denominator + self.denominator * rhs.numerator,
+            denominator: self.denominator * rhs.denominator,
+        }
+    }
+}
+
+impl<F: Field> Add<F> for Assigned<F> {
+    type Output = Assigned<F>;
+    fn add(self, rhs: F) -> Assigned<F> {
+        Assigned {
+            numerator: self.numerator + self.denominator * rhs,
+            denominator: self.denominator,
+        }
+    }
+}
+
+impl<F: Field> Sub for Assigned<F> {
+    type Output = Assigned<F>;
+    fn sub(self, rhs: Assigned<F>) -> Assigned<F> {
+        self + (-rhs)
+    }
+}
+
+impl<F: Field> Sub<F> for Assigned<F> {
+    type Output = Assigned<F>;
+    fn sub(self, rhs: F) -> Assigned<F> {
+        self + (-rhs)
+    }
+}
+
+impl<F: Field> Mul for Assigned<F> {
+    type Output = Assigned<F>;
+    fn mul(self, rhs: Assigned<F>) -> Assigned<F> {
+        Assigned {
+            numerator: self.numerator * rhs.numerator,
+            denominator: self.denominator * rhs.denominator,
+        }
+    }
+}
+
+impl<F: Field> Mul<F> for Assigned<F> {
+    type Output = Assigned<F>;
+    fn mul(self, rhs: F) -> Assigned<F> {
+        Assigned {
+            numerator: self.numerator * rhs,
+            denominator: self.denominator,
+        }
+    }
+}
+
 impl<F: Field> Assigned<F> {
     /// Returns the numerator.
     pub fn numerator(&self) -> F {

--- a/src/plonk/keygen.rs
+++ b/src/plonk/keygen.rs
@@ -5,11 +5,11 @@ use super::{
     circuit::{Advice, Any, Assignment, Circuit, Column, ConstraintSystem, Fixed, Selector},
     permutation, Assigned, Error, LagrangeCoeff, Permutation, Polynomial, ProvingKey, VerifyingKey,
 };
-use crate::arithmetic::CurveAffine;
 use crate::poly::{
     commitment::{Blind, Params},
     EvaluationDomain, Rotation,
 };
+use crate::{arithmetic::CurveAffine, poly::batch_invert_assigned};
 
 pub(crate) fn create_domain<C, ConcreteCircuit>(
     params: &Params<C>,
@@ -35,7 +35,7 @@ where
 /// Assembly to be used in circuit synthesis.
 #[derive(Debug)]
 struct Assembly<F: Field> {
-    fixed: Vec<Polynomial<F, LagrangeCoeff>>,
+    fixed: Vec<Polynomial<Assigned<F>, LagrangeCoeff>>,
     permutations: Vec<permutation::keygen::Assembly>,
     _marker: std::marker::PhantomData<F>,
 }
@@ -105,7 +105,7 @@ impl<F: Field> Assignment<F> for Assembly<F> {
             .fixed
             .get_mut(column.index())
             .and_then(|v| v.get_mut(row))
-            .ok_or(Error::BoundsFailure)? = to()?.into().evaluate();
+            .ok_or(Error::BoundsFailure)? = to()?.into();
 
         Ok(())
     }
@@ -167,7 +167,7 @@ where
     let (domain, cs, config) = create_domain::<C, ConcreteCircuit>(params);
 
     let mut assembly: Assembly<C::Scalar> = Assembly {
-        fixed: vec![domain.empty_lagrange(); cs.num_fixed_columns],
+        fixed: vec![domain.empty_lagrange_assigned(); cs.num_fixed_columns],
         permutations: cs
             .permutations
             .iter()
@@ -179,6 +179,8 @@ where
     // Synthesize the circuit to obtain URS
     circuit.synthesize(&mut assembly, config)?;
 
+    let fixed = batch_invert_assigned(&assembly.fixed);
+
     let permutation_helper = permutation::keygen::Assembly::build_helper(params, &cs, &domain);
 
     let permutation_vks = cs
@@ -188,8 +190,7 @@ where
         .map(|(p, assembly)| assembly.build_vk(params, &domain, &permutation_helper, p))
         .collect();
 
-    let fixed_commitments = assembly
-        .fixed
+    let fixed_commitments = fixed
         .iter()
         .map(|poly| params.commit_lagrange(poly, Blind::default()).to_affine())
         .collect();
@@ -216,7 +217,7 @@ where
     let config = ConcreteCircuit::configure(&mut cs);
 
     let mut assembly: Assembly<C::Scalar> = Assembly {
-        fixed: vec![vk.domain.empty_lagrange(); vk.cs.num_fixed_columns],
+        fixed: vec![vk.domain.empty_lagrange_assigned(); vk.cs.num_fixed_columns],
         permutations: vk
             .cs
             .permutations
@@ -229,8 +230,9 @@ where
     // Synthesize the circuit to obtain URS
     circuit.synthesize(&mut assembly, config)?;
 
-    let fixed_polys: Vec<_> = assembly
-        .fixed
+    let fixed = batch_invert_assigned(&assembly.fixed);
+
+    let fixed_polys: Vec<_> = fixed
         .iter()
         .map(|poly| vk.domain.lagrange_to_coeff(poly.clone()))
         .collect();
@@ -266,7 +268,7 @@ where
     Ok(ProvingKey {
         vk,
         l0,
-        fixed_values: assembly.fixed,
+        fixed_values: fixed,
         fixed_polys,
         fixed_cosets,
         permutations: permutation_pks,

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -3,8 +3,11 @@
 //! the committed polynomials at arbitrary points.
 
 use crate::arithmetic::parallelize;
+use crate::arithmetic::BatchInvert;
+use crate::plonk::Assigned;
 
 use ff::Field;
+use pasta_curves::arithmetic::FieldExt;
 use std::fmt::Debug;
 use std::marker::PhantomData;
 use std::ops::{Add, Deref, DerefMut, Index, IndexMut, Mul, RangeFrom, RangeFull, Sub};
@@ -125,6 +128,50 @@ impl<F, B> Polynomial<F, B> {
     /// coefficients used to describe it.
     pub fn num_coeffs(&self) -> usize {
         self.values.len()
+    }
+}
+
+pub(crate) fn batch_invert_assigned<F: FieldExt>(
+    assigned: &[Polynomial<Assigned<F>, LagrangeCoeff>],
+) -> Vec<Polynomial<F, LagrangeCoeff>> {
+    let mut assigned_denominators: Vec<_> = assigned
+        .iter()
+        .map(|f| {
+            f.iter()
+                .map(|value| value.denominator())
+                .collect::<Vec<_>>()
+        })
+        .collect();
+
+    assigned_denominators
+        .iter_mut()
+        .flat_map(|f| {
+            f.iter_mut()
+                // If the denominator is zero or one, we can skip it, reducing the
+                // size of the batch inversion.
+                .filter(|d| !(d.is_zero() || **d == F::one()))
+        })
+        .batch_invert();
+
+    assigned
+        .iter()
+        .zip(assigned_denominators.into_iter())
+        .map(|(poly, inv_denoms)| poly.invert(inv_denoms))
+        .collect()
+}
+
+impl<F: Field> Polynomial<Assigned<F>, LagrangeCoeff> {
+    pub(crate) fn invert(&self, inv_denoms: Vec<F>) -> Polynomial<F, LagrangeCoeff> {
+        assert_eq!(inv_denoms.len(), self.values.len());
+        Polynomial {
+            values: self
+                .values
+                .iter()
+                .zip(inv_denoms.into_iter())
+                .map(|(a, inv_den)| a.numerator() * inv_den)
+                .collect(),
+            _marker: self._marker,
+        }
     }
 }
 

--- a/src/poly/domain.rs
+++ b/src/poly/domain.rs
@@ -1,7 +1,10 @@
 //! Contains utilities for performing polynomial arithmetic over an evaluation
 //! domain that is of a suitable size for the application.
 
-use crate::arithmetic::{best_fft, parallelize, BatchInvert, FieldExt, Group};
+use crate::{
+    arithmetic::{best_fft, parallelize, BatchInvert, FieldExt, Group},
+    plonk::Assigned,
+};
 
 use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation};
 
@@ -173,6 +176,18 @@ impl<G: Group> EvaluationDomain<G> {
     pub fn empty_lagrange(&self) -> Polynomial<G, LagrangeCoeff> {
         Polynomial {
             values: vec![G::group_zero(); self.n as usize],
+            _marker: PhantomData,
+        }
+    }
+
+    /// Returns an empty (zero) polynomial in the Lagrange coefficient basis, with
+    /// deferred inversions.
+    pub(crate) fn empty_lagrange_assigned(&self) -> Polynomial<Assigned<G>, LagrangeCoeff>
+    where
+        G: Field,
+    {
+        Polynomial {
+            values: vec![G::group_zero().into(); self.n as usize],
             _marker: PhantomData,
         }
     }


### PR DESCRIPTION
Value closures passed to `assign_advice` and `assign_fixed` can now return a `(numerator, denominator)` tuple, in order to defer inversions until after assignment.