### PR TITLE
Reduce depth of AST by special casing the application of Horner's rule

### DIFF
--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- PLONK prover was improved to avoid stack overflows when large numbers of gates
+  are involved in a proof.
+
 ## [0.1.0-beta.3] - 2022-03-22
 ### Added
 - `halo2_proofs::circuit`:

--- a/halo2_proofs/src/plonk/vanishing/prover.rs
+++ b/halo2_proofs/src/plonk/vanishing/prover.rs
@@ -77,9 +77,7 @@ impl<C: CurveAffine> Committed<C> {
         transcript: &mut T,
     ) -> Result<Constructed<C>, Error> {
         // Evaluate the h(X) polynomial's constraint system expressions for the constraints provided
-        let h_poly = expressions
-            .reduce(|h_poly, v| &(&h_poly * *y) + &v) // Fold the gates together with the y challenge
-            .unwrap_or_else(|| poly::Ast::ConstantTerm(C::Scalar::zero()));
+        let h_poly = poly::Ast::distribute_powers(expressions, *y); // Fold the gates together with the y challenge
         let h_poly = evaluator.evaluate(&h_poly, domain); // Evaluate the h(X) polynomial
 
         // Divide by t(X) = X^{params.n} - 1.

--- a/halo2_proofs/src/poly/evaluator.rs
+++ b/halo2_proofs/src/poly/evaluator.rs
@@ -154,7 +154,7 @@ impl<E, F: Field, B: Basis> Evaluator<E, F, B> {
                     .iter()
                     .map(|term| collect_rotations(term))
                     .reduce(|a, b| a.union(&b).cloned().collect())
-                    .unwrap_or(HashSet::new()),
+                    .unwrap_or_default(),
                 Ast::LinearTerm(_) | Ast::ConstantTerm(_) => HashSet::default(),
             }
         }

--- a/halo2_proofs/src/poly/evaluator.rs
+++ b/halo2_proofs/src/poly/evaluator.rs
@@ -205,7 +205,10 @@ impl<E, F: Field, B: Basis> Evaluator<E, F, B> {
             /// Returns the actual size of the chunk we're operating on in this
             /// context, which may be smaller than `chunk_size`.
             fn local_chunk_size(&self) -> usize {
-                cmp::min(self.chunk_size, self.poly_len - self.chunk_size * self.chunk_index)
+                cmp::min(
+                    self.chunk_size,
+                    self.poly_len - self.chunk_size * self.chunk_index,
+                )
             }
         }
 


### PR DESCRIPTION
The existing code will fold together a very deep AST that applies Horner's
rule to each gate in a proof -- which could include multiple circuits and
so for some applications will quickly grow such that when we recursively
descend later during evaluation the stack will easily overflow.

This change special cases the application of Horner's rule to a
"DistributePowers" AST node to keep the tree depth from exploding in size.

Closes #536 