### PR TITLE
CI: Pin nightly version in book workflow

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          # Pinned until https://github.com/rust-lang/rust/issues/93476 is fixed.
+          toolchain: nightly-2022-01-18
           override: true
 
       - name: Setup mdBook


### PR DESCRIPTION
We require nightly Rust to build the documentation, but latest nightly
has a bug where `--no-deps` causes an ICE.