### PR TITLE
Introduce plonk::Error::ColumnNotInPermutation error.

### DIFF
--- a/src/plonk/error.rs
+++ b/src/plonk/error.rs
@@ -2,6 +2,8 @@ use std::error;
 use std::fmt;
 use std::io;
 
+use super::{Any, Column};
+
 /// This is an error that could occur during proving or circuit synthesis.
 // TODO: these errors need to be cleaned up
 #[derive(Debug)]
@@ -28,6 +30,9 @@ pub enum Error {
     ///
     /// [`ConstraintSystem::enable_constant`]: crate::plonk::ConstraintSystem::enable_constant
     NotEnoughColumnsForConstants,
+    /// The instance sets up a copy constraint involving a column that has not been
+    /// included in the permutation.
+    ColumnNotInPermutation(Column<Any>),
 }
 
 impl From<io::Error> for Error {
@@ -54,6 +59,11 @@ impl fmt::Display for Error {
                     "Too few fixed columns are enabled for global constants usage"
                 )
             }
+            Error::ColumnNotInPermutation(column) => write!(
+                f,
+                "Column {:?} must be included in the permutation.",
+                column
+            ),
         }
     }
 }

--- a/src/plonk/permutation/keygen.rs
+++ b/src/plonk/permutation/keygen.rs
@@ -51,12 +51,12 @@ impl Assembly {
             .columns
             .iter()
             .position(|c| c == &left_column)
-            .ok_or(Error::Synthesis)?;
+            .ok_or(Error::ColumnNotInPermutation(left_column))?;
         let right_column = self
             .columns
             .iter()
             .position(|c| c == &right_column)
-            .ok_or(Error::Synthesis)?;
+            .ok_or(Error::ColumnNotInPermutation(right_column))?;
 
         // Check bounds
         if left_row >= self.mapping[left_column].len()


### PR DESCRIPTION
Closes #384. 

This is raised when a copy constraint involves a column that has
not been included in the permutation.