### PR TITLE
Add a `Constraints` helper

### DIFF
--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to Rust's notion of
   - `MockProver::assert_satisfied`, for requiring that a circuit is satisfied.
     It panics like `assert_eq!(mock_prover.verify(), Ok(()))`, but pretty-prints
     any verification failures before panicking.
+- `halo2_proofs::plonk::Constraints` helper, for constructing a gate from a set
+  of constraints with a common selector.
 
 ### Changed
 - `halo2_proofs::dev`:

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -785,6 +785,10 @@ impl<F: Field> From<Expression<F>> for Vec<Constraint<F>> {
 ///     )
 /// });
 /// ```
+///
+/// Note that the use of `std::array::IntoIter::new` is only necessary if you need to
+/// support Rust 1.51 or 1.52. If your minimum supported Rust version is 1.53 or greater,
+/// you can pass an array directly.
 #[derive(Debug)]
 pub struct Constraints<F: Field, C: Into<Constraint<F>>, Iter: IntoIterator<Item = C>> {
     selector: Expression<F>,


### PR DESCRIPTION
There are two existing patterns for constructing a gate from a set of
constraints with a common selector:

- Create an iterator of constraints, where each constraint includes the
  selector:
  ```
  vec![
      ("foo", selector.clone() * foo),
      ("bar", selector.clone() * bar),
      ("baz", selector * bar),
  ]
  ```
  This requires the user to write O(n) `selector.clone()` calls.

- Create an iterator of constraints, and then map the selector in:
  ```
  vec![
      ("foo", foo),
      ("bar", bar),
      ("baz", bar),
  ].into_iter().map(move |(name, poly)| (name, selector.clone() * poly))
  ```
  This looks cleaner overall, but the API is not as intuitive, and it
  is messier when the constraints are named.

The `Constraints` struct provides a third, clearer API:
```
Constraints::with_selector(
    selector,
    vec![
        ("foo", foo),
        ("bar", bar),
        ("baz", bar),
    ],
)
```
This focuses on the structure of the constraints, and handles the
selector application for the user.