### PR TITLE
Add a `Layouter::assign_table` API

### DIFF
--- a/examples/circuit-layout.rs
+++ b/examples/circuit-layout.rs
@@ -3,7 +3,7 @@ use halo2::{
     circuit::{Cell, Layouter, Region, SimpleFloorPlanner},
     dev::CircuitLayout,
     pasta::Fp,
-    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed},
+    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, TableColumn},
     poly::Rotation,
 };
 use plotters::prelude::*;
@@ -27,7 +27,7 @@ fn main() {
         sb: Column<Fixed>,
         sc: Column<Fixed>,
         sm: Column<Fixed>,
-        sl: Column<Fixed>,
+        sl: TableColumn,
     }
 
     trait StandardCs<FF: FieldExt> {
@@ -171,7 +171,7 @@ fn main() {
             layouter: &mut impl Layouter<FF>,
             values: &[FF],
         ) -> Result<(), Error> {
-            layouter.assign_region(
+            layouter.assign_table(
                 || "",
                 |mut region| {
                     for (index, &value) in values.iter().enumerate() {
@@ -211,7 +211,7 @@ fn main() {
             let sa = meta.fixed_column();
             let sb = meta.fixed_column();
             let sc = meta.fixed_column();
-            let sl = meta.fixed_column();
+            let sl = meta.lookup_table_column();
 
             /*
              *   A         B      ...  sl

--- a/examples/circuit-layout.rs
+++ b/examples/circuit-layout.rs
@@ -173,9 +173,9 @@ fn main() {
         ) -> Result<(), Error> {
             layouter.assign_table(
                 || "",
-                |mut region| {
+                |mut table| {
                     for (index, &value) in values.iter().enumerate() {
-                        region.assign_fixed(|| "table col", self.config.sl, index, || Ok(value))?;
+                        table.assign_cell(|| "table col", self.config.sl, index, || Ok(value))?;
                     }
                     Ok(())
                 },

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -6,7 +6,7 @@ use ff::Field;
 
 use crate::{
     arithmetic::FieldExt,
-    plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector},
+    plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector, TableColumn},
 };
 
 pub mod floor_planner;
@@ -245,9 +245,6 @@ impl<'r, F: Field> Region<'r, F> {
 }
 
 /// A lookup table in the circuit.
-///
-/// TODO: Add wrapper type to `ConstraintSystem` to allow us to only deal with lookup
-/// columns here.
 #[derive(Debug)]
 pub struct Table<'r, F: Field> {
     table: &'r mut dyn layouter::TableLayouter<F>,
@@ -266,7 +263,7 @@ impl<'r, F: Field> Table<'r, F> {
     pub fn assign_fixed<'v, V, VR, A, AR>(
         &'v mut self,
         annotation: A,
-        column: Column<Fixed>,
+        column: TableColumn,
         offset: usize,
         mut to: V,
     ) -> Result<(), Error>

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -257,10 +257,12 @@ impl<'r, F: Field> From<&'r mut dyn layouter::TableLayouter<F>> for Table<'r, F>
 }
 
 impl<'r, F: Field> Table<'r, F> {
-    /// Assign a fixed value.
+    /// Assigns a fixed value to a table cell.
+    ///
+    /// Returns an error if the table cell has already been assigned to.
     ///
     /// Even though `to` has `FnMut` bounds, it is guaranteed to be called at most once.
-    pub fn assign_fixed<'v, V, VR, A, AR>(
+    pub fn assign_cell<'v, V, VR, A, AR>(
         &'v mut self,
         annotation: A,
         column: TableColumn,
@@ -274,7 +276,7 @@ impl<'r, F: Field> Table<'r, F> {
         AR: Into<String>,
     {
         self.table
-            .assign_fixed(&|| annotation().into(), column, offset, &mut || {
+            .assign_cell(&|| annotation().into(), column, offset, &mut || {
                 to().map(|v| v.into())
             })
     }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -244,6 +244,45 @@ impl<'r, F: Field> Region<'r, F> {
     }
 }
 
+/// A lookup table in the circuit.
+///
+/// TODO: Add wrapper type to `ConstraintSystem` to allow us to only deal with lookup
+/// columns here.
+#[derive(Debug)]
+pub struct Table<'r, F: Field> {
+    table: &'r mut dyn layouter::TableLayouter<F>,
+}
+
+impl<'r, F: Field> From<&'r mut dyn layouter::TableLayouter<F>> for Table<'r, F> {
+    fn from(table: &'r mut dyn layouter::TableLayouter<F>) -> Self {
+        Table { table }
+    }
+}
+
+impl<'r, F: Field> Table<'r, F> {
+    /// Assign a fixed value.
+    ///
+    /// Even though `to` has `FnMut` bounds, it is guaranteed to be called at most once.
+    pub fn assign_fixed<'v, V, VR, A, AR>(
+        &'v mut self,
+        annotation: A,
+        column: Column<Fixed>,
+        offset: usize,
+        mut to: V,
+    ) -> Result<(), Error>
+    where
+        V: FnMut() -> Result<VR, Error> + 'v,
+        VR: Into<Assigned<F>>,
+        A: Fn() -> AR,
+        AR: Into<String>,
+    {
+        self.table
+            .assign_fixed(&|| annotation().into(), column, offset, &mut || {
+                to().map(|v| v.into())
+            })
+    }
+}
+
 /// A layout strategy within a circuit. The layouter is chip-agnostic and applies its
 /// strategy to the context and config it is given.
 ///
@@ -269,6 +308,20 @@ pub trait Layouter<F: Field> {
     fn assign_region<A, AR, N, NR>(&mut self, name: N, assignment: A) -> Result<AR, Error>
     where
         A: FnMut(Region<'_, F>) -> Result<AR, Error>,
+        N: Fn() -> NR,
+        NR: Into<String>;
+
+    /// Assign a table region to an absolute row number.
+    ///
+    /// ```ignore
+    /// fn assign_table(&mut self, || "table name", |table| {
+    ///     let config = chip.config();
+    ///     table.assign_fixed(config.a, offset, || { Some(value)});
+    /// });
+    /// ```
+    fn assign_table<A, N, NR>(&mut self, name: N, assignment: A) -> Result<(), Error>
+    where
+        A: FnMut(Table<'_, F>) -> Result<(), Error>,
         N: Fn() -> NR,
         NR: Into<String>;
 
@@ -326,6 +379,15 @@ impl<'a, F: Field, L: Layouter<F> + 'a> Layouter<F> for NamespacedLayouter<'a, F
         NR: Into<String>,
     {
         self.0.assign_region(name, assignment)
+    }
+
+    fn assign_table<A, N, NR>(&mut self, name: N, assignment: A) -> Result<(), Error>
+    where
+        A: FnMut(Table<'_, F>) -> Result<(), Error>,
+        N: Fn() -> NR,
+        NR: Into<String>,
+    {
+        self.0.assign_table(name, assignment)
     }
 
     fn constrain_instance(

--- a/src/circuit/floor_planner/single_pass.rs
+++ b/src/circuit/floor_planner/single_pass.rs
@@ -390,6 +390,7 @@ pub(crate) struct SimpleTableLayouter<'r, 'a, F: Field, CS: Assignment<F> + 'a> 
 impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> fmt::Debug for SimpleTableLayouter<'r, 'a, F, CS> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SimpleTableLayouter")
+            .field("used_columns", &self.used_columns)
             .field("default_and_assigned", &self.default_and_assigned)
             .finish()
     }

--- a/src/circuit/floor_planner/single_pass.rs
+++ b/src/circuit/floor_planner/single_pass.rs
@@ -407,7 +407,7 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> SimpleTableLayouter<'r, 'a, F, CS
 impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
     for SimpleTableLayouter<'r, 'a, F, CS>
 {
-    fn assign_fixed<'v>(
+    fn assign_cell<'v>(
         &'v mut self,
         annotation: &'v (dyn Fn() -> String + 'v),
         column: TableColumn,

--- a/src/circuit/floor_planner/v1.rs
+++ b/src/circuit/floor_planner/v1.rs
@@ -292,6 +292,8 @@ impl<'p, 'a, F: Field, CS: Assignment<F> + 'a> AssignmentPass<'p, 'a, F, CS> {
         N: Fn() -> NR,
         NR: Into<String>,
     {
+        // Maintenance hazard: there is near-duplicate code in `SingleChipLayouter::assign_table`.
+
         // Assign table cells.
         self.plan.cs.enter_region(name);
         let mut table = SimpleTableLayouter::new(self.plan.cs, &self.plan.table_columns);

--- a/src/circuit/floor_planner/v1.rs
+++ b/src/circuit/floor_planner/v1.rs
@@ -325,7 +325,7 @@ impl<'p, 'a, F: Field, CS: Assignment<F> + 'a> AssignmentPass<'p, 'a, F, CS> {
 
         // Record these columns so that we can prevent them from being used again.
         for column in default_and_assigned.keys() {
-            self.plan.table_columns.push(column.clone());
+            self.plan.table_columns.push(*column);
         }
 
         for (col, (default_val, _)) in default_and_assigned {

--- a/src/circuit/floor_planner/v1.rs
+++ b/src/circuit/floor_planner/v1.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     plonk::{
         Advice, Any, Assigned, Assignment, Circuit, Column, Error, Fixed, FloorPlanner, Instance,
-        Selector,
+        Selector, TableColumn,
     },
 };
 
@@ -34,7 +34,7 @@ struct V1Plan<'a, F: Field, CS: Assignment<F> + 'a> {
     /// Stores the constants to be assigned, and the cells to which they are copied.
     constants: Vec<(Assigned<F>, Cell)>,
     /// Stores the table fixed columns.
-    table_columns: Vec<Column<Fixed>>,
+    table_columns: Vec<TableColumn>,
 }
 
 impl<'a, F: Field, CS: Assignment<F> + 'a> fmt::Debug for V1Plan<'a, F, CS> {
@@ -334,7 +334,7 @@ impl<'p, 'a, F: Field, CS: Assignment<F> + 'a> AssignmentPass<'p, 'a, F, CS> {
             // that all cells up to first_unused were assigned.
             self.plan
                 .cs
-                .fill_from_row(col, first_unused, default_val.unwrap())?;
+                .fill_from_row(col.inner(), first_unused, default_val.unwrap())?;
         }
 
         Ok(result)

--- a/src/circuit/layouter.rs
+++ b/src/circuit/layouter.rs
@@ -7,8 +7,7 @@ use std::fmt;
 use ff::Field;
 
 use super::{Cell, RegionIndex};
-use crate::plonk::Assigned;
-use crate::plonk::{Advice, Any, Column, Error, Fixed, Instance, Selector};
+use crate::plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector, TableColumn};
 
 /// Helper trait for implementing a custom [`Layouter`].
 ///
@@ -115,7 +114,7 @@ pub trait TableLayouter<F: Field>: fmt::Debug {
     fn assign_fixed<'v>(
         &'v mut self,
         annotation: &'v (dyn Fn() -> String + 'v),
-        column: Column<Fixed>,
+        column: TableColumn,
         offset: usize,
         to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
     ) -> Result<(), Error>;

--- a/src/circuit/layouter.rs
+++ b/src/circuit/layouter.rs
@@ -110,8 +110,10 @@ pub trait RegionLayouter<F: Field>: fmt::Debug {
 ///
 /// [`Layouter`]: super::Layouter
 pub trait TableLayouter<F: Field>: fmt::Debug {
-    /// Assign a fixed value
-    fn assign_fixed<'v>(
+    /// Assigns a fixed value to a table cell.
+    ///
+    /// Returns an error if the table cell has already been assigned to.
+    fn assign_cell<'v>(
         &'v mut self,
         annotation: &'v (dyn Fn() -> String + 'v),
         column: TableColumn,

--- a/src/circuit/layouter.rs
+++ b/src/circuit/layouter.rs
@@ -105,6 +105,22 @@ pub trait RegionLayouter<F: Field>: fmt::Debug {
     fn constrain_equal(&mut self, left: Cell, right: Cell) -> Result<(), Error>;
 }
 
+/// Helper trait for implementing a custom [`Layouter`].
+///
+/// This trait is used for implementing table assignments.
+///
+/// [`Layouter`]: super::Layouter
+pub trait TableLayouter<F: Field>: fmt::Debug {
+    /// Assign a fixed value
+    fn assign_fixed<'v>(
+        &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
+        column: Column<Fixed>,
+        offset: usize,
+        to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
+    ) -> Result<(), Error>;
+}
+
 /// The shape of a region. For a region at a certain index, we track
 /// the set of columns it uses as well as the number of rows it uses.
 #[derive(Clone, Debug)]

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -467,6 +467,19 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
             .copy(left_column, left_row, right_column, right_row)
     }
 
+    fn fill_from_row(
+        &mut self,
+        _: Column<Fixed>,
+        from_row: usize,
+        _: Option<Assigned<F>>,
+    ) -> Result<(), Error> {
+        if !self.usable_rows.contains(&from_row) {
+            return Err(Error::BoundsFailure);
+        }
+
+        Ok(())
+    }
+
     fn push_namespace<NR, N>(&mut self, _: N)
     where
         NR: Into<String>,

--- a/src/dev/cost.rs
+++ b/src/dev/cost.rs
@@ -107,6 +107,15 @@ impl<F: Field> Assignment<F> for Assembly {
         Ok(())
     }
 
+    fn fill_from_row(
+        &mut self,
+        _: Column<Fixed>,
+        _: usize,
+        _: Option<Assigned<F>>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     fn push_namespace<NR, N>(&mut self, _: N)
     where
         NR: Into<String>,

--- a/src/dev/graph.rs
+++ b/src/dev/graph.rs
@@ -145,6 +145,15 @@ impl<F: Field> Assignment<F> for Graph {
         Ok(())
     }
 
+    fn fill_from_row(
+        &mut self,
+        _: Column<Fixed>,
+        _: usize,
+        _: Option<Assigned<F>>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     fn push_namespace<NR, N>(&mut self, name_fn: N)
     where
         NR: Into<String>,

--- a/src/dev/graph/layout.rs
+++ b/src/dev/graph/layout.rs
@@ -437,6 +437,15 @@ impl<F: Field> Assignment<F> for Layout {
         Ok(())
     }
 
+    fn fill_from_row(
+        &mut self,
+        _: Column<Fixed>,
+        _: usize,
+        _: Option<Assigned<F>>,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
     fn push_namespace<NR, N>(&mut self, _: N)
     where
         NR: Into<String>,

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -478,6 +478,14 @@ pub trait Assignment<F: Field> {
         right_row: usize,
     ) -> Result<(), Error>;
 
+    /// Fills a fixed `column` starting from the given `row` with value `to`.
+    fn fill_from_row(
+        &mut self,
+        column: Column<Fixed>,
+        row: usize,
+        to: Option<Assigned<F>>,
+    ) -> Result<(), Error>;
+
     /// Creates a new (sub)namespace and enters into it.
     ///
     /// Not intended for downstream consumption; use [`Layouter::namespace`] instead.

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -238,6 +238,15 @@ pub fn create_proof<
                     Ok(())
                 }
 
+                fn fill_from_row(
+                    &mut self,
+                    _: Column<Fixed>,
+                    _: usize,
+                    _: Option<Assigned<F>>,
+                ) -> Result<(), Error> {
+                    Ok(())
+                }
+
                 fn push_namespace<NR, N>(&mut self, _: N)
                 where
                     NR: Into<String>,

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -232,7 +232,7 @@ fn plonk_api() {
                 || "",
                 |mut table| {
                     for (index, &value) in values.iter().enumerate() {
-                        table.assign_fixed(|| "table col", self.config.sl, index, || Ok(value))?;
+                        table.assign_cell(|| "table col", self.config.sl, index, || Ok(value))?;
                     }
                     Ok(())
                 },

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -228,11 +228,11 @@ fn plonk_api() {
             layouter: &mut impl Layouter<FF>,
             values: &[FF],
         ) -> Result<(), Error> {
-            layouter.assign_region(
+            layouter.assign_table(
                 || "",
-                |mut region| {
+                |mut table| {
                     for (index, &value) in values.iter().enumerate() {
-                        region.assign_fixed(|| "table col", self.config.sl, index, || Ok(value))?;
+                        table.assign_fixed(|| "table col", self.config.sl, index, || Ok(value))?;
                     }
                     Ok(())
                 },
@@ -864,7 +864,7 @@ fn plonk_api() {
         (0x374a656456a0aae7429b23336f825752b575dd5a44290ff614946ee59d6a20c0, 0x054491e187e6e3460e7601fb54ae10836d34d420026f96316f0c5c62f86db9b8),
         (0x02e62cd68370b13711139a08cbcdd889e800a272b9ea10acc90880fff9d89199, 0x1a96c468cb0ce77065d3a58f1e55fea9b72d15e44c01bba1e110bd0cbc6e9bc6),
         (0x224ef42758215157d3ee48fb8d769da5bddd35e5929a90a4a89736f5c4b5ae9b, 0x11bc3a1e08eb320cde764f1492ecef956d71e996e2165f7a9a30ad2febb511c1),
-        (0x3c145eb1e4f1e49d9eed351a4e2d9f3deed13bc5ba028d3b425084d606418cc8, 0x045d846e7df4e563ce57cd5483d17bad87f0345e18409bf15abc3d71953ae71c),
+        (0x2d5415bf917fcac32bfb705f8ca35cb12d9bad52aa33ccca747350f9235d3a18, 0x2b2921f815fad504052512743963ef20ed5b401d20627793b006413e73fe4dd4),
     ],
     permutation: VerifyingKey {
         commitments: [

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -825,10 +825,6 @@ fn plonk_api() {
                     index: 5,
                     column_type: Fixed,
                 },
-                Column {
-                    index: 6,
-                    column_type: Fixed,
-                },
             ],
         },
         lookups: [
@@ -879,7 +875,6 @@ fn plonk_api() {
             (0x3eaa38689d9e391c8a8fafab9568f20c45816321d38f309d4cc37f4b1601af72, 0x247f8270a462ea88450221a56aa6b55d2bc352b80b03501e99ea983251ceea13),
             (0x394437571f9de32dccdc546fd4737772d8d92593c85438aa3473243997d5acc8, 0x14924ec6e3174f1fab7f0ce7070c22f04bbd0a0ecebdfc5c94be857f25493e95),
             (0x3d907e0591343bd285c2c846f3e871a6ac70d80ec29e9500b8cb57f544e60202, 0x1034e48df35830244cabea076be8a16d67d7896e27c6ac22b285d017105da9c3),
-            (0x21d210b41675a1eae44cbd0f3fd27d69e30716c71873f6089cee61acacd403ab, 0x2275e97c7e84f68bfaa528a9d8be4e059f7abefd80d03fbfca774e8414a9b7c1),
         ],
     },
 }"#####

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -7,7 +7,7 @@ use halo2::dev::MockProver;
 use halo2::pasta::{Eq, EqAffine, Fp};
 use halo2::plonk::{
     create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Circuit, Column, ConstraintSystem,
-    Error, Fixed, VerifyingKey,
+    Error, Fixed, TableColumn, VerifyingKey,
 };
 use halo2::poly::{commitment::Params, Rotation};
 use halo2::transcript::{Blake2bRead, Blake2bWrite, Challenge255};
@@ -37,7 +37,7 @@ fn plonk_api() {
         sc: Column<Fixed>,
         sm: Column<Fixed>,
         sp: Column<Fixed>,
-        sl: Column<Fixed>,
+        sl: TableColumn,
     }
 
     trait StandardCs<FF: FieldExt> {
@@ -270,7 +270,7 @@ fn plonk_api() {
             let sb = meta.fixed_column();
             let sc = meta.fixed_column();
             let sp = meta.fixed_column();
-            let sl = meta.fixed_column();
+            let sl = meta.lookup_table_column();
 
             /*
              *   A         B      ...  sl
@@ -332,7 +332,6 @@ fn plonk_api() {
             meta.enable_equality(sb.into());
             meta.enable_equality(sc.into());
             meta.enable_equality(sp.into());
-            meta.enable_equality(sl.into());
 
             PlonkConfig {
                 a,


### PR DESCRIPTION
The new API correctly handles lookup table assignments; in particular, layouters now ensure that every column used in a table has a valid table entry on every usable row.