### PR TITLE
Merge the common pieces of the permutation argument into a separate proof component

### DIFF
--- a/src/plonk/permutation/verifier.rs
+++ b/src/plonk/permutation/verifier.rs
@@ -10,6 +10,10 @@ use crate::{
     transcript::{EncodedChallenge, TranscriptRead},
 };
 
+pub struct CommonCommitted<C: CurveAffine> {
+    permutation_evals: Vec<C::Scalar>,
+}
+
 pub struct Committed<C: CurveAffine> {
     permutation_product_commitments: Vec<C>,
 }
@@ -23,7 +27,6 @@ pub struct EvaluatedSet<C: CurveAffine> {
 
 pub struct Evaluated<C: CurveAffine> {
     sets: Vec<EvaluatedSet<C>>,
-    permutation_evals: Vec<C::Scalar>,
 }
 
 impl Argument {
@@ -50,18 +53,26 @@ impl Argument {
     }
 }
 
-impl<C: CurveAffine> Committed<C> {
-    pub(crate) fn evaluate<E: EncodedChallenge<C>, T: TranscriptRead<C, E>>(
-        self,
-        vkey: &VerifyingKey<C>,
+impl<C: CurveAffine> VerifyingKey<C> {
+    pub(in crate::plonk) fn evaluate<E: EncodedChallenge<C>, T: TranscriptRead<C, E>>(
+        &self,
         transcript: &mut T,
-    ) -> Result<Evaluated<C>, Error> {
-        let permutation_evals = vkey
+    ) -> Result<CommonCommitted<C>, Error> {
+        let permutation_evals = self
             .commitments
             .iter()
             .map(|_| transcript.read_scalar().map_err(|_| Error::TranscriptError))
             .collect::<Result<Vec<_>, _>>()?;
 
+        Ok(CommonCommitted { permutation_evals })
+    }
+}
+
+impl<C: CurveAffine> Committed<C> {
+    pub(crate) fn evaluate<E: EncodedChallenge<C>, T: TranscriptRead<C, E>>(
+        self,
+        transcript: &mut T,
+    ) -> Result<Evaluated<C>, Error> {
         let mut sets = vec![];
 
         let mut iter = self.permutation_product_commitments.into_iter();
@@ -91,10 +102,7 @@ impl<C: CurveAffine> Committed<C> {
             });
         }
 
-        Ok(Evaluated {
-            sets,
-            permutation_evals,
-        })
+        Ok(Evaluated { sets })
     }
 }
 
@@ -103,6 +111,7 @@ impl<C: CurveAffine> Evaluated<C> {
         &'a self,
         vk: &'a plonk::VerifyingKey<C>,
         p: &'a Argument,
+        common: &'a CommonCommitted<C>,
         advice_evals: &'a [C::Scalar],
         fixed_evals: &'a [C::Scalar],
         instance_evals: &'a [C::Scalar],
@@ -152,7 +161,7 @@ impl<C: CurveAffine> Evaluated<C> {
                 self.sets
                     .iter()
                     .zip(p.columns.chunks(chunk_len))
-                    .zip(self.permutation_evals.chunks(chunk_len))
+                    .zip(common.permutation_evals.chunks(chunk_len))
                     .enumerate()
                     .map(move |(chunk_index, ((set, columns), permutation_evals))| {
                         let mut left = set.permutation_product_next_eval;
@@ -201,7 +210,6 @@ impl<C: CurveAffine> Evaluated<C> {
     pub(in crate::plonk) fn queries<'r, 'params: 'r>(
         &'r self,
         vk: &'r plonk::VerifyingKey<C>,
-        vkey: &'r VerifyingKey<C>,
         x: ChallengeX<C>,
     ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone {
         let blinding_factors = vk.cs.blinding_factors();
@@ -234,14 +242,19 @@ impl<C: CurveAffine> Evaluated<C> {
                     set.permutation_product_last_eval.unwrap(),
                 ))
             }))
-            // Open permutation commitments for each permutation argument at x
-            .chain(
-                vkey.commitments
-                    .iter()
-                    .zip(self.permutation_evals.iter())
-                    .map(move |(commitment, &eval)| {
-                        VerifierQuery::new_commitment(commitment, *x, eval)
-                    }),
-            )
+    }
+}
+
+impl<C: CurveAffine> CommonCommitted<C> {
+    pub(in crate::plonk) fn queries<'r, 'params: 'r>(
+        &'r self,
+        vkey: &'r VerifyingKey<C>,
+        x: ChallengeX<C>,
+    ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone {
+        // Open permutation commitments for each permutation argument at x
+        vkey.commitments
+            .iter()
+            .zip(self.permutation_evals.iter())
+            .map(move |(commitment, &eval)| VerifierQuery::new_commitment(commitment, *x, eval))
     }
 }

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -518,12 +518,13 @@ pub fn create_proof<
 
     let vanishing = vanishing.evaluate(x, xn, domain, transcript)?;
 
+    // Evaluate common permutation data
+    pk.permutation.evaluate(x, transcript)?;
+
     // Evaluate the permutations, if any, at omega^i x.
     let permutations: Vec<permutation::prover::Evaluated<C>> = permutations
         .into_iter()
-        .map(|permutation| -> Result<_, _> {
-            permutation.evaluate(pk, &pk.permutation, x, transcript)
-        })
+        .map(|permutation| -> Result<_, _> { permutation.evaluate(pk, x, transcript) })
         .collect::<Result<Vec<_>, _>>()?;
 
     // Evaluate the lookups, if any, at omega^i x.
@@ -566,7 +567,7 @@ pub fn create_proof<
                             blind: advice.advice_blinds[column.index()],
                         }),
                 )
-                .chain(permutation.open(pk, &pk.permutation, x))
+                .chain(permutation.open(pk, x))
                 .chain(lookups.iter().flat_map(move |p| p.open(pk, x)).into_iter())
         })
         .chain(
@@ -580,6 +581,7 @@ pub fn create_proof<
                     blind: Blind::default(),
                 }),
         )
+        .chain(pk.permutation.open(x))
         // We query the h(X) polynomial at x
         .chain(vanishing.open(x));
 


### PR DESCRIPTION
The permutation argument has some fixed polynomials (which define the permutation) that are evaluated at `x`. Right now the code evaluates them for every argument, but the evaluations do not vary across circuit instances. Similarly to how we merge fixed evaluations across circuit instances, we do the same with these permutation polynomial openings.

This reduces the proof size and proving time.