### PR TITLE
Bench heavily padded lookup in MockProver.

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -34,6 +34,10 @@ harness = false
 name = "plonk"
 harness = false
 
+[[bench]]
+name = "dev_lookup"
+harness = false
+
 [dependencies]
 backtrace = { version = "0.3", optional = true }
 rayon = "1.5.1"

--- a/halo2_proofs/benches/dev_lookup.rs
+++ b/halo2_proofs/benches/dev_lookup.rs
@@ -1,0 +1,116 @@
+#[macro_use]
+extern crate criterion;
+
+use halo2_proofs::arithmetic::FieldExt;
+use halo2_proofs::circuit::{Layouter, SimpleFloorPlanner};
+use halo2_proofs::dev::MockProver;
+use halo2_proofs::plonk::*;
+use halo2_proofs::poly::Rotation;
+use pasta_curves::pallas;
+
+use std::marker::PhantomData;
+
+use criterion::{BenchmarkId, Criterion};
+
+fn criterion_benchmark(c: &mut Criterion) {
+    #[derive(Clone, Default)]
+    struct MyCircuit<F: FieldExt> {
+        k: usize,
+        _marker: PhantomData<F>,
+    }
+
+    #[derive(Clone)]
+    struct MyConfig {
+        selector: Selector,
+        table: TableColumn,
+        advice: Column<Advice>,
+    }
+
+    impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
+        type Config = MyConfig;
+        type FloorPlanner = SimpleFloorPlanner;
+
+        fn without_witnesses(&self) -> Self {
+            Self::default()
+        }
+
+        fn configure(meta: &mut ConstraintSystem<F>) -> MyConfig {
+            let config = MyConfig {
+                selector: meta.complex_selector(),
+                table: meta.lookup_table_column(),
+                advice: meta.advice_column(),
+            };
+
+            meta.lookup(|meta| {
+                let selector = meta.query_selector(config.selector);
+                let not_selector = Expression::Constant(F::one()) - selector.clone();
+                let advice = meta.query_advice(config.advice, Rotation::cur());
+                vec![(selector * advice + not_selector, config.table)]
+            });
+
+            config
+        }
+
+        fn synthesize(
+            &self,
+            config: MyConfig,
+            mut layouter: impl Layouter<F>,
+        ) -> Result<(), Error> {
+            layouter.assign_table(
+                || "8-bit table",
+                |mut table| {
+                    for row in 0u64..(1 << 8) {
+                        table.assign_cell(
+                            || format!("row {}", row),
+                            config.table,
+                            row as usize,
+                            || Ok(F::from(row + 1)),
+                        )?;
+                    }
+
+                    Ok(())
+                },
+            )?;
+
+            layouter.assign_region(
+                || "assign values",
+                |mut region| {
+                    for offset in 0u64..(1 << 10) {
+                        config.selector.enable(&mut region, offset as usize)?;
+                        region.assign_advice(
+                            || format!("offset {}", offset),
+                            config.advice,
+                            offset as usize,
+                            || Ok(F::from((offset % 256) + 1)),
+                        )?;
+                    }
+
+                    Ok(())
+                },
+            )
+        }
+    }
+
+    fn prover(k: u32) {
+        let circuit = MyCircuit::<pallas::Base> {
+            k: k as usize,
+            _marker: PhantomData,
+        };
+        let prover = MockProver::run(k, &circuit, vec![]).unwrap();
+        assert_eq!(prover.verify(), Ok(()))
+    }
+
+    let k_range = 14..=18;
+
+    let mut prover_group = c.benchmark_group("dev-lookup");
+    prover_group.sample_size(10);
+    for k in k_range.clone() {
+        prover_group.bench_with_input(BenchmarkId::from_parameter(k), &k, |b, &k| {
+            b.iter(|| prover(k));
+        });
+    }
+    prover_group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/halo2_proofs/benches/dev_lookup.rs
+++ b/halo2_proofs/benches/dev_lookup.rs
@@ -15,7 +15,6 @@ use criterion::{BenchmarkId, Criterion};
 fn criterion_benchmark(c: &mut Criterion) {
     #[derive(Clone, Default)]
     struct MyCircuit<F: FieldExt> {
-        k: usize,
         _marker: PhantomData<F>,
     }
 
@@ -93,7 +92,6 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     fn prover(k: u32) {
         let circuit = MyCircuit::<pallas::Base> {
-            k: k as usize,
             _marker: PhantomData,
         };
         let prover = MockProver::run(k, &circuit, vec![]).unwrap();
@@ -104,7 +102,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
     let mut prover_group = c.benchmark_group("dev-lookup");
     prover_group.sample_size(10);
-    for k in k_range.clone() {
+    for k in k_range {
         prover_group.bench_with_input(BenchmarkId::from_parameter(k), &k, |b, &k| {
             b.iter(|| prover(k));
         });


### PR DESCRIPTION
Closes #528.

When run on top of #445, we see performance improvements of about 65%:

```

dev-lookup/14           time:   [4.8397 ms 5.0149 ms 5.3867 ms]                          
                        change: [-61.752% -60.165% -58.040%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  2 (20.00%) high severe
dev-lookup/15           time:   [8.3559 ms 8.4126 ms 8.5434 ms]                         
                        change: [-66.010% -65.394% -64.644%] (p = 0.00 < 0.05)
                        Performance has improved.
dev-lookup/16           time:   [17.002 ms 17.195 ms 17.332 ms]                         
                        change: [-66.549% -66.182% -65.789%] (p = 0.00 < 0.05)
                        Performance has improved.
dev-lookup/17           time:   [33.441 ms 35.614 ms 38.032 ms]                         
                        change: [-66.653% -65.223% -63.606%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) high mild
  1 (10.00%) high severe
dev-lookup/18           time:   [63.678 ms 65.627 ms 67.417 ms]                         
                        change: [-70.026% -69.202% -68.376%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```