### PR TITLE
improve error message on ColumnNotInPermutation

### DIFF
--- a/src/plonk/error.rs
+++ b/src/plonk/error.rs
@@ -76,7 +76,7 @@ impl fmt::Display for Error {
             }
             Error::ColumnNotInPermutation(column) => write!(
                 f,
-                "Column {:?} must be included in the permutation.",
+                "Column {:?} must be included in the permutation. Help: try applying `meta.enable_equalty` on the column",
                 column
             ),
         }


### PR DESCRIPTION
### Problem

When a user forgets to add `meta.enable_equalty` on the columns to enforce copy constraints, it was hard for the user to find out the root cause of the error. The issue was reported in #384 and later fixed in #385.

#385 introduced a new error message `ColumnNotInPermutation` to isolate this particular error from the other `Synthesis` error. We could improve further by hinting the user how to fix it correctly.

### Solution

Hint user to apply `meta.enable_equalty` on the column.