### PR TITLE
Migrate PLONK-gate-using circuits to use SingleChipLayouter

### DIFF
--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -3,6 +3,8 @@ extern crate criterion;
 
 extern crate halo2;
 use halo2::arithmetic::FieldExt;
+use halo2::circuit::layouter::SingleChipLayouter;
+use halo2::circuit::{Cell, Layouter};
 use halo2::pasta::{EqAffine, Fp};
 use halo2::plonk::*;
 use halo2::poly::{commitment::Params, Rotation};
@@ -35,13 +37,21 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
     }
 
     trait StandardCS<FF: FieldExt> {
-        fn raw_multiply<F>(&mut self, f: F) -> Result<(Variable, Variable, Variable), Error>
+        fn raw_multiply<F>(
+            &self,
+            layouter: &mut impl Layouter<FF>,
+            f: F,
+        ) -> Result<(Cell, Cell, Cell), Error>
         where
-            F: FnOnce() -> Result<(FF, FF, FF), Error>;
-        fn raw_add<F>(&mut self, f: F) -> Result<(Variable, Variable, Variable), Error>
+            F: FnMut() -> Result<(FF, FF, FF), Error>;
+        fn raw_add<F>(
+            &self,
+            layouter: &mut impl Layouter<FF>,
+            f: F,
+        ) -> Result<(Cell, Cell, Cell), Error>
         where
-            F: FnOnce() -> Result<(FF, FF, FF), Error>;
-        fn copy(&mut self, a: Variable, b: Variable) -> Result<(), Error>;
+            F: FnMut() -> Result<(FF, FF, FF), Error>;
+        fn copy(&self, layouter: &mut impl Layouter<FF>, a: Cell, b: Cell) -> Result<(), Error>;
     }
 
     #[derive(Clone)]
@@ -50,118 +60,114 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
         k: u32,
     }
 
-    struct StandardPLONK<'a, F: FieldExt, CS: Assignment<F> + 'a> {
-        cs: &'a mut CS,
+    struct StandardPLONK<F: FieldExt> {
         config: PLONKConfig,
-        current_gate: usize,
         _marker: PhantomData<F>,
     }
 
-    impl<'a, FF: FieldExt, CS: Assignment<FF>> StandardPLONK<'a, FF, CS> {
-        fn new(cs: &'a mut CS, config: PLONKConfig) -> Self {
+    impl<FF: FieldExt> StandardPLONK<FF> {
+        fn new(config: PLONKConfig) -> Self {
             StandardPLONK {
-                cs,
                 config,
-                current_gate: 0,
                 _marker: PhantomData,
             }
         }
     }
 
-    impl<'a, FF: FieldExt, CS: Assignment<FF>> StandardCS<FF> for StandardPLONK<'a, FF, CS> {
-        fn raw_multiply<F>(&mut self, f: F) -> Result<(Variable, Variable, Variable), Error>
+    impl<FF: FieldExt> StandardCS<FF> for StandardPLONK<FF> {
+        fn raw_multiply<F>(
+            &self,
+            layouter: &mut impl Layouter<FF>,
+            mut f: F,
+        ) -> Result<(Cell, Cell, Cell), Error>
         where
-            F: FnOnce() -> Result<(FF, FF, FF), Error>,
+            F: FnMut() -> Result<(FF, FF, FF), Error>,
         {
-            let index = self.current_gate;
-            self.current_gate += 1;
-            let mut value = None;
-            self.cs.assign_advice(
-                || "lhs",
-                self.config.a,
-                index,
-                || {
-                    value = Some(f()?);
-                    Ok(value.ok_or(Error::SynthesisError)?.0)
-                },
-            )?;
-            self.cs.assign_advice(
-                || "rhs",
-                self.config.b,
-                index,
-                || Ok(value.ok_or(Error::SynthesisError)?.1),
-            )?;
-            self.cs.assign_advice(
-                || "out",
-                self.config.c,
-                index,
-                || Ok(value.ok_or(Error::SynthesisError)?.2),
-            )?;
+            layouter.assign_region(
+                || "raw_multiply",
+                |mut region| {
+                    let mut value = None;
+                    let lhs = region.assign_advice(
+                        || "lhs",
+                        self.config.a,
+                        0,
+                        || {
+                            value = Some(f()?);
+                            Ok(value.ok_or(Error::SynthesisError)?.0)
+                        },
+                    )?;
+                    let rhs = region.assign_advice(
+                        || "rhs",
+                        self.config.b,
+                        0,
+                        || Ok(value.ok_or(Error::SynthesisError)?.1),
+                    )?;
+                    let out = region.assign_advice(
+                        || "out",
+                        self.config.c,
+                        0,
+                        || Ok(value.ok_or(Error::SynthesisError)?.2),
+                    )?;
 
-            self.cs
-                .assign_fixed(|| "a", self.config.sa, index, || Ok(FF::zero()))?;
-            self.cs
-                .assign_fixed(|| "b", self.config.sb, index, || Ok(FF::zero()))?;
-            self.cs
-                .assign_fixed(|| "c", self.config.sc, index, || Ok(FF::one()))?;
-            self.cs
-                .assign_fixed(|| "a * b", self.config.sm, index, || Ok(FF::one()))?;
-            Ok((
-                Variable(self.config.a, index),
-                Variable(self.config.b, index),
-                Variable(self.config.c, index),
-            ))
+                    region.assign_fixed(|| "a", self.config.sa, 0, || Ok(FF::zero()))?;
+                    region.assign_fixed(|| "b", self.config.sb, 0, || Ok(FF::zero()))?;
+                    region.assign_fixed(|| "c", self.config.sc, 0, || Ok(FF::one()))?;
+                    region.assign_fixed(|| "a * b", self.config.sm, 0, || Ok(FF::one()))?;
+                    Ok((lhs, rhs, out))
+                },
+            )
         }
-        fn raw_add<F>(&mut self, f: F) -> Result<(Variable, Variable, Variable), Error>
+        fn raw_add<F>(
+            &self,
+            layouter: &mut impl Layouter<FF>,
+            mut f: F,
+        ) -> Result<(Cell, Cell, Cell), Error>
         where
-            F: FnOnce() -> Result<(FF, FF, FF), Error>,
+            F: FnMut() -> Result<(FF, FF, FF), Error>,
         {
-            let index = self.current_gate;
-            self.current_gate += 1;
-            let mut value = None;
-            self.cs.assign_advice(
-                || "lhs",
-                self.config.a,
-                index,
-                || {
-                    value = Some(f()?);
-                    Ok(value.ok_or(Error::SynthesisError)?.0)
-                },
-            )?;
-            self.cs.assign_advice(
-                || "rhs",
-                self.config.b,
-                index,
-                || Ok(value.ok_or(Error::SynthesisError)?.1),
-            )?;
-            self.cs.assign_advice(
-                || "out",
-                self.config.c,
-                index,
-                || Ok(value.ok_or(Error::SynthesisError)?.2),
-            )?;
+            layouter.assign_region(
+                || "raw_add",
+                |mut region| {
+                    let mut value = None;
+                    let lhs = region.assign_advice(
+                        || "lhs",
+                        self.config.a,
+                        0,
+                        || {
+                            value = Some(f()?);
+                            Ok(value.ok_or(Error::SynthesisError)?.0)
+                        },
+                    )?;
+                    let rhs = region.assign_advice(
+                        || "rhs",
+                        self.config.b,
+                        0,
+                        || Ok(value.ok_or(Error::SynthesisError)?.1),
+                    )?;
+                    let out = region.assign_advice(
+                        || "out",
+                        self.config.c,
+                        0,
+                        || Ok(value.ok_or(Error::SynthesisError)?.2),
+                    )?;
 
-            self.cs
-                .assign_fixed(|| "a", self.config.sa, index, || Ok(FF::one()))?;
-            self.cs
-                .assign_fixed(|| "b", self.config.sb, index, || Ok(FF::one()))?;
-            self.cs
-                .assign_fixed(|| "c", self.config.sc, index, || Ok(FF::one()))?;
-            self.cs
-                .assign_fixed(|| "a * b", self.config.sm, index, || Ok(FF::zero()))?;
-            Ok((
-                Variable(self.config.a, index),
-                Variable(self.config.b, index),
-                Variable(self.config.c, index),
-            ))
+                    region.assign_fixed(|| "a", self.config.sa, 0, || Ok(FF::one()))?;
+                    region.assign_fixed(|| "b", self.config.sb, 0, || Ok(FF::one()))?;
+                    region.assign_fixed(|| "c", self.config.sc, 0, || Ok(FF::one()))?;
+                    region.assign_fixed(|| "a * b", self.config.sm, 0, || Ok(FF::zero()))?;
+                    Ok((lhs, rhs, out))
+                },
+            )
         }
-        fn copy(&mut self, left: Variable, right: Variable) -> Result<(), Error> {
-            self.cs.copy(
-                &self.config.perm,
-                left.0.into(),
-                left.1,
-                right.0.into(),
-                right.1,
+        fn copy(
+            &self,
+            layouter: &mut impl Layouter<FF>,
+            left: Cell,
+            right: Cell,
+        ) -> Result<(), Error> {
+            layouter.assign_region(
+                || "copy",
+                |mut region| region.constrain_equal(&self.config.perm, left, right),
             )
         }
     }
@@ -211,11 +217,12 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
             cs: &mut impl Assignment<F>,
             config: PLONKConfig,
         ) -> Result<(), Error> {
-            let mut cs = StandardPLONK::new(cs, config);
+            let mut layouter = SingleChipLayouter::new(cs)?;
+            let cs = StandardPLONK::new(config);
 
             for _ in 0..(1 << (self.k - 1)) {
                 let mut a_squared = None;
-                let (a0, _, c0) = cs.raw_multiply(|| {
+                let (a0, _, c0) = cs.raw_multiply(&mut layouter, || {
                     a_squared = self.a.map(|a| a.square());
                     Ok((
                         self.a.ok_or(Error::SynthesisError)?,
@@ -223,7 +230,7 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
                         a_squared.ok_or(Error::SynthesisError)?,
                     ))
                 })?;
-                let (a1, b1, _) = cs.raw_add(|| {
+                let (a1, b1, _) = cs.raw_add(&mut layouter, || {
                     let fin = a_squared.and_then(|a2| self.a.map(|a| a + a2));
                     Ok((
                         self.a.ok_or(Error::SynthesisError)?,
@@ -231,8 +238,8 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
                         fin.ok_or(Error::SynthesisError)?,
                     ))
                 })?;
-                cs.copy(a0, a1)?;
-                cs.copy(b1, c0)?;
+                cs.copy(&mut layouter, a0, a1)?;
+                cs.copy(&mut layouter, b1, c0)?;
             }
 
             Ok(())


### PR DESCRIPTION
These were all early examples that used the `Circuit` trait without any layouter, which is incompatible with upcoming changes.

The minimal change to the `PinnedVerificationKey` is because the lookup table is being allocated at the top of its columns instead of in-place.