### PR TITLE
Clean up our trait usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- `halo2::arithmetic::BatchInvert` (use `ff::BatchInvert` instead).
 
 ## [0.1.0-beta.1] - 2021-09-24
 Initial beta release!

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -201,7 +201,7 @@ fn serial_fft<G: Group>(a: &mut [G], omega: G::Scalar, log_n: u32) {
 
     let mut m = 1;
     for _ in 0..log_n {
-        let w_m = omega.pow(&[u64::from(n / (2 * m)), 0, 0, 0]);
+        let w_m = omega.pow_vartime(&[u64::from(n / (2 * m)), 0, 0, 0]);
 
         let mut k = 0;
         while k < n {
@@ -228,7 +228,7 @@ fn parallel_fft<G: Group>(a: &mut [G], omega: G::Scalar, log_n: u32, log_threads
     let num_threads = 1 << log_threads;
     let log_new_n = log_n - log_threads;
     let mut tmp = vec![vec![G::group_zero(); 1 << log_new_n]; num_threads];
-    let new_omega = omega.pow(&[num_threads as u64, 0, 0, 0]);
+    let new_omega = omega.pow_vartime(&[num_threads as u64, 0, 0, 0]);
 
     multicore::scope(|scope| {
         let a = &*a;
@@ -236,8 +236,8 @@ fn parallel_fft<G: Group>(a: &mut [G], omega: G::Scalar, log_n: u32, log_threads
         for (j, tmp) in tmp.iter_mut().enumerate() {
             scope.spawn(move |_| {
                 // Shuffle into a sub-FFT
-                let omega_j = omega.pow(&[j as u64, 0, 0, 0]);
-                let omega_step = omega.pow(&[(j as u64) << log_new_n, 0, 0, 0]);
+                let omega_j = omega.pow_vartime(&[j as u64, 0, 0, 0]);
+                let omega_step = omega.pow_vartime(&[(j as u64) << log_new_n, 0, 0, 0]);
 
                 let mut elt = G::Scalar::one();
 

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -292,14 +292,14 @@ impl<F: Group + Field> Mul<F> for Value<F> {
 ///         layouter.assign_region(|| "Example region", |mut region| {
 ///             config.s.enable(&mut region, 0)?;
 ///             region.assign_advice(|| "a", config.a, 0, || {
-///                 self.a.map(|v| F::from_u64(v)).ok_or(Error::SynthesisError)
+///                 self.a.map(|v| F::from(v)).ok_or(Error::SynthesisError)
 ///             })?;
 ///             region.assign_advice(|| "b", config.b, 0, || {
-///                 self.b.map(|v| F::from_u64(v)).ok_or(Error::SynthesisError)
+///                 self.b.map(|v| F::from(v)).ok_or(Error::SynthesisError)
 ///             })?;
 ///             region.assign_advice(|| "c", config.c, 0, || {
 ///                 self.a
-///                     .and_then(|a| self.b.map(|b| F::from_u64(a * b)))
+///                     .and_then(|a| self.b.map(|b| F::from(a * b)))
 ///                     .ok_or(Error::SynthesisError)
 ///             })?;
 ///             Ok(())

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,0 +1,16 @@
+use std::io;
+
+use pasta_curves::arithmetic::CurveAffine;
+
+pub(crate) trait CurveRead: CurveAffine {
+    /// Reads a compressed element from the buffer and attempts to parse it
+    /// using `from_bytes`.
+    fn read<R: io::Read>(reader: &mut R) -> io::Result<Self> {
+        let mut compressed = Self::Repr::default();
+        reader.read_exact(compressed.as_mut())?;
+        Option::from(Self::from_bytes(&compressed))
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "invalid point encoding in proof"))
+    }
+}
+
+impl<C: CurveAffine> CurveRead for C {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
 #![deny(unsafe_code)]
+// Remove this once we update pasta_curves
+#![allow(unused_imports)]
 
 pub mod arithmetic;
 pub mod circuit;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,4 @@ pub mod poly;
 pub mod transcript;
 
 pub mod dev;
+mod helpers;

--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -8,6 +8,7 @@
 use blake2b_simd::Params as Blake2bParams;
 
 use crate::arithmetic::{CurveAffine, FieldExt};
+use crate::helpers::CurveRead;
 use crate::poly::{
     commitment::Params, Coeff, EvaluationDomain, ExtendedLagrangeCoeff, LagrangeCoeff,
     PinnedEvaluationDomain, Polynomial,

--- a/src/plonk/lookup/prover.rs
+++ b/src/plonk/lookup/prover.rs
@@ -4,7 +4,7 @@ use super::super::{
 };
 use super::Argument;
 use crate::{
-    arithmetic::{eval_polynomial, parallelize, BatchInvert, CurveAffine, FieldExt},
+    arithmetic::{eval_polynomial, parallelize, CurveAffine, FieldExt},
     poly::{
         commitment::{Blind, Params},
         multiopen::ProverQuery,
@@ -12,8 +12,10 @@ use crate::{
     },
     transcript::{EncodedChallenge, TranscriptWrite},
 };
-use ff::Field;
-use group::Curve;
+use group::{
+    ff::{BatchInvert, Field},
+    Curve,
+};
 use std::{
     collections::BTreeMap,
     iter,

--- a/src/plonk/permutation.rs
+++ b/src/plonk/permutation.rs
@@ -1,6 +1,7 @@
 use super::circuit::{Any, Column};
 use crate::{
     arithmetic::CurveAffine,
+    helpers::CurveRead,
     poly::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial},
 };
 
@@ -80,7 +81,7 @@ pub(crate) struct VerifyingKey<C: CurveAffine> {
 impl<C: CurveAffine> VerifyingKey<C> {
     pub(crate) fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
         for commitment in &self.commitments {
-            commitment.write(writer)?;
+            writer.write_all(commitment.to_bytes().as_ref())?;
         }
 
         Ok(())

--- a/src/plonk/permutation/prover.rs
+++ b/src/plonk/permutation/prover.rs
@@ -1,11 +1,13 @@
-use ff::Field;
-use group::Curve;
+use group::{
+    ff::{BatchInvert, Field},
+    Curve,
+};
 use std::iter::{self, ExactSizeIterator};
 
 use super::super::{circuit::Any, ChallengeBeta, ChallengeGamma, ChallengeX};
 use super::{Argument, ProvingKey};
 use crate::{
-    arithmetic::{eval_polynomial, parallelize, BatchInvert, CurveAffine, FieldExt},
+    arithmetic::{eval_polynomial, parallelize, CurveAffine, FieldExt},
     plonk::{self, Error},
     poly::{
         commitment::{Blind, Params},

--- a/src/poly.rs
+++ b/src/poly.rs
@@ -3,10 +3,9 @@
 //! the committed polynomials at arbitrary points.
 
 use crate::arithmetic::parallelize;
-use crate::arithmetic::BatchInvert;
 use crate::plonk::Assigned;
 
-use ff::Field;
+use group::ff::{BatchInvert, Field};
 use pasta_curves::arithmetic::FieldExt;
 use std::fmt::Debug;
 use std::marker::PhantomData;

--- a/src/poly/commitment.rs
+++ b/src/poly/commitment.rs
@@ -7,6 +7,7 @@ use super::{Coeff, LagrangeCoeff, Polynomial};
 use crate::arithmetic::{
     best_fft, best_multiexp, parallelize, CurveAffine, CurveExt, FieldExt, Group,
 };
+use crate::helpers::CurveRead;
 
 use ff::{Field, PrimeField};
 use group::{prime::PrimeCurveAffine, Curve, Group as _};

--- a/src/poly/commitment/verifier.rs
+++ b/src/poly/commitment/verifier.rs
@@ -1,11 +1,13 @@
-use ff::Field;
-use group::Curve;
+use group::{
+    ff::{BatchInvert, Field},
+    Curve,
+};
 
 use super::super::Error;
 use super::{Params, MSM};
 use crate::transcript::{EncodedChallenge, TranscriptRead};
 
-use crate::arithmetic::{best_multiexp, BatchInvert, CurveAffine};
+use crate::arithmetic::{best_multiexp, CurveAffine};
 
 /// A guard returned by the verifier
 #[derive(Debug, Clone)]

--- a/src/poly/domain.rs
+++ b/src/poly/domain.rs
@@ -2,13 +2,14 @@
 //! domain that is of a suitable size for the application.
 
 use crate::{
-    arithmetic::{best_fft, parallelize, BatchInvert, FieldExt, Group},
+    arithmetic::{best_fft, parallelize, FieldExt, Group},
     plonk::Assigned,
 };
 
 use super::{Coeff, ExtendedLagrangeCoeff, LagrangeCoeff, Polynomial, Rotation};
 
-use ff::{Field, PrimeField};
+use group::ff::{BatchInvert, Field, PrimeField};
+
 use std::marker::PhantomData;
 
 /// This structure contains precomputed constants and other details needed for

--- a/src/poly/domain.rs
+++ b/src/poly/domain.rs
@@ -51,7 +51,7 @@ impl<G: Group> EvaluationDomain<G> {
             extended_k += 1;
         }
 
-        let mut extended_omega = G::Scalar::ROOT_OF_UNITY;
+        let mut extended_omega = G::Scalar::root_of_unity();
 
         // Get extended_omega, the 2^{extended_k}'th root of unity
         // The loop computes extended_omega = omega^{2 ^ (S - extended_k)}

--- a/src/poly/domain.rs
+++ b/src/poly/domain.rs
@@ -106,8 +106,8 @@ impl<G: Group> EvaluationDomain<G> {
             // We invert in a batch, below.
         }
 
-        let mut ifft_divisor = G::Scalar::from_u64(1 << k); // Inversion computed later
-        let mut extended_ifft_divisor = G::Scalar::from_u64(1 << extended_k); // Inversion computed later
+        let mut ifft_divisor = G::Scalar::from(1 << k); // Inversion computed later
+        let mut extended_ifft_divisor = G::Scalar::from(1 << extended_k); // Inversion computed later
 
         // The barycentric weight of 1 over the evaluation domain
         // 1 / \prod_{i != 0} (1 - omega^i)

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -379,7 +379,7 @@ fn plonk_api() {
         }
     }
 
-    let a = Fp::from_u64(2834758237) * Fp::ZETA;
+    let a = Fp::from(2834758237) * Fp::ZETA;
     let instance = Fp::one() + Fp::one();
     let lookup_table = vec![instance, a, a, Fp::zero()];
 


### PR DESCRIPTION
This removes our dependence on several `FieldExt` and `CurveAffine` methods, preparing us for their removal from `pasta_curves`.