### PR TITLE
halo2_proofs: Improve `plonk::verify_proof` API

### DIFF
--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -9,13 +9,19 @@ and this project adheres to Rust's notion of
 (relative to `halo2 0.1.0-beta.1`)
 
 ### Added
+- `halo2_proofs::plonk`:
+  - `VerificationStrategy`
+  - `SingleVerifier`, an implementation of `VerificationStrategy` for verifying
+    proofs individually.
+  - `BatchVerifier`, an implementation of `VerificationStrategy` for verifying
+    multiple proofs in a batch.
 - `halo2_proofs::dev::FailureLocation` (used in `VerifyFailure::Lookup`)
 
 ### Changed
-- `halo2_proofs` now depends on `rand_core` instead of `rand`, and requires the
-  caller to provide the specific RNG implementation:
-  - `halo2_proofs::plonk::{create_proof, verify_proof}` now take an argument
-    `R: rand_core::RngCore`.
+- `halo2_proofs::plonk::verify_proof` now takes a `VerificationStrategy` instead
+  of an `MSM` directly.
+- `halo2_proofs` now depends on `rand_core` instead of `rand`.
+- `halo2_proofs::plonk::create_proof` now take an argument `R: rand_core::RngCore`.
 - `halo2_proofs::plonk::Error` has been overhauled:
   - `Error` now implements `std::fmt::Display` and `std::error::Error`.
   - `Error` no longer implements `PartialEq`. Tests can check for specific error

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -268,12 +268,9 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     fn verifier(params: &Params<EqAffine>, vk: &VerifyingKey<EqAffine>, proof: &[u8]) {
-        let rng = OsRng;
-        let msm = params.empty_msm();
+        let strategy = SingleVerifier::new(params);
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(proof);
-        let guard = verify_proof(params, vk, msm, &[&[]], rng, &mut transcript).unwrap();
-        let msm = guard.clone().use_challenges();
-        assert!(msm.eval());
+        assert!(verify_proof(params, vk, strategy, &[&[]], &mut transcript).is_ok());
     }
 
     let k_range = 8..=16;

--- a/halo2_proofs/src/poly/multiopen.rs
+++ b/halo2_proofs/src/poly/multiopen.rs
@@ -323,7 +323,6 @@ fn test_roundtrip() {
 
         let guard = verify_proof(
             &params,
-            rng,
             &mut transcript,
             std::iter::empty()
                 .chain(Some(VerifierQuery::new_commitment(&a, x, avx)))
@@ -346,7 +345,6 @@ fn test_roundtrip() {
 
         let guard = verify_proof(
             &params,
-            rng,
             &mut transcript,
             std::iter::empty()
                 .chain(Some(VerifierQuery::new_commitment(&a, x, avx)))

--- a/halo2_proofs/src/poly/multiopen/verifier.rs
+++ b/halo2_proofs/src/poly/multiopen/verifier.rs
@@ -19,11 +19,9 @@ pub fn verify_proof<
     I,
     C: CurveAffine,
     E: EncodedChallenge<C>,
-    R: RngCore,
     T: TranscriptRead<C, E>,
 >(
     params: &'params Params<C>,
-    rng: R,
     transcript: &mut T,
     queries: I,
     mut msm: MSM<'params, C>,
@@ -31,11 +29,6 @@ pub fn verify_proof<
 where
     I: IntoIterator<Item = VerifierQuery<'r, 'params, C>> + Clone,
 {
-    // Scale the MSM by a random factor to ensure that if the existing MSM
-    // has is_zero() == false then this argument won't be able to interfere
-    // with it to make it true, with high probability.
-    msm.scale(C::Scalar::random(rng));
-
     // Sample x_1 for compressing openings at the same point sets together
     let x_1: ChallengeX1<_> = transcript.squeeze_challenge_scalar();
 


### PR DESCRIPTION
Previously `plonk::verify_proof` took an `MSM` as an argument, to enable
batch verification. However, this also required that it take a source of
randomness in order to enforce separation of proofs within a batch. This
made single-proof verification unnecessarily non-deterministic.

We now have a `VerificationStrategy` trait encapsulating the necessary
details, and separate `SingleVerifier` and `BatchVerifier` structs for
the specific variants. Proof verifiers no longer need to create and
manage the `MSM` themselves, and single-proof verifiers no longer need
to supply a source of randomness.

Co-authored-by: Sean Bowe <sean@electriccoin.co>