### PR TITLE
impl std::error::Error for halo2::plonk::Error

### DIFF
--- a/src/plonk.rs
+++ b/src/plonk.rs
@@ -160,6 +160,14 @@ pub enum Error {
     NotEnoughColumnsForConstants,
 }
 
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "{}", self)
+    }
+}
+
+impl std::error::Error for Error {}
+
 impl<C: CurveAffine> ProvingKey<C> {
     /// Get the underlying [`VerifyingKey`].
     pub fn get_vk(&self) -> &VerifyingKey<C> {


### PR DESCRIPTION
We're calling `orchard::circuit::Proof::verify()` from zebra and are trying to handle the returned error type `halo2::plonk::Error` nicely. If we impl `std::error::Error` on it here, we don't need to create wrapper types for it.