### PR TITLE
Add `RegionLayouter::constrain_instance` method

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -177,6 +177,17 @@ impl<'r, F: Field> Region<'r, F> {
         )
     }
 
+    /// Constrain a cell to equal an instance column's cell at absolute location
+    /// `row`.
+    pub fn constrain_instance(
+        &mut self,
+        cell: Cell,
+        instance: Column<Instance>,
+        row: usize,
+    ) -> Result<(), Error> {
+        self.region.constrain_instance(cell, instance, row)
+    }
+
     /// Assign a fixed value.
     ///
     /// Even though `to` has `FnMut` bounds, it is guaranteed to be called at most once.

--- a/src/circuit/floor_planner/single_pass.rs
+++ b/src/circuit/floor_planner/single_pass.rs
@@ -226,6 +226,20 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F>
         Ok((cell, value))
     }
 
+    fn constrain_instance<'v>(
+        &mut self,
+        cell: Cell,
+        instance: Column<Instance>,
+        row: usize,
+    ) -> Result<(), Error> {
+        self.layouter.cs.copy(
+            cell.column,
+            *self.layouter.regions[*cell.region_index] + cell.row_offset,
+            instance.into(),
+            row,
+        )
+    }
+
     fn assign_fixed<'v>(
         &'v mut self,
         annotation: &'v (dyn Fn() -> String + 'v),

--- a/src/circuit/floor_planner/v1.rs
+++ b/src/circuit/floor_planner/v1.rs
@@ -310,6 +310,20 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
         Ok((cell, value))
     }
 
+    fn constrain_instance<'v>(
+        &mut self,
+        cell: Cell,
+        instance: Column<Instance>,
+        row: usize,
+    ) -> Result<(), Error> {
+        self.plan.cs.copy(
+            cell.column,
+            *self.plan.regions[*cell.region_index] + cell.row_offset,
+            instance.into(),
+            row,
+        )
+    }
+
     fn assign_fixed<'v>(
         &'v mut self,
         annotation: &'v (dyn Fn() -> String + 'v),

--- a/src/circuit/layouter.rs
+++ b/src/circuit/layouter.rs
@@ -71,6 +71,15 @@ pub trait RegionLayouter<F: Field>: fmt::Debug {
         offset: usize,
     ) -> Result<(Cell, Option<F>), Error>;
 
+    /// Constrain a cell to equal an instance column's cell at absolute location
+    /// `row`.
+    fn constrain_instance(
+        &mut self,
+        cell: Cell,
+        instance: Column<Instance>,
+        row: usize,
+    ) -> Result<(), Error>;
+
     /// Assign a fixed value
     fn assign_fixed<'v>(
         &'v mut self,
@@ -171,6 +180,15 @@ impl<F: Field> RegionLayouter<F> for RegionShape {
             },
             None,
         ))
+    }
+
+    fn constrain_instance<'v>(
+        &mut self,
+        _cell: Cell,
+        _instance: Column<Instance>,
+        _row: usize,
+    ) -> Result<(), Error> {
+        Ok(())
     }
 
     fn assign_fixed<'v>(

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -66,7 +66,7 @@ pub enum VerifyFailure {
     /// A permutation did not preserve the original value of a cell.
     Permutation {
         /// The column in which this permutation is not satisfied.
-        column: Column<Any>,
+        column: metadata::Column,
         /// The row on which this permutation is not satisfied.
         row: usize,
     },
@@ -769,7 +769,8 @@ impl<F: FieldExt> MockProver<F> {
                             None
                         } else {
                             Some(VerifyFailure::Permutation {
-                                column: *self.cs.permutation.get_columns().get(column).unwrap(),
+                                column: (*self.cs.permutation.get_columns().get(column).unwrap())
+                                    .into(),
                                 row,
                             })
                         }

--- a/src/dev/metadata.rs
+++ b/src/dev/metadata.rs
@@ -1,6 +1,37 @@
 //! Metadata about circuits.
 
+use crate::plonk::{self, Any};
 use std::fmt;
+
+/// Metadata about a column within a circuit.
+#[derive(Debug, PartialEq)]
+pub struct Column {
+    /// The index of the column.
+    index: usize,
+    /// The type of the column.
+    column_type: Any,
+}
+
+impl fmt::Display for Column {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Column {} ('{:?}')", self.index, self.column_type)
+    }
+}
+
+impl From<(usize, Any)> for Column {
+    fn from((index, column_type): (usize, Any)) -> Self {
+        Column { index, column_type }
+    }
+}
+
+impl From<plonk::Column<Any>> for Column {
+    fn from(column: plonk::Column<Any>) -> Self {
+        Column {
+            index: column.index(),
+            column_type: *column.column_type(),
+        }
+    }
+}
 
 /// Metadata about a configured gate within a circuit.
 #[derive(Debug, PartialEq)]


### PR DESCRIPTION
This allows us to call `region.constrain_instance()` (where previously we had to call `layouter.constrain_instance()`.