### PR TITLE
Change to `Into<Column<Any>>` for pub API methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to Rust's notion of
   regular parameter APIs.
 - `halo2::dev::VerifyFailure::ConstraintNotSatisfied` now has a `cell_values`
   field, storing the values of the cells used in the unsatisfied constraint.
+- `halo2::plonk::ConstraintSystem::enable_equality` and 
+  `halo2::plonk::ConstraintSystem::query_any` now take `Into<Column<Any>>` instead 
+  of `Column<Any>` as a parameter to avoid excesive `.into()` usage.
 
 ### Removed
 - `halo2::arithmetic::BatchInvert` (use `ff::BatchInvert` instead).

--- a/benches/plonk.rs
+++ b/benches/plonk.rs
@@ -181,9 +181,9 @@ fn bench_with_k(name: &str, k: u32, c: &mut Criterion) {
             let b = meta.advice_column();
             let c = meta.advice_column();
 
-            meta.enable_equality(a.into());
-            meta.enable_equality(b.into());
-            meta.enable_equality(c.into());
+            meta.enable_equality(a);
+            meta.enable_equality(b);
+            meta.enable_equality(c);
 
             let sm = meta.fixed_column();
             let sa = meta.fixed_column();

--- a/examples/circuit-layout.rs
+++ b/examples/circuit-layout.rs
@@ -188,9 +188,9 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
         let c = meta.advice_column();
         let d = meta.advice_column();
 
-        meta.enable_equality(a.into());
-        meta.enable_equality(b.into());
-        meta.enable_equality(c.into());
+        meta.enable_equality(a);
+        meta.enable_equality(b);
+        meta.enable_equality(c);
 
         let sm = meta.fixed_column();
         let sa = meta.fixed_column();
@@ -214,7 +214,7 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
          * ]
          */
         meta.lookup(|meta| {
-            let a_ = meta.query_any(a.into(), Rotation::cur());
+            let a_ = meta.query_any(a, Rotation::cur());
             vec![(a_, sl)]
         });
 

--- a/examples/sha256/table16.rs
+++ b/examples/sha256/table16.rs
@@ -299,7 +299,7 @@ impl Table16Chip {
 
         // Add all advice columns to permutation
         for column in [a_1, a_2, a_3, a_4, a_5, a_6, a_7, a_8].iter() {
-            meta.enable_equality((*column).into());
+            meta.enable_equality(*column);
         }
 
         let compression =

--- a/examples/simple-example.rs
+++ b/examples/simple-example.rs
@@ -81,10 +81,10 @@ impl<F: FieldExt> FieldChip<F> {
         instance: Column<Instance>,
         constant: Column<Fixed>,
     ) -> <Self as Chip<F>>::Config {
-        meta.enable_equality(instance.into());
+        meta.enable_equality(instance);
         meta.enable_constant(constant);
         for column in &advice {
-            meta.enable_equality((*column).into());
+            meta.enable_equality(*column);
         }
         let s_mul = meta.selector();
 

--- a/examples/two-chip.rs
+++ b/examples/two-chip.rs
@@ -266,7 +266,7 @@ impl<F: FieldExt> MulChip<F> {
         advice: [Column<Advice>; 2],
     ) -> <Self as Chip<F>>::Config {
         for column in &advice {
-            meta.enable_equality((*column).into());
+            meta.enable_equality(*column);
         }
         let s_mul = meta.selector();
 
@@ -395,7 +395,7 @@ impl<F: FieldExt> FieldChip<F> {
         let add_config = AddChip::configure(meta, advice);
         let mul_config = MulChip::configure(meta, advice);
 
-        meta.enable_equality(instance.into());
+        meta.enable_equality(instance);
 
         FieldConfig {
             advice,

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -1188,11 +1188,7 @@ impl<F: Field> ConstraintSystem<F> {
         panic!("get_instance_query_index called for non-existent query");
     }
 
-    pub(crate) fn get_any_query_index(
-        &self,
-        column: Column<Any>,
-        at: Rotation,
-    ) -> usize {
+    pub(crate) fn get_any_query_index(&self, column: Column<Any>, at: Rotation) -> usize {
         match column.column_type() {
             Any::Advice => {
                 self.get_advice_query_index(Column::<Advice>::try_from(column).unwrap(), at)

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -1151,12 +1151,8 @@ impl<F: Field> ConstraintSystem<F> {
     fn query_any_index<C: Into<Column<Any>>>(&mut self, column: C, at: Rotation) -> usize {
         let column = column.into();
         match column.column_type() {
-            Any::Advice => {
-                self.query_advice_index(Column::<Advice>::try_from(column).unwrap(), at)
-            }
-            Any::Fixed => {
-                self.query_fixed_index(Column::<Fixed>::try_from(column).unwrap(), at)
-            }
+            Any::Advice => self.query_advice_index(Column::<Advice>::try_from(column).unwrap(), at),
+            Any::Fixed => self.query_fixed_index(Column::<Fixed>::try_from(column).unwrap(), at),
             Any::Instance => {
                 self.query_instance_index(Column::<Instance>::try_from(column).unwrap(), at)
             }
@@ -1206,8 +1202,9 @@ impl<F: Field> ConstraintSystem<F> {
             Any::Fixed => {
                 self.get_fixed_query_index(Column::<Fixed>::try_from(column).unwrap(), at)
             }
-            Any::Instance => self
-                .get_instance_query_index(Column::<Instance>::try_from(column).unwrap(), at),
+            Any::Instance => {
+                self.get_instance_query_index(Column::<Instance>::try_from(column).unwrap(), at)
+            }
         }
     }
 
@@ -1566,20 +1563,12 @@ impl<'a, F: Field> VirtualCells<'a, F> {
     }
 
     /// Query an Any column at a relative position
-    pub fn query_any<C: Into<Column<Any>>>(
-        &mut self,
-        column: C,
-        at: Rotation,
-    ) -> Expression<F> {
+    pub fn query_any<C: Into<Column<Any>>>(&mut self, column: C, at: Rotation) -> Expression<F> {
         let column = column.into();
         match column.column_type() {
-            Any::Advice => {
-                self.query_advice(Column::<Advice>::try_from(column).unwrap(), at)
-            }
+            Any::Advice => self.query_advice(Column::<Advice>::try_from(column).unwrap(), at),
             Any::Fixed => self.query_fixed(Column::<Fixed>::try_from(column).unwrap(), at),
-            Any::Instance => {
-                self.query_instance(Column::<Instance>::try_from(column).unwrap(), at)
-            }
+            Any::Instance => self.query_instance(Column::<Instance>::try_from(column).unwrap(), at),
         }
     }
 }

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -1148,8 +1148,7 @@ impl<F: Field> ConstraintSystem<F> {
         index
     }
 
-    fn query_any_index<C: Into<Column<Any>>>(&mut self, column: C, at: Rotation) -> usize {
-        let column = column.into();
+    fn query_any_index(&mut self, column: Column<Any>, at: Rotation) -> usize {
         match column.column_type() {
             Any::Advice => self.query_advice_index(Column::<Advice>::try_from(column).unwrap(), at),
             Any::Fixed => self.query_fixed_index(Column::<Fixed>::try_from(column).unwrap(), at),
@@ -1189,12 +1188,11 @@ impl<F: Field> ConstraintSystem<F> {
         panic!("get_instance_query_index called for non-existent query");
     }
 
-    pub(crate) fn get_any_query_index<C: Into<Column<Any>> + Copy>(
+    pub(crate) fn get_any_query_index(
         &self,
-        column: C,
+        column: Column<Any>,
         at: Rotation,
     ) -> usize {
-        let column = column.into();
         match column.column_type() {
             Any::Advice => {
                 self.get_advice_query_index(Column::<Advice>::try_from(column).unwrap(), at)

--- a/src/plonk/circuit.rs
+++ b/src/plonk/circuit.rs
@@ -1067,9 +1067,10 @@ impl<F: Field> ConstraintSystem<F> {
     }
 
     /// Enable the ability to enforce equality over cells in this column
-    pub fn enable_equality<C: Into<Column<Any>> + Copy>(&mut self, column: C) {
+    pub fn enable_equality<C: Into<Column<Any>>>(&mut self, column: C) {
+        let column = column.into();
         self.query_any_index(column, Rotation::cur());
-        self.permutation.add_column(column.into());
+        self.permutation.add_column(column);
     }
 
     /// Add a lookup argument for some input expressions and table columns.
@@ -1147,16 +1148,17 @@ impl<F: Field> ConstraintSystem<F> {
         index
     }
 
-    fn query_any_index<C: Into<Column<Any>> + Copy>(&mut self, column: C, at: Rotation) -> usize {
-        match column.into().column_type() {
+    fn query_any_index<C: Into<Column<Any>>>(&mut self, column: C, at: Rotation) -> usize {
+        let column = column.into();
+        match column.column_type() {
             Any::Advice => {
-                self.query_advice_index(Column::<Advice>::try_from(column.into()).unwrap(), at)
+                self.query_advice_index(Column::<Advice>::try_from(column).unwrap(), at)
             }
             Any::Fixed => {
-                self.query_fixed_index(Column::<Fixed>::try_from(column.into()).unwrap(), at)
+                self.query_fixed_index(Column::<Fixed>::try_from(column).unwrap(), at)
             }
             Any::Instance => {
-                self.query_instance_index(Column::<Instance>::try_from(column.into()).unwrap(), at)
+                self.query_instance_index(Column::<Instance>::try_from(column).unwrap(), at)
             }
         }
     }
@@ -1196,15 +1198,16 @@ impl<F: Field> ConstraintSystem<F> {
         column: C,
         at: Rotation,
     ) -> usize {
-        match column.into().column_type() {
+        let column = column.into();
+        match column.column_type() {
             Any::Advice => {
-                self.get_advice_query_index(Column::<Advice>::try_from(column.into()).unwrap(), at)
+                self.get_advice_query_index(Column::<Advice>::try_from(column).unwrap(), at)
             }
             Any::Fixed => {
-                self.get_fixed_query_index(Column::<Fixed>::try_from(column.into()).unwrap(), at)
+                self.get_fixed_query_index(Column::<Fixed>::try_from(column).unwrap(), at)
             }
             Any::Instance => self
-                .get_instance_query_index(Column::<Instance>::try_from(column.into()).unwrap(), at),
+                .get_instance_query_index(Column::<Instance>::try_from(column).unwrap(), at),
         }
     }
 
@@ -1563,18 +1566,19 @@ impl<'a, F: Field> VirtualCells<'a, F> {
     }
 
     /// Query an Any column at a relative position
-    pub fn query_any<C: Into<Column<Any>> + Copy>(
+    pub fn query_any<C: Into<Column<Any>>>(
         &mut self,
         column: C,
         at: Rotation,
     ) -> Expression<F> {
-        match column.into().column_type() {
+        let column = column.into();
+        match column.column_type() {
             Any::Advice => {
-                self.query_advice(Column::<Advice>::try_from(column.into()).unwrap(), at)
+                self.query_advice(Column::<Advice>::try_from(column).unwrap(), at)
             }
-            Any::Fixed => self.query_fixed(Column::<Fixed>::try_from(column.into()).unwrap(), at),
+            Any::Fixed => self.query_fixed(Column::<Fixed>::try_from(column).unwrap(), at),
             Any::Instance => {
-                self.query_instance(Column::<Instance>::try_from(column.into()).unwrap(), at)
+                self.query_instance(Column::<Instance>::try_from(column).unwrap(), at)
             }
         }
     }

--- a/src/plonk/permutation.rs
+++ b/src/plonk/permutation.rs
@@ -61,7 +61,8 @@ impl Argument {
         3
     }
 
-    pub(crate) fn add_column(&mut self, column: Column<Any>) {
+    pub(crate) fn add_column<C: Into<Column<Any>>>(&mut self, column: C) {
+        let column = column.into();
         if !self.columns.contains(&column) {
             self.columns.push(column);
         }

--- a/src/plonk/permutation.rs
+++ b/src/plonk/permutation.rs
@@ -61,8 +61,7 @@ impl Argument {
         3
     }
 
-    pub(crate) fn add_column<C: Into<Column<Any>>>(&mut self, column: C) {
-        let column = column.into();
+    pub(crate) fn add_column(&mut self, column: Column<Any>) {
         if !self.columns.contains(&column) {
             self.columns.push(column);
         }

--- a/tests/plonk_api.rs
+++ b/tests/plonk_api.rs
@@ -263,9 +263,9 @@ fn plonk_api() {
             let d = meta.advice_column();
             let p = meta.instance_column();
 
-            meta.enable_equality(a.into());
-            meta.enable_equality(b.into());
-            meta.enable_equality(c.into());
+            meta.enable_equality(a);
+            meta.enable_equality(b);
+            meta.enable_equality(c);
 
             let sm = meta.fixed_column();
             let sa = meta.fixed_column();
@@ -291,7 +291,7 @@ fn plonk_api() {
              */
 
             meta.lookup(|meta| {
-                let a_ = meta.query_any(a.into(), Rotation::cur());
+                let a_ = meta.query_any(a, Rotation::cur());
                 vec![(a_, sl)]
             });
 
@@ -319,15 +319,15 @@ fn plonk_api() {
                 vec![sp * (a - p)]
             });
 
-            meta.enable_equality(sf.into());
-            meta.enable_equality(e.into());
-            meta.enable_equality(d.into());
-            meta.enable_equality(p.into());
-            meta.enable_equality(sm.into());
-            meta.enable_equality(sa.into());
-            meta.enable_equality(sb.into());
-            meta.enable_equality(sc.into());
-            meta.enable_equality(sp.into());
+            meta.enable_equality(sf);
+            meta.enable_equality(e);
+            meta.enable_equality(d);
+            meta.enable_equality(p);
+            meta.enable_equality(sm);
+            meta.enable_equality(sa);
+            meta.enable_equality(sb);
+            meta.enable_equality(sc);
+            meta.enable_equality(sp);
 
             PlonkConfig {
                 a,


### PR DESCRIPTION
As suggested by daira in #345, it's sometimes annoying to call `.into()`
for all of the columns in methods like `enable_equality`.
Specially when you end up with situations where you have `&Column<_>` where you are forced to do something like:
`meta.enable_equality((*column).into())`

This change changes the public API methods that require `Column<Any>`
by `<C: Into<Column<Any>> + Copy>` which removes the need to call `.into()` on the public API and it's called inside of the functions that accept this
parameters.

The `Copy` is added since `Into` consumes the Column, and sometimes we
fall into the situation of needing to clone when we can simply require
the copy and avoid more code verbosity.

Resolves: #345