### PR TITLE
dev: Enable `VerifyFailure::ConstraintNotSatisfied` to point to region offsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,9 @@ and this project adheres to Rust's notion of
 - `halo2::dev::VerifyFailure` has been overhauled:
   - `VerifyFailure::ConstraintNotSatisfied` now has a `cell_values` field,
     storing the values of the cells used in the unsatisfied constraint.
-  - The `row` field of `VerifyFailure::Lookup` has been replaced by a `location`
-    field, which can now indicate whether the location falls within an assigned
-    region.
+  - The `row` fields of `VerifyFailure::{ConstraintNotSatisfied, Lookup}` have
+    been replaced by `location` fields, which can now indicate whether the
+    location falls within an assigned region.
 - `halo2::plonk::ConstraintSystem::enable_equality` and 
   `halo2::plonk::ConstraintSystem::query_any` now take `Into<Column<Any>>` instead 
   of `Column<Any>` as a parameter to avoid excesive `.into()` usage.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 ### Added
-- `halo2::dev::LookupFailure` (used in `VerifyFailure::Lookup`)
+- `halo2::dev::FailureLocation` (used in `VerifyFailure::Lookup`)
 
 ### Changed
 - `halo2::plonk::Error` has been overhauled:

--- a/src/dev/metadata.rs
+++ b/src/dev/metadata.rs
@@ -164,3 +164,12 @@ impl From<(usize, String)> for Region {
         Region { index, name }
     }
 }
+
+impl From<(usize, &str)> for Region {
+    fn from((index, name): (usize, &str)) -> Self {
+        Region {
+            index,
+            name: name.to_owned(),
+        }
+    }
+}


### PR DESCRIPTION
Follows on from #431.