### PR TITLE
CI: Fix rustdoc rendering to handle workspace

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Build latest rustdocs
         uses: actions-rs/cargo@v1
         with:
-          command: rustdoc
-          args: -- --cfg docsrs --html-in-header katex-header.html
+          command: doc
+          args: --no-deps --workspace --all-features
+        env:
+          RUSTDOCFLAGS: -Z unstable-options --enable-index-page --cfg docsrs --html-in-header ${{ github.workspace }}/katex-header.html
 
       - name: Move latest rustdocs into book
         run: |


### PR DESCRIPTION
`cargo rustdoc` only works for a single package. To render docs for
a workspace while passing config options to `rustdoc`, we need to use
the `RUSTDOCFLAGS` environment variable.

We also add several other flags to handle the switch to `cargo doc`:
- `--no-deps` ensures we only build packages in the workspace.
- `--enable-index-page` (unstable) adds a landing page showing the list
  of rendered crate docs.