### PR TITLE
book: Fix rendering of cost-model output.

### DIFF
--- a/book/src/user/dev-tools.md
+++ b/book/src/user/dev-tools.md
@@ -61,7 +61,7 @@ Optional arguments:
 For example, to estimate the cost of a circuit with three advice columns and one fixed
 column (with various rotations), and a maximum gate degree of 4:
 
-```shell
+```plaintext
 $ cargo run --example cost-model -- -a 0,1 -a 0 -a-0,-1,1 -f 0 -g 4 11
     Finished dev [unoptimized + debuginfo] target(s) in 0.03s
      Running `target/debug/examples/cost-model -a 0,1 -a 0 -a 0,-1,1 -f 0 -g 4 11`


### PR DESCRIPTION
Currently on the bottom of the dev-tools HTML page[0] we can see HTML
tags being rendered inside the code tag.

This commit should stop html tags appearing inside the `<code>` tags, and
allow for proper printing of the book.

[0] https://zcash.github.io/halo2/user/dev-tools.html
