### PR TITLE
halo2 0.1.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,4 +6,6 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-Initial release!
+
+## [0.1.0-beta.1] - 2021-09-24
+Initial beta release!

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2"
-version = "0.0.1"
+version = "0.1.0-beta.1"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Ying Tong Lai <yingtong@electriccoin.co>",
@@ -15,9 +15,6 @@ license-file = "LICENSE-BOSL"
 repository = "https://github.com/zcash/halo2"
 documentation = "https://docs.rs/halo2"
 readme = "README.md"
-
-# We are not publishing this yet.
-publish = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 description = """
 Fast proof-carrying data implementation with no trusted setup
 """
-license-file = "LICENSE-BOSL"
+license-file = "COPYING"
 repository = "https://github.com/zcash/halo2"
 documentation = "https://docs.rs/halo2"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
 ]
 edition = "2018"
 description = """
-Fast proof-carrying data implementation with no trusted setup
+[BETA] Fast proof-carrying data implementation with no trusted setup
 """
 license-file = "COPYING"
 repository = "https://github.com/zcash/halo2"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # halo2 [![Crates.io](https://img.shields.io/crates/v/halo2.svg)](https://crates.io/crates/halo2) #
 
-**IMPORTANT**: This library is being actively developed and should not be used in production software.
+**IMPORTANT**: This library is in beta, and should not be used in production software.
 
 ## [Documentation](https://docs.rs/halo2)
 


### PR DESCRIPTION
This is the beta version of `halo2` used on testnet in zcashd v4.5.0.