### PR TITLE
`Expression::Negated`

### DIFF
--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -200,7 +200,7 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
                 let sc = meta.query_fixed(sc, Rotation::cur());
                 let sm = meta.query_fixed(sm, Rotation::cur());
 
-                vec![a.clone() * sa + b.clone() * sb + a * b * sm + (c * sc * (-F::one()))]
+                vec![a.clone() * sa + b.clone() * sb + a * b * sm - (c * sc)]
             });
 
             PlonkConfig {

--- a/examples/circuit-layout.rs
+++ b/examples/circuit-layout.rs
@@ -246,13 +246,7 @@ fn main() {
                 let sc = meta.query_fixed(sc, Rotation::cur());
                 let sm = meta.query_fixed(sm, Rotation::cur());
 
-                vec![
-                    a.clone() * sa
-                        + b.clone() * sb
-                        + a * b * sm
-                        + (c * sc * (-F::one()))
-                        + sf * (d * e),
-                ]
+                vec![a.clone() * sa + b.clone() * sb + a * b * sm - (c * sc) + sf * (d * e)]
             });
 
             PlonkConfig {

--- a/examples/simple-example.rs
+++ b/examples/simple-example.rs
@@ -118,7 +118,7 @@ impl<F: FieldExt> FieldChip<F> {
             // has the following properties:
             // - When s_mul = 0, any value is allowed in lhs, rhs, and out.
             // - When s_mul != 0, this constrains lhs * rhs = out.
-            vec![s_mul * (lhs * rhs + out * -F::one())]
+            vec![s_mul * (lhs * rhs - out)]
         });
 
         FieldConfig {

--- a/examples/two-chip.rs
+++ b/examples/two-chip.rs
@@ -170,7 +170,7 @@ impl<F: FieldExt> AddChip<F> {
             let out = meta.query_advice(advice[0], Rotation::next());
             let s_add = meta.query_selector(s_add);
 
-            vec![s_add * (lhs + rhs + out * -F::one())]
+            vec![s_add * (lhs + rhs - out)]
         });
 
         AddConfig { advice, s_add }
@@ -311,7 +311,7 @@ impl<F: FieldExt> MulChip<F> {
             // has the following properties:
             // - When s_mul = 0, any value is allowed in lhs, rhs, and out.
             // - When s_mul != 0, this constrains lhs * rhs = out.
-            vec![s_mul * (lhs * rhs + out * -F::one())]
+            vec![s_mul * (lhs * rhs - out)]
         });
 
         MulConfig { advice, s_mul }

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::fmt;
 use std::iter;
-use std::ops::{Add, Mul, Range};
+use std::ops::{Add, Mul, Neg, Range};
 
 use ff::Field;
 
@@ -165,6 +165,17 @@ impl<F: Group + Field> From<CellValue<F>> for Value<F> {
             CellValue::Unassigned => Value::Real(F::zero()),
             CellValue::Assigned(v) => Value::Real(v),
             CellValue::Poison(_) => Value::Poison,
+        }
+    }
+}
+
+impl<F: Group + Field> Neg for Value<F> {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        match self {
+            Value::Real(a) => Value::Real(-a),
+            _ => Value::Poison,
         }
     }
 }
@@ -654,6 +665,7 @@ impl<F: FieldExt> MockProver<F> {
                                 &load(n, row, &self.cs.fixed_queries, &self.fixed),
                                 &load(n, row, &self.cs.advice_queries, &self.advice),
                                 &load_instance(n, row, &self.cs.instance_queries, &self.instance),
+                                &|a| -a,
                                 &|a, b| a + b,
                                 &|a, b| a * b,
                                 &|a, scalar| a * scalar,
@@ -717,6 +729,7 @@ impl<F: FieldExt> MockProver<F> {
                                         [(row as i32 + n + rotation) as usize % n as usize],
                                 )
                             },
+                            &|a| -a,
                             &|a, b| a + b,
                             &|a, b| a * b,
                             &|a, scalar| a * scalar,

--- a/src/plonk/circuit/compress_selectors.rs
+++ b/src/plonk/circuit/compress_selectors.rs
@@ -328,6 +328,7 @@ mod tests {
                         },
                         &|_, _, _| panic!("should not occur in returned expressions"),
                         &|_, _, _| panic!("should not occur in returned expressions"),
+                        &|a| -a,
                         &|a, b| a + b,
                         &|a, b| a * b,
                         &|a, f| a * f,

--- a/src/plonk/lookup/prover.rs
+++ b/src/plonk/lookup/prover.rs
@@ -111,6 +111,7 @@ impl<F: FieldExt> Argument<F> {
                         &|_, column_index, rotation| {
                             instance_values[column_index].clone().rotate(rotation)
                         },
+                        &|a| -a,
                         &|a, b| a + &b,
                         &|a, b| {
                             let mut modified_a = vec![C::Scalar::one(); params.n as usize];
@@ -151,6 +152,7 @@ impl<F: FieldExt> Argument<F> {
                                 .domain
                                 .rotate_extended(&instance_cosets[column_index], rotation)
                         },
+                        &|a| -a,
                         &|a, b| a + &b,
                         &|a, b| a * &b,
                         &|a, scalar| a * scalar,

--- a/src/plonk/lookup/verifier.rs
+++ b/src/plonk/lookup/verifier.rs
@@ -138,6 +138,7 @@ impl<C: CurveAffine> Evaluated<C> {
                             &|index, _, _| fixed_evals[index],
                             &|index, _, _| advice_evals[index],
                             &|index, _, _| instance_evals[index],
+                            &|a| -a,
                             &|a, b| a + &b,
                             &|a, b| a * &b,
                             &|a, scalar| a * &scalar,

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -453,6 +453,7 @@ pub fn create_proof<
                                         rotation,
                                     )
                                 },
+                                &|a| -a,
                                 &|a, b| a + &b,
                                 &|a, b| a * &b,
                                 &|a, scalar| a * scalar,

--- a/src/plonk/verifier.rs
+++ b/src/plonk/verifier.rs
@@ -188,6 +188,7 @@ pub fn verify_proof<'params, C: CurveAffine, E: EncodedChallenge<C>, T: Transcri
                                 &|index, _, _| fixed_evals[index],
                                 &|index, _, _| advice_evals[index],
                                 &|index, _, _| instance_evals[index],
+                                &|a| -a,
                                 &|a, b| a + &b,
                                 &|a, b| a * &b,
                                 &|a, scalar| a * &scalar,

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -10,7 +10,7 @@ use ff::Field;
 use pasta_curves::arithmetic::FieldExt;
 use std::fmt::Debug;
 use std::marker::PhantomData;
-use std::ops::{Add, Deref, DerefMut, Index, IndexMut, Mul, RangeFrom, RangeFull, Sub};
+use std::ops::{Add, Deref, DerefMut, Index, IndexMut, Mul, Neg, RangeFrom, RangeFull, Sub};
 
 pub mod commitment;
 mod domain;
@@ -189,6 +189,20 @@ impl<F: Field> Polynomial<F, ExtendedLagrangeCoeff> {
             }
         });
         p
+    }
+}
+
+impl<'a, F: Field, B: Basis> Neg for Polynomial<F, B> {
+    type Output = Polynomial<F, B>;
+
+    fn neg(mut self) -> Polynomial<F, B> {
+        parallelize(&mut self.values, |lhs, _| {
+            for lhs in lhs.iter_mut() {
+                *lhs = -*lhs;
+            }
+        });
+
+        self
     }
 }
 

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -554,7 +554,7 @@ fn plonk_api() {
                             },
                         ),
                     ),
-                    Scaled(
+                    Negated(
                         Product(
                             Advice {
                                 query_index: 2,
@@ -571,7 +571,6 @@ fn plonk_api() {
                                 ),
                             },
                         ),
-                        0x40000000000000000000000000000000224698fc094cf91b992d30ed00000000,
                     ),
                 ),
                 Product(
@@ -616,7 +615,7 @@ fn plonk_api() {
                             0,
                         ),
                     },
-                    Scaled(
+                    Negated(
                         Instance {
                             query_index: 0,
                             column_index: 0,
@@ -624,7 +623,6 @@ fn plonk_api() {
                                 0,
                             ),
                         },
-                        0x40000000000000000000000000000000224698fc094cf91b992d30ed00000000,
                     ),
                 ),
             ),

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -306,13 +306,7 @@ fn plonk_api() {
                 let sc = meta.query_fixed(sc, Rotation::cur());
                 let sm = meta.query_fixed(sm, Rotation::cur());
 
-                vec![
-                    a.clone() * sa
-                        + b.clone() * sb
-                        + a * b * sm
-                        + (c * sc * (-F::one()))
-                        + sf * (d * e),
-                ]
+                vec![a.clone() * sa + b.clone() * sb + a * b * sm - (c * sc) + sf * (d * e)]
             });
 
             meta.create_gate("Public input", |meta| {
@@ -320,7 +314,7 @@ fn plonk_api() {
                 let p = meta.query_instance(p, Rotation::cur());
                 let sp = meta.query_fixed(sp, Rotation::cur());
 
-                vec![sp * (a + p * (-F::one()))]
+                vec![sp * (a - p)]
             });
 
             meta.enable_equality(sf.into());


### PR DESCRIPTION
Previously, we were storing negations as "scaled by -1", which meant we needed to evaluate them with multiplications instead of cheaper negations or additions.