### PR TITLE
dev: Refactor VerifyFailure to extract metadata structs

### DIFF
--- a/examples/simple-example.rs
+++ b/examples/simple-example.rs
@@ -367,10 +367,7 @@ fn main() {
     assert_eq!(
         prover.verify(),
         Err(vec![VerifyFailure::Constraint {
-            gate_index: 1,
-            gate_name: "public input",
-            constraint_index: 0,
-            constraint_name: "",
+            constraint: ((1, "public input").into(), 0, "").into(),
             row: 6,
         }])
     );

--- a/examples/two-chip.rs
+++ b/examples/two-chip.rs
@@ -634,10 +634,7 @@ fn main() {
     assert_eq!(
         prover.verify(),
         Err(vec![VerifyFailure::Constraint {
-            gate_index: 0,
-            gate_name: "public input",
-            constraint_index: 0,
-            constraint_name: "",
+            constraint: ((0, "public input").into(), 0, "").into(),
             row: 7,
         }])
     );

--- a/src/dev/metadata.rs
+++ b/src/dev/metadata.rs
@@ -1,0 +1,86 @@
+//! Metadata about circuits.
+
+use std::fmt;
+
+/// Metadata about a configured gate within a circuit.
+#[derive(Debug, PartialEq)]
+pub struct Gate {
+    /// The index of the active gate. These indices are assigned in the order in which
+    /// `ConstraintSystem::create_gate` is called during `Circuit::configure`.
+    index: usize,
+    /// The name of the active gate. These are specified by the gate creator (such as
+    /// a chip implementation), and is not enforced to be unique.
+    name: &'static str,
+}
+
+impl fmt::Display for Gate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Gate {} ('{}')", self.index, self.name)
+    }
+}
+
+impl From<(usize, &'static str)> for Gate {
+    fn from((index, name): (usize, &'static str)) -> Self {
+        Gate { index, name }
+    }
+}
+
+/// Metadata about a configured constraint within a circuit.
+#[derive(Debug, PartialEq)]
+pub struct Constraint {
+    /// The gate containing the constraint.
+    gate: Gate,
+    /// The index of the polynomial constraint within the gate. These indices correspond
+    /// to the order in which the constraints are returned from the closure passed to
+    /// `ConstraintSystem::create_gate` during `Circuit::configure`.
+    index: usize,
+    /// The name of the constraint. This is specified by the gate creator (such as a chip
+    /// implementation), and is not enforced to be unique.
+    name: &'static str,
+}
+
+impl fmt::Display for Constraint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Constraint {}{} in gate {} ('{}')",
+            self.index,
+            if self.name.is_empty() {
+                String::new()
+            } else {
+                format!(" ('{}')", self.name)
+            },
+            self.gate.index,
+            self.gate.name,
+        )
+    }
+}
+
+impl From<(Gate, usize, &'static str)> for Constraint {
+    fn from((gate, index, name): (Gate, usize, &'static str)) -> Self {
+        Constraint { gate, index, name }
+    }
+}
+
+/// Metadata about an assigned region within a circuit.
+#[derive(Debug, PartialEq)]
+pub struct Region {
+    /// The index of the region. These indices are assigned in the order in which
+    /// `Layouter::assign_region` is called during `Circuit::synthesize`.
+    index: usize,
+    /// The name of the region. This is specified by the region creator (such as a chip
+    /// implementation), and is not enforced to be unique.
+    name: String,
+}
+
+impl fmt::Display for Region {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Region {} ('{}')", self.index, self.name)
+    }
+}
+
+impl From<(usize, String)> for Region {
+    fn from((index, name): (usize, String)) -> Self {
+        Region { index, name }
+    }
+}


### PR DESCRIPTION
This is a step towards making the metadata more reusable and developer-friendly.