### PR TITLE
halo2_gadgets: Migrate from bigint to uint

### DIFF
--- a/halo2_gadgets/Cargo.toml
+++ b/halo2_gadgets/Cargo.toml
@@ -22,7 +22,6 @@ rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "../katex-header.html"]
 
 [dependencies]
 arrayvec = "0.7.0"
-bigint = "4"
 bitvec = "0.22"
 ff = "0.11"
 group = "0.11"
@@ -32,6 +31,7 @@ pasta_curves = "0.3"
 proptest = { version = "1.0.0", optional = true }
 rand = "0.8"
 subtle = "2.3"
+uint = "=0.9.1" # uint 0.9.2 bumps the MSRV to 1.56.1
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", optional = true }

--- a/halo2_gadgets/src/ecc/chip/mul.rs
+++ b/halo2_gadgets/src/ecc/chip/mul.rs
@@ -8,7 +8,6 @@ use std::{
     ops::{Deref, Range},
 };
 
-use bigint::U256;
 use ff::PrimeField;
 use halo2_proofs::{
     arithmetic::FieldExt,
@@ -16,6 +15,7 @@ use halo2_proofs::{
     plonk::{Advice, Column, ConstraintSystem, Error, Selector},
     poly::Rotation,
 };
+use uint::construct_uint;
 
 use pasta_curves::pallas;
 
@@ -425,6 +425,10 @@ impl<F: FieldExt> Deref for Z<F> {
 }
 
 fn decompose_for_scalar_mul(scalar: Option<&pallas::Base>) -> Vec<Option<bool>> {
+    construct_uint! {
+        struct U256(4);
+    }
+
     let bitstring = scalar.map(|scalar| {
         // We use `k = scalar + t_q` in the double-and-add algorithm, where
         // the scalar field `F_q = 2^254 + t_q`.

--- a/halo2_gadgets/src/utilities.rs
+++ b/halo2_gadgets/src/utilities.rs
@@ -182,7 +182,6 @@ pub fn i2lebsp<const NUM_BITS: usize>(int: u64) -> [bool; NUM_BITS] {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bigint::U256;
     use group::ff::{Field, PrimeField};
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner},
@@ -195,6 +194,7 @@ mod tests {
     use rand::rngs::OsRng;
     use std::convert::TryInto;
     use std::iter;
+    use uint::construct_uint;
 
     #[test]
     fn test_range_check() {
@@ -280,6 +280,10 @@ mod tests {
     #[test]
     fn test_bitrange_subset() {
         let rng = OsRng;
+
+        construct_uint! {
+            struct U256(4);
+        }
 
         // Subset full range.
         {


### PR DESCRIPTION
Closes zcash/halo2#457.