### PR TITLE
sha256: Fix `AssignedCell` `From` impls for `AssignedBits` and `Bits`

### DIFF
--- a/examples/sha256/table16.rs
+++ b/examples/sha256/table16.rs
@@ -75,21 +75,21 @@ impl<const LEN: usize> From<[bool; LEN]> for Bits<LEN> {
     }
 }
 
-impl<const LEN: usize> From<Bits<LEN>> for [bool; LEN] {
-    fn from(bits: Bits<LEN>) -> Self {
+impl<const LEN: usize> From<&Bits<LEN>> for [bool; LEN] {
+    fn from(bits: &Bits<LEN>) -> Self {
         bits.0
     }
 }
 
-impl<const LEN: usize> From<Bits<LEN>> for Assigned<pallas::Base> {
-    fn from(bits: Bits<LEN>) -> Assigned<pallas::Base> {
+impl<const LEN: usize> From<&Bits<LEN>> for Assigned<pallas::Base> {
+    fn from(bits: &Bits<LEN>) -> Assigned<pallas::Base> {
         assert!(LEN <= 64);
         pallas::Base::from_u64(lebs2ip(&bits.0)).into()
     }
 }
 
-impl From<Bits<16>> for u16 {
-    fn from(bits: Bits<16>) -> u16 {
+impl From<&Bits<16>> for u16 {
+    fn from(bits: &Bits<16>) -> u16 {
         lebs2ip(&bits.0) as u16
     }
 }
@@ -100,8 +100,8 @@ impl From<u16> for Bits<16> {
     }
 }
 
-impl From<Bits<32>> for u32 {
-    fn from(bits: Bits<32>) -> u32 {
+impl From<&Bits<32>> for u32 {
+    fn from(bits: &Bits<32>) -> u32 {
         lebs2ip(&bits.0) as u32
     }
 }

--- a/examples/sha256/table16/message_schedule/subregion2.rs
+++ b/examples/sha256/table16/message_schedule/subregion2.rs
@@ -294,7 +294,7 @@ impl MessageScheduleConfig {
     fn decompose_word(
         &self,
         region: &mut Region<'_, pallas::Base>,
-        word: Option<Bits<32>>,
+        word: Option<&Bits<32>>,
         index: usize,
     ) -> Result<Subregion2Word, Error> {
         let row = get_word_row(index);

--- a/examples/sha256/table16/message_schedule/subregion3.rs
+++ b/examples/sha256/table16/message_schedule/subregion3.rs
@@ -200,7 +200,7 @@ impl MessageScheduleConfig {
     fn decompose_subregion3_word(
         &self,
         region: &mut Region<'_, pallas::Base>,
-        word: Option<Bits<32>>,
+        word: Option<&Bits<32>>,
         index: usize,
     ) -> Result<Subregion3Word, Error> {
         let row = get_word_row(index);


### PR DESCRIPTION
zcash/halo2#337 had been updated to account for `AssignedCell`, before
the change to simplify its bounds was made. `AssignedCell` now requires
the `From` impls to take `&VR`.