### PR TITLE
Expand `Assigned<F>` APIs

### DIFF
--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -122,6 +122,20 @@ where
     }
 }
 
+impl<F: Field> AssignedCell<Assigned<F>, F> {
+    /// Evaluates this assigned cell's value directly, performing an unbatched inversion
+    /// if necessary.
+    ///
+    /// If the denominator is zero, the returned cell's value is zero.
+    pub fn evaluate(self) -> AssignedCell<F, F> {
+        AssignedCell {
+            value: self.value.map(|v| v.evaluate()),
+            cell: self.cell,
+            _marker: Default::default(),
+        }
+    }
+}
+
 impl<V: Clone, F: Field> AssignedCell<V, F>
 where
     for<'v> Assigned<F>: From<&'v V>,

--- a/halo2_proofs/src/plonk/assigned.rs
+++ b/halo2_proofs/src/plonk/assigned.rs
@@ -152,6 +152,18 @@ impl<F: Field> Assigned<F> {
         }
     }
 
+    /// Returns true iff this element is zero.
+    pub fn is_zero_vartime(&self) -> bool {
+        match self {
+            Self::Zero => true,
+            Self::Trivial(x) => x.is_zero_vartime(),
+            // Assigned maps x/0 -> 0.
+            Self::Rational(numerator, denominator) => {
+                numerator.is_zero_vartime() || denominator.is_zero_vartime()
+            }
+        }
+    }
+
     /// Inverts this assigned value (taking the inverse of zero to be zero).
     pub fn invert(&self) -> Self {
         match self {

--- a/halo2_proofs/src/plonk/assigned.rs
+++ b/halo2_proofs/src/plonk/assigned.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use group::ff::Field;
 
@@ -121,6 +121,25 @@ impl<F: Field> Add<F> for Assigned<F> {
     }
 }
 
+impl<F: Field> Add<&Assigned<F>> for Assigned<F> {
+    type Output = Assigned<F>;
+    fn add(self, rhs: &Self) -> Assigned<F> {
+        self + *rhs
+    }
+}
+
+impl<F: Field> AddAssign for Assigned<F> {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
+    }
+}
+
+impl<F: Field> AddAssign<&Assigned<F>> for Assigned<F> {
+    fn add_assign(&mut self, rhs: &Self) {
+        *self = *self + rhs;
+    }
+}
+
 impl<F: Field> Sub for Assigned<F> {
     type Output = Assigned<F>;
     fn sub(self, rhs: Assigned<F>) -> Assigned<F> {
@@ -132,6 +151,25 @@ impl<F: Field> Sub<F> for Assigned<F> {
     type Output = Assigned<F>;
     fn sub(self, rhs: F) -> Assigned<F> {
         self + (-rhs)
+    }
+}
+
+impl<F: Field> Sub<&Assigned<F>> for Assigned<F> {
+    type Output = Assigned<F>;
+    fn sub(self, rhs: &Self) -> Assigned<F> {
+        self - *rhs
+    }
+}
+
+impl<F: Field> SubAssign for Assigned<F> {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
+    }
+}
+
+impl<F: Field> SubAssign<&Assigned<F>> for Assigned<F> {
+    fn sub_assign(&mut self, rhs: &Self) {
+        *self = *self - rhs;
     }
 }
 
@@ -160,6 +198,25 @@ impl<F: Field> Mul<F> for Assigned<F> {
     type Output = Assigned<F>;
     fn mul(self, rhs: F) -> Assigned<F> {
         self * Self::Trivial(rhs)
+    }
+}
+
+impl<F: Field> Mul<&Assigned<F>> for Assigned<F> {
+    type Output = Assigned<F>;
+    fn mul(self, rhs: &Assigned<F>) -> Assigned<F> {
+        self * *rhs
+    }
+}
+
+impl<F: Field> MulAssign for Assigned<F> {
+    fn mul_assign(&mut self, rhs: Self) {
+        *self = *self * rhs;
+    }
+}
+
+impl<F: Field> MulAssign<&Assigned<F>> for Assigned<F> {
+    fn mul_assign(&mut self, rhs: &Self) {
+        *self = *self * rhs;
     }
 }
 

--- a/halo2_proofs/src/plonk/assigned.rs
+++ b/halo2_proofs/src/plonk/assigned.rs
@@ -522,7 +522,10 @@ mod proptests {
         /// Generates half of the denominators as zero to represent a deferred inversion.
         fn arb_rational()(
             numerator in arb_element(),
-            denominator in prop_oneof![Just(Fp::zero()), arb_element()],
+            denominator in prop_oneof![
+                1 => Just(Fp::zero()),
+                2 => arb_element(),
+            ],
         ) -> Assigned<Fp> {
             Assigned::Rational(numerator, denominator)
         }
@@ -546,7 +549,11 @@ mod proptests {
             num_binary in 0usize..5,
         )(
             values in vec(
-                prop_oneof![Just(Assigned::Zero), arb_trivial(), arb_rational()],
+                prop_oneof![
+                    1 => Just(Assigned::Zero),
+                    2 => arb_trivial(),
+                    2 => arb_rational(),
+                ],
                 // Ensure that:
                 // - we have at least one value to apply unary operators to.
                 // - we can apply every binary operator pairwise sequentially.

--- a/halo2_proofs/src/plonk/assigned.rs
+++ b/halo2_proofs/src/plonk/assigned.rs
@@ -251,6 +251,36 @@ impl<F: Field> Assigned<F> {
         }
     }
 
+    /// Doubles this element.
+    #[must_use]
+    pub fn double(&self) -> Self {
+        match self {
+            Self::Zero => Self::Zero,
+            Self::Trivial(x) => Self::Trivial(x.double()),
+            Self::Rational(numerator, denominator) => {
+                Self::Rational(numerator.double(), *denominator)
+            }
+        }
+    }
+
+    /// Squares this element.
+    #[must_use]
+    pub fn square(&self) -> Self {
+        match self {
+            Self::Zero => Self::Zero,
+            Self::Trivial(x) => Self::Trivial(x.square()),
+            Self::Rational(numerator, denominator) => {
+                Self::Rational(numerator.square(), denominator.square())
+            }
+        }
+    }
+
+    /// Cubes this element.
+    #[must_use]
+    pub fn cube(&self) -> Self {
+        self.square() * self
+    }
+
     /// Inverts this assigned value (taking the inverse of zero to be zero).
     pub fn invert(&self) -> Self {
         match self {

--- a/halo2_proofs/src/plonk/assigned.rs
+++ b/halo2_proofs/src/plonk/assigned.rs
@@ -17,6 +17,12 @@ pub enum Assigned<F> {
     Rational(F, F),
 }
 
+impl<F: Field> From<&Assigned<F>> for Assigned<F> {
+    fn from(val: &Assigned<F>) -> Self {
+        *val
+    }
+}
+
 impl<F: Field> From<&F> for Assigned<F> {
     fn from(numerator: &F) -> Self {
         Assigned::Trivial(*numerator)


### PR DESCRIPTION
This PR adds various usability methods to `Assigned<F: Field>`, to make it easier to use in contexts where `F: Field` was previously used.

Closes zcash/halo2#425.