### PR TITLE
Fix compilation with rustc 1.57.0

### DIFF
--- a/examples/sha256/table16/spread_table.rs
+++ b/examples/sha256/table16/spread_table.rs
@@ -418,9 +418,9 @@ mod tests {
                         for _ in 0..10 {
                             let word: u16 = rng.gen();
                             add_row(
-                                F::from(get_tag(word).into()),
-                                F::from(word.into()),
-                                F::from(interleave_u16_with_zeros(word).into()),
+                                F::from(u64::from(get_tag(word))),
+                                F::from(u64::from(word)),
+                                F::from(u64::from(interleave_u16_with_zeros(word))),
                             )?;
                         }
 


### PR DESCRIPTION
The type inference algorithm seems to have been simplified,
meaning that the combination of T::from(x.into()) doesn't work anymore.

In any case, the code was also incomprehensible to a human, as it's not clear
by which "route" it does the transformation. It took me a few minutes to
figure out it's a `u64`.