### PR TITLE
[dev] Implement `Assignment::fill_from_row()` for `MockProver`.

### DIFF
--- a/src/dev.rs
+++ b/src/dev.rs
@@ -996,7 +996,10 @@ mod tests {
     use super::{LookupFailure, MockProver, VerifyFailure};
     use crate::{
         circuit::{Layouter, SimpleFloorPlanner},
-        plonk::{Advice, Any, Circuit, Column, ConstraintSystem, Error, Selector, TableColumn},
+        plonk::{
+            Advice, Any, Circuit, Column, ConstraintSystem, Error, Expression, Selector,
+            TableColumn,
+        },
         poly::Rotation,
     };
 
@@ -1099,9 +1102,10 @@ mod tests {
                     let q = cells.query_selector(q);
 
                     // If q is enabled, a must be in the table.
-                    // FIXME: This lookup expression should fail when q = 0,
-                    // since 0 is not in the table.
-                    vec![(q * a, table)]
+                    // When q is not enabled, lookup the default value instead.
+                    let not_q = Expression::Constant(Fp::one()) - q.clone();
+                    let default = Expression::Constant(Fp::from(2));
+                    vec![(q * a + not_q * default, table)]
                 });
 
                 FaultyCircuitConfig { a, q, table }

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -553,12 +553,16 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
 
     fn fill_from_row(
         &mut self,
-        _: Column<Fixed>,
+        col: Column<Fixed>,
         from_row: usize,
-        _: Option<Assigned<F>>,
+        to: Option<Assigned<F>>,
     ) -> Result<(), Error> {
         if !self.usable_rows.contains(&from_row) {
             return Err(Error::not_enough_rows_available(self.k));
+        }
+
+        for row in self.usable_rows.clone().skip(from_row) {
+            self.assign_fixed(|| "", col, row, || to.ok_or(Error::Synthesis))?;
         }
 
         Ok(())

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -1095,7 +1095,8 @@ mod tests {
                     let q = cells.query_selector(q);
 
                     // If q is enabled, a must be in the table.
-                    // Zero is in the table, which satisfies the disabled case.
+                    // FIXME: This lookup expression should fail when q = 0,
+                    // since 0 is not in the table.
                     vec![(q * a, table)]
                 });
 
@@ -1114,12 +1115,12 @@ mod tests {
                 layouter.assign_table(
                     || "Doubling table",
                     |mut table| {
-                        (0..(1 << (K - 1)))
+                        (1..(1 << (K - 1)))
                             .map(|i| {
                                 table.assign_cell(
                                     || format!("table[{}] = {}", i, 2 * i),
                                     config.table,
-                                    i,
+                                    i - 1,
                                     || Ok(Fp::from(2 * i as u64)),
                                 )
                             })


### PR DESCRIPTION
This fills the unused rows of a table column with its default value in the `MockProver`.

Review this commit-by-commit, checking that the `bad_lookup` test:
- passes in the first commit (wrong behaviour),
- fails in the second commit (expected behaviour), and
- passes in the last commit after being fixed.