### PR TITLE
halo2_proofs: rename variables for consistency

### DIFF
--- a/book/src/design/protocol.md
+++ b/book/src/design/protocol.md
@@ -369,7 +369,7 @@ $$
 15. $\verifier$ responds with challenge $x_3$.
 16. $\prover$ sends $\mathbf{u} \in \field^{n_q}$ such that $\mathbf{u}_i = q_i(x_3)$ for all $i \in [0, n_q)$.
 17. $\verifier$ responds with challenge $x_4$.
-18. $\verifier$ set $P = Q' + x_4 \sum\limits_{i=0}^{n_q - 1} [x_4^i] Q_i$ and $v = $
+18. $\verifier$ sets $P = Q' + x_4 \sum\limits_{i=0}^{n_q - 1} [x_4^i] Q_i$ and $v = $
 $$
 \sum\limits_{i=0}^{n_q - 1}
 \left(

--- a/book/src/design/protocol.md
+++ b/book/src/design/protocol.md
@@ -369,7 +369,7 @@ $$
 15. $\verifier$ responds with challenge $x_3$.
 16. $\prover$ sends $\mathbf{u} \in \field^{n_q}$ such that $\mathbf{u}_i = q_i(x_3)$ for all $i \in [0, n_q)$.
 17. $\verifier$ responds with challenge $x_4$.
-18. $\prover$ and $\verifier$ set $P = Q' + x_4 \sum\limits_{i=0}^{n_q - 1} [x_4^i] Q_i$ and $v = $
+18. $\verifier$ set $P = Q' + x_4 \sum\limits_{i=0}^{n_q - 1} [x_4^i] Q_i$ and $v = $
 $$
 \sum\limits_{i=0}^{n_q - 1}
 \left(
@@ -392,12 +392,12 @@ $$
 19. $\prover$ sets $p(X) = q'(X) + [x_4] \sum\limits_{i=0}^{n_q - 1} x_4^i q_i(X)$.
 20. $\prover$ samples a random polynomial $s(X)$ of degree $n - 1$ with a root at $x_3$ and sends a commitment $S = \innerprod{\mathbf{s}}{\mathbf{G}} + [\cdot] W$ where $\mathbf{s}$ defines the coefficients of $s(X)$.
 21. $\verifier$ responds with challenges $\xi, z$.
-22. $\prover$ and $\verifier$ set $P' = P - [v] \mathbf{G}_0 + [\xi] S$.
-23. $\prover$ sets $p'(X) = p(X) - v + \xi s(X)$.
+22. $\verifier$ sets $P' = P - [v] \mathbf{G}_0 + [\xi] S$.
+23. $\prover$ sets $p'(X) = p(X) - p(x_3) + \xi s(X)$ (where $p(x_3)$ should correspond with the verifier's computed value $v$).
 24. Initialize $\mathbf{p'}$ as the coefficients of $p'(X)$ and $\mathbf{G'} = \mathbf{G}$ and $\mathbf{b} = (x_3^0, x_3^1, ..., x_3^{n - 1})$. $\prover$ and $\verifier$ will interact in the following $k$ rounds, where in the $j$th round starting in round $j=0$ and ending in round $j=k-1$:
   * $\prover$ sends $L_j = \innerprod{\mathbf{p'}_\hi}{\mathbf{G'}_\lo} + [z \innerprod{\mathbf{p'}_\hi}{\mathbf{b}_\lo}] U + [\cdot] W$ and $R_j = \innerprod{\mathbf{p'}_\lo}{\mathbf{G'}_\hi} + [z \innerprod{\mathbf{p'}_\lo}{\mathbf{b}_\hi}] U + [\cdot] W$.
   * $\verifier$ responds with challenge $u_j$.
-  * $\prover$ and $\verifier$ set $\mathbf{G'} := \mathbf{G'}_\lo + u_j \mathbf{G'}_\hi$ and $\mathbf{b} = \mathbf{b}_\lo + u_j \mathbf{b}_\hi$.
+  * $\prover$ and $\verifier$ set $\mathbf{G'} := \mathbf{G'}_\lo + u_j \mathbf{G'}_\hi$ and $\mathbf{b} := \mathbf{b}_\lo + u_j \mathbf{b}_\hi$.
   * $\prover$ sets $\mathbf{p'} := \mathbf{p'}_\lo + u_j^{-1} \mathbf{p'}_\hi$.
-25. $\prover$ sends $c = \mathbf{p'}_0$ and synthetic blinding factor $f$.
+25. $\prover$ sends $c = \mathbf{p'}_0$ and synthetic blinding factor $f$ computed from the elided blinding factors.
 26. $\verifier$ accepts only if $\sum_{j=0}^{k - 1} [u_j^{-1}] L_j + P' + \sum_{j=0}^{k - 1} [u_j] R_j = [c] \mathbf{G'}_0 + [c \mathbf{b}_0 z] U + [f] W$.

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -30,7 +30,7 @@ pub struct Params<C: CurveAffine> {
     pub(crate) n: u64,
     pub(crate) g: Vec<C>,
     pub(crate) g_lagrange: Vec<C>,
-    pub(crate) h: C,
+    pub(crate) w: C,
     pub(crate) u: C,
 }
 
@@ -102,7 +102,7 @@ impl<C: CurveAffine> Params<C> {
         };
 
         let hasher = C::CurveExt::hash_to_curve("Halo2-Parameters");
-        let h = hasher(&[1]).to_affine();
+        let w = hasher(&[1]).to_affine();
         let u = hasher(&[2]).to_affine();
 
         Params {
@@ -110,7 +110,7 @@ impl<C: CurveAffine> Params<C> {
             n,
             g,
             g_lagrange,
-            h,
+            w,
             u,
         }
     }
@@ -126,7 +126,7 @@ impl<C: CurveAffine> Params<C> {
         tmp_scalars.push(r.0);
 
         tmp_bases.extend(self.g.iter());
-        tmp_bases.push(self.h);
+        tmp_bases.push(self.w);
 
         best_multiexp::<C>(&tmp_scalars, &tmp_bases)
     }
@@ -146,7 +146,7 @@ impl<C: CurveAffine> Params<C> {
         tmp_scalars.push(r.0);
 
         tmp_bases.extend(self.g_lagrange.iter());
-        tmp_bases.push(self.h);
+        tmp_bases.push(self.w);
 
         best_multiexp::<C>(&tmp_scalars, &tmp_bases)
     }
@@ -171,7 +171,7 @@ impl<C: CurveAffine> Params<C> {
         for g_lagrange_element in &self.g_lagrange {
             writer.write_all(g_lagrange_element.to_bytes().as_ref())?;
         }
-        writer.write_all(self.h.to_bytes().as_ref())?;
+        writer.write_all(self.w.to_bytes().as_ref())?;
         writer.write_all(self.u.to_bytes().as_ref())?;
 
         Ok(())
@@ -188,7 +188,7 @@ impl<C: CurveAffine> Params<C> {
         let g: Vec<_> = (0..n).map(|_| C::read(reader)).collect::<Result<_, _>>()?;
         let g_lagrange: Vec<_> = (0..n).map(|_| C::read(reader)).collect::<Result<_, _>>()?;
 
-        let h = C::read(reader)?;
+        let w = C::read(reader)?;
         let u = C::read(reader)?;
 
         Ok(Params {
@@ -196,7 +196,7 @@ impl<C: CurveAffine> Params<C> {
             n,
             g,
             g_lagrange,
-            h,
+            w,
             u,
         })
     }

--- a/halo2_proofs/src/poly/commitment/msm.rs
+++ b/halo2_proofs/src/poly/commitment/msm.rs
@@ -8,7 +8,7 @@ use group::Group;
 pub struct MSM<'a, C: CurveAffine> {
     pub(crate) params: &'a Params<C>,
     g_scalars: Option<Vec<C::Scalar>>,
-    h_scalar: Option<C::Scalar>,
+    w_scalar: Option<C::Scalar>,
     u_scalar: Option<C::Scalar>,
     other_scalars: Vec<C::Scalar>,
     other_bases: Vec<C>,
@@ -18,7 +18,7 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
     /// Create a new, empty MSM using the provided parameters.
     pub fn new(params: &'a Params<C>) -> Self {
         let g_scalars = None;
-        let h_scalar = None;
+        let w_scalar = None;
         let u_scalar = None;
         let other_scalars = vec![];
         let other_bases = vec![];
@@ -26,7 +26,7 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
         MSM {
             params,
             g_scalars,
-            h_scalar,
+            w_scalar,
             u_scalar,
             other_scalars,
             other_bases,
@@ -42,8 +42,8 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
             self.add_to_g_scalars(g_scalars);
         }
 
-        if let Some(h_scalar) = &other.h_scalar {
-            self.add_to_h_scalar(*h_scalar);
+        if let Some(w_scalar) = &other.w_scalar {
+            self.add_to_w_scalar(*w_scalar);
         }
 
         if let Some(u_scalar) = &other.u_scalar {
@@ -83,9 +83,9 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
         }
     }
 
-    /// Add to `h_scalar`
-    pub fn add_to_h_scalar(&mut self, scalar: C::Scalar) {
-        self.h_scalar = self.h_scalar.map_or(Some(scalar), |a| Some(a + &scalar));
+    /// Add to `w_scalar`
+    pub fn add_to_w_scalar(&mut self, scalar: C::Scalar) {
+        self.w_scalar = self.w_scalar.map_or(Some(scalar), |a| Some(a + &scalar));
     }
 
     /// Add to `u_scalar`
@@ -111,14 +111,14 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
             })
         }
 
-        self.h_scalar = self.h_scalar.map(|a| a * &factor);
+        self.w_scalar = self.w_scalar.map(|a| a * &factor);
         self.u_scalar = self.u_scalar.map(|a| a * &factor);
     }
 
     /// Perform multiexp and check that it results in zero
     pub fn eval(self) -> bool {
         let len = self.g_scalars.as_ref().map(|v| v.len()).unwrap_or(0)
-            + self.h_scalar.map(|_| 1).unwrap_or(0)
+            + self.w_scalar.map(|_| 1).unwrap_or(0)
             + self.u_scalar.map(|_| 1).unwrap_or(0)
             + self.other_scalars.len();
         let mut scalars: Vec<C::Scalar> = Vec::with_capacity(len);
@@ -127,9 +127,9 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
         scalars.extend(&self.other_scalars);
         bases.extend(&self.other_bases);
 
-        if let Some(h_scalar) = self.h_scalar {
-            scalars.push(h_scalar);
-            bases.push(self.params.h);
+        if let Some(w_scalar) = self.w_scalar {
+            scalars.push(w_scalar);
+            bases.push(self.params.w);
         }
 
         if let Some(u_scalar) = self.u_scalar {

--- a/halo2_proofs/src/poly/commitment/prover.rs
+++ b/halo2_proofs/src/poly/commitment/prover.rs
@@ -33,23 +33,23 @@ pub fn create_proof<
     params: &Params<C>,
     mut rng: R,
     transcript: &mut T,
-    px: &Polynomial<C::Scalar, Coeff>,
-    blind: Blind<C::Scalar>,
+    p_poly: &Polynomial<C::Scalar, Coeff>,
+    p_blind: Blind<C::Scalar>,
     x: C::Scalar,
 ) -> io::Result<()> {
     // We're limited to polynomials of degree n - 1.
-    assert!(px.len() <= params.n as usize);
+    assert_eq!(p_poly.len(), params.n as usize);
 
     // Sample a random polynomial (of same degree) that has a root at x, first
     // by setting all coefficients to random values.
-    let mut s_poly = (*px).clone();
+    let mut s_poly = (*p_poly).clone();
     for coeff in s_poly.iter_mut() {
         *coeff = C::Scalar::random(&mut rng);
     }
     // Evaluate the random polynomial at x
-    let v_prime = eval_polynomial(&s_poly[..], x);
+    let s_at_x = eval_polynomial(&s_poly[..], x);
     // Subtract constant coefficient to get a random polynomial with a root at x
-    s_poly[0] = s_poly[0] - &v_prime;
+    s_poly[0] = s_poly[0] - &s_at_x;
     // And sample a random blind
     let s_poly_blind = Blind(C::Scalar::random(&mut rng));
 
@@ -60,27 +60,29 @@ pub fn create_proof<
     // Challenge that will ensure that the prover cannot change P but can only
     // witness a random polynomial commitment that agrees with P at x, with high
     // probability.
-    let iota = *transcript.squeeze_challenge_scalar::<()>();
+    let xi = *transcript.squeeze_challenge_scalar::<()>();
 
     // Challenge that ensures that the prover did not interfere with the U term
     // in their commitments.
     let z = *transcript.squeeze_challenge_scalar::<()>();
 
-    // We'll be opening `s_poly_commitment * iota + P - [v] G_0` to ensure it
-    // has a root at zero.
-    let mut final_poly = s_poly * iota + px;
-    let v = eval_polynomial(&final_poly, x);
-    final_poly[0] = final_poly[0] - &v;
-    let blind = s_poly_blind * Blind(iota) + blind;
-    let mut blind = blind.0;
+    // We'll be opening `P' = P - [v] G_0 + [\xi] S` to ensure it has a root at
+    // zero.
+    let mut p_prime_poly = s_poly * xi + p_poly;
+    let v = eval_polynomial(&p_prime_poly, x);
+    p_prime_poly[0] = p_prime_poly[0] - &v;
+    let p_prime_blind = s_poly_blind * Blind(xi) + p_blind;
 
-    // Initialize the vector `a` as the coefficients of the polynomial,
-    // rounding up to the parameters.
-    let mut a = final_poly.values;
-    a.resize(params.n as usize, C::Scalar::zero());
+    // This accumulates the synthetic blinding factor `f` starting
+    // with the blinding factor for `P'`.
+    let mut f = p_prime_blind.0;
+
+    // Initialize the vector `p_prime` as the coefficients of the polynomial.
+    let mut p_prime = p_prime_poly.values;
+    assert_eq!(p_prime.len(), params.n as usize);
 
     // Initialize the vector `b` as the powers of `x`. The inner product of
-    // `a` and `b` is the evaluation of the polynomial at `x`.
+    // `p_prime` and `b` is the evaluation of the polynomial at `x`.
     let mut b = Vec::with_capacity(1 << params.k);
     {
         let mut cur = C::Scalar::one();
@@ -90,60 +92,60 @@ pub fn create_proof<
         }
     }
 
-    // Initialize the vector `G` from the URS. We'll be progressively collapsing
+    // Initialize the vector `G'` from the URS. We'll be progressively collapsing
     // this vector into smaller and smaller vectors until it is of length 1.
-    let mut g = params.g.clone();
+    let mut g_prime = params.g.clone();
 
     // Perform the inner product argument, round by round.
-    for k in (1..=params.k).rev() {
-        let half = 1 << (k - 1); // half the length of `a`, `b`, `G`
+    for j in 0..params.k {
+        let half = 1 << (params.k - j - 1); // half the length of `p_prime`, `b`, `G'`
 
         // Compute L, R
         //
         // TODO: If we modify multiexp to take "extra" bases, we could speed
         // this piece up a bit by combining the multiexps.
-        let l = best_multiexp(&a[half..], &g[0..half]);
-        let r = best_multiexp(&a[0..half], &g[half..]);
-        let value_l = compute_inner_product(&a[half..], &b[0..half]);
-        let value_r = compute_inner_product(&a[0..half], &b[half..]);
-        let l_randomness = C::Scalar::random(&mut rng);
-        let r_randomness = C::Scalar::random(&mut rng);
-        let l = l + &best_multiexp(&[value_l * &z, l_randomness], &[params.u, params.h]);
-        let r = r + &best_multiexp(&[value_r * &z, r_randomness], &[params.u, params.h]);
-        let l = l.to_affine();
-        let r = r.to_affine();
+        let l_j = best_multiexp(&p_prime[half..], &g_prime[0..half]);
+        let r_j = best_multiexp(&p_prime[0..half], &g_prime[half..]);
+        let value_l_j = compute_inner_product(&p_prime[half..], &b[0..half]);
+        let value_r_j = compute_inner_product(&p_prime[0..half], &b[half..]);
+        let l_j_randomness = C::Scalar::random(&mut rng);
+        let r_j_randomness = C::Scalar::random(&mut rng);
+        let l_j = l_j + &best_multiexp(&[value_l_j * &z, l_j_randomness], &[params.u, params.w]);
+        let r_j = r_j + &best_multiexp(&[value_r_j * &z, r_j_randomness], &[params.u, params.w]);
+        let l_j = l_j.to_affine();
+        let r_j = r_j.to_affine();
 
         // Feed L and R into the real transcript
-        transcript.write_point(l)?;
-        transcript.write_point(r)?;
+        transcript.write_point(l_j)?;
+        transcript.write_point(r_j)?;
 
-        let challenge = *transcript.squeeze_challenge_scalar::<()>();
-        let challenge_inv = challenge.invert().unwrap(); // TODO, bubble this up
+        let u_j = *transcript.squeeze_challenge_scalar::<()>();
+        let u_j_inv = u_j.invert().unwrap(); // TODO, bubble this up
 
-        // Collapse `a` and `b`.
+        // Collapse `p_prime` and `b`.
         // TODO: parallelize
         for i in 0..half {
-            a[i] = a[i] + &(a[i + half] * &challenge_inv);
-            b[i] = b[i] + &(b[i + half] * &challenge);
+            p_prime[i] = p_prime[i] + &(p_prime[i + half] * &u_j_inv);
+            b[i] = b[i] + &(b[i + half] * &u_j);
         }
-        a.truncate(half);
+        p_prime.truncate(half);
         b.truncate(half);
 
-        // Collapse `G`
-        parallel_generator_collapse(&mut g, challenge);
-        g.truncate(half);
+        // Collapse `G'`
+        parallel_generator_collapse(&mut g_prime, u_j);
+        g_prime.truncate(half);
 
         // Update randomness (the synthetic blinding factor at the end)
-        blind += &(l_randomness * &challenge_inv);
-        blind += &(r_randomness * &challenge);
+        f += &(l_j_randomness * &u_j_inv);
+        f += &(r_j_randomness * &u_j);
     }
 
-    // We have fully collapsed `a`, `b`, `G`
-    assert_eq!(a.len(), 1);
-    let a = a[0];
+    // We have fully collapsed `p_prime`, `b`, `G'`
+    assert_eq!(p_prime.len(), 1);
+    let c = p_prime[0];
 
-    transcript.write_scalar(a)?;
-    transcript.write_scalar(blind)?; // \xi
+    transcript.write_scalar(c)?;
+    transcript.write_scalar(f)?;
 
     Ok(())
 }

--- a/halo2_proofs/src/poly/commitment/verifier.rs
+++ b/halo2_proofs/src/poly/commitment/verifier.rs
@@ -24,8 +24,8 @@ pub struct Accumulator<C: CurveAffine, E: EncodedChallenge<C>> {
     /// The claimed output of the linear-time polycommit opening protocol
     pub g: C,
 
-    /// A vector of 128-bit challenges u_0, ..., u_{k - 1} sampled by the
-    /// verifier, to be used in computing G'_0.
+    /// A vector of challenges u_0, ..., u_{k - 1} sampled by the verifier, to
+    /// be used in computing G'_0.
     pub u_packed: Vec<E>,
 }
 


### PR DESCRIPTION
This changes variable names in the multiopen and commitment opening implementations
and the book's protocol description to keep names and indicies consistent with one
another.

Co-Authored-By: Jack Grigg <jack@electriccoin.co>