### PR TITLE
halo2_gadgets: Migrate chip gates to `Constraints::with_selector`

### DIFF
--- a/halo2_gadgets/src/ecc/chip/add.rs
+++ b/halo2_gadgets/src/ecc/chip/add.rs
@@ -4,7 +4,7 @@ use super::EccPoint;
 use ff::{BatchInvert, Field};
 use halo2_proofs::{
     circuit::Region,
-    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
 use pasta_curves::{arithmetic::FieldExt, pallas};
@@ -204,11 +204,13 @@ impl Config {
             // ((1 - (x_q - x_p) * α - (y_q + y_p) * δ)) * y_r
             let poly12 = (one - if_alpha - if_delta) * y_r;
 
-            array::IntoIter::new([
-                poly1, poly2, poly3, poly4, poly5, poly6, poly7, poly8, poly9, poly10, poly11,
-                poly12,
-            ])
-            .map(move |poly| q_add.clone() * poly)
+            Constraints::with_selector(
+                q_add,
+                array::IntoIter::new([
+                    poly1, poly2, poly3, poly4, poly5, poly6, poly7, poly8, poly9, poly10, poly11,
+                    poly12,
+                ]),
+            )
         });
     }
 

--- a/halo2_gadgets/src/ecc/chip/add_incomplete.rs
+++ b/halo2_gadgets/src/ecc/chip/add_incomplete.rs
@@ -5,7 +5,7 @@ use ff::Field;
 use group::Curve;
 use halo2_proofs::{
     circuit::Region,
-    plonk::{Advice, Column, ConstraintSystem, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
     poly::Rotation,
 };
 use pasta_curves::{arithmetic::CurveAffine, pallas};
@@ -74,8 +74,10 @@ impl Config {
             // (y_r + y_q)(x_p − x_q) − (y_p − y_q)(x_q − x_r) = 0
             let poly2 = (y_r + y_q.clone()) * (x_p - x_q.clone()) - (y_p - y_q) * (x_q - x_r);
 
-            array::IntoIter::new([("x_r", poly1), ("y_r", poly2)])
-                .map(move |(name, poly)| (name, q_add_incomplete.clone() * poly))
+            Constraints::with_selector(
+                q_add_incomplete,
+                array::IntoIter::new([("x_r", poly1), ("y_r", poly2)]),
+            )
         });
     }
 

--- a/halo2_gadgets/src/ecc/chip/mul.rs
+++ b/halo2_gadgets/src/ecc/chip/mul.rs
@@ -12,7 +12,7 @@ use ff::PrimeField;
 use halo2_proofs::{
     arithmetic::FieldExt,
     circuit::{AssignedCell, Layouter, Region},
-    plonk::{Advice, Column, ConstraintSystem, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
     poly::Rotation,
 };
 use uint::construct_uint;
@@ -151,12 +151,14 @@ impl Config {
             let lsb_x = ternary(lsb.clone(), x_p.clone(), x_p - base_x);
             let lsb_y = ternary(lsb, y_p.clone(), y_p + base_y);
 
-            std::array::IntoIter::new([
-                ("bool_check", bool_check),
-                ("lsb_x", lsb_x),
-                ("lsb_y", lsb_y),
-            ])
-            .map(move |(name, poly)| (name, q_mul_lsb.clone() * poly))
+            Constraints::with_selector(
+                q_mul_lsb,
+                std::array::IntoIter::new([
+                    ("bool_check", bool_check),
+                    ("lsb_x", lsb_x),
+                    ("lsb_y", lsb_y),
+                ]),
+            )
         });
     }
 

--- a/halo2_gadgets/src/ecc/chip/mul/complete.rs
+++ b/halo2_gadgets/src/ecc/chip/mul/complete.rs
@@ -4,7 +4,7 @@ use crate::utilities::{bool_check, ternary};
 
 use halo2_proofs::{
     circuit::Region,
-    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
 
@@ -72,8 +72,10 @@ impl Config {
                 // k_i = 1 => y_p = base_y
                 let y_switch = ternary(k, base_y.clone() - y_p.clone(), base_y + y_p);
 
-                std::array::IntoIter::new([("bool_check", bool_check), ("y_switch", y_switch)])
-                    .map(move |(name, poly)| (name, q_mul_decompose_var.clone() * poly))
+                Constraints::with_selector(
+                    q_mul_decompose_var,
+                    std::array::IntoIter::new([("bool_check", bool_check), ("y_switch", y_switch)]),
+                )
             },
         );
     }

--- a/halo2_gadgets/src/ecc/chip/mul/overflow.rs
+++ b/halo2_gadgets/src/ecc/chip/mul/overflow.rs
@@ -3,7 +3,7 @@ use crate::{primitives::sinsemilla, utilities::lookup_range_check::LookupRangeCh
 use halo2_proofs::circuit::AssignedCell;
 use halo2_proofs::{
     circuit::Layouter,
-    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
 
@@ -82,14 +82,15 @@ impl Config {
             // (1 - k_254) * (1 - z_130 * eta) * s_minus_lo_130 = 0
             let canonicity = (one.clone() - k_254) * (one - z_130 * eta) * s_minus_lo_130;
 
-            iter::empty()
-                .chain(Some(("s_check", s_check)))
-                .chain(Some(("recovery", recovery)))
-                .chain(Some(("lo_zero", lo_zero)))
-                .chain(Some(("s_minus_lo_130_check", s_minus_lo_130_check)))
-                .chain(Some(("canonicity", canonicity)))
-                .map(|(name, poly)| (name, q_mul_overflow.clone() * poly))
-                .collect::<Vec<_>>()
+            Constraints::with_selector(
+                q_mul_overflow,
+                iter::empty()
+                    .chain(Some(("s_check", s_check)))
+                    .chain(Some(("recovery", recovery)))
+                    .chain(Some(("lo_zero", lo_zero)))
+                    .chain(Some(("s_minus_lo_130_check", s_minus_lo_130_check)))
+                    .chain(Some(("canonicity", canonicity))),
+            )
         });
     }
 

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/base_field_elem.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/base_field_elem.rs
@@ -9,7 +9,7 @@ use crate::{
 use group::ff::PrimeField;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter},
-    plonk::{Advice, Column, ConstraintSystem, Error, Expression, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
 use pasta_curves::{arithmetic::FieldExt, pallas};
@@ -148,10 +148,12 @@ impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
                     )))
             };
 
-            canon_checks
-                .chain(decomposition_checks)
-                .chain(Some(("alpha_0_prime check", alpha_0_prime_check)))
-                .map(move |(name, poly)| (name, q_mul_fixed_base_field.clone() * poly))
+            Constraints::with_selector(
+                q_mul_fixed_base_field,
+                canon_checks
+                    .chain(decomposition_checks)
+                    .chain(Some(("alpha_0_prime check", alpha_0_prime_check))),
+            )
         });
     }
 

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -5,7 +5,7 @@ use crate::{ecc::chip::MagnitudeSign, utilities::bool_check};
 
 use halo2_proofs::{
     circuit::{Layouter, Region},
-    plonk::{ConstraintSystem, Error, Expression, Selector},
+    plonk::{ConstraintSystem, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
 use pasta_curves::pallas;
@@ -57,13 +57,15 @@ impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
             // Check that the correct sign is witnessed s.t. sign * y_p = y_a
             let negation_check = sign * y_p - y_a;
 
-            array::IntoIter::new([
-                ("last_window_check", last_window_check),
-                ("sign_check", sign_check),
-                ("y_check", y_check),
-                ("negation_check", negation_check),
-            ])
-            .map(move |(name, poly)| (name, q_mul_fixed_short.clone() * poly))
+            Constraints::with_selector(
+                q_mul_fixed_short,
+                array::IntoIter::new([
+                    ("last_window_check", last_window_check),
+                    ("sign_check", sign_check),
+                    ("y_check", y_check),
+                    ("negation_check", negation_check),
+                ]),
+            )
         });
     }
 

--- a/halo2_gadgets/src/sinsemilla/chip.rs
+++ b/halo2_gadgets/src/sinsemilla/chip.rs
@@ -16,8 +16,8 @@ use std::marker::PhantomData;
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter},
     plonk::{
-        Advice, Column, ConstraintSystem, Error, Expression, Fixed, Selector, TableColumn,
-        VirtualCells,
+        Advice, Column, ConstraintSystem, Constraints, Error, Expression, Fixed, Selector,
+        TableColumn, VirtualCells,
     },
     poly::Rotation,
 };
@@ -210,7 +210,7 @@ where
             // 2 * y_q - Y_{A,0} = 0
             let init_y_q_check = y_q * two - Y_A_cur;
 
-            vec![q_s4 * init_y_q_check]
+            Constraints::with_selector(q_s4, Some(("init_y_q_check", init_y_q_check)))
         });
 
         meta.create_gate("Sinsemilla gate", |meta| {
@@ -259,10 +259,10 @@ where
                 lhs - rhs
             };
 
-            vec![
-                ("Secant line", q_s1.clone() * secant_line),
-                ("y check", q_s1 * y_check),
-            ]
+            Constraints::with_selector(
+                q_s1,
+                std::array::IntoIter::new([("Secant line", secant_line), ("y check", y_check)]),
+            )
         });
 
         config

--- a/halo2_gadgets/src/sinsemilla/merkle/chip.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle/chip.rs
@@ -2,7 +2,7 @@
 
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter},
-    plonk::{Advice, Column, ConstraintSystem, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
     poly::Rotation,
 };
 use pasta_curves::{arithmetic::FieldExt, pallas};
@@ -163,13 +163,15 @@ where
             // <https://zips.z.cash/protocol/protocol.pdf#merklepath>
             let right_check = b_2 + c_whole * two_pow_5 - right_node;
 
-            array::IntoIter::new([
-                ("l_check", l_check),
-                ("left_check", left_check),
-                ("right_check", right_check),
-                ("b1_b2_check", b1_b2_check),
-            ])
-            .map(move |(name, poly)| (name, q_decompose.clone() * poly))
+            Constraints::with_selector(
+                q_decompose,
+                array::IntoIter::new([
+                    ("l_check", l_check),
+                    ("left_check", left_check),
+                    ("right_check", right_check),
+                    ("b1_b2_check", b1_b2_check),
+                ]),
+            )
         });
 
         MerkleConfig {

--- a/halo2_gadgets/src/utilities.rs
+++ b/halo2_gadgets/src/utilities.rs
@@ -186,7 +186,7 @@ mod tests {
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner},
         dev::{FailureLocation, MockProver, VerifyFailure},
-        plonk::{Any, Circuit, ConstraintSystem, Error, Selector},
+        plonk::{Any, Circuit, ConstraintSystem, Constraints, Error, Selector},
         poly::Rotation,
     };
     use pasta_curves::{arithmetic::FieldExt, pallas};
@@ -226,7 +226,7 @@ mod tests {
                     let selector = meta.query_selector(selector);
                     let advice = meta.query_advice(advice, Rotation::cur());
 
-                    vec![selector * range_check(advice, RANGE)]
+                    Constraints::with_selector(selector, Some(range_check(advice, RANGE)))
                 });
 
                 Config { selector, advice }

--- a/halo2_gadgets/src/utilities/cond_swap.rs
+++ b/halo2_gadgets/src/utilities/cond_swap.rs
@@ -3,7 +3,7 @@
 use super::{bool_check, ternary, UtilitiesInstructions};
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter},
-    plonk::{Advice, Column, ConstraintSystem, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
     poly::Rotation,
 };
 use pasta_curves::arithmetic::FieldExt;
@@ -189,8 +189,14 @@ impl<F: FieldExt> CondSwapChip<F> {
             // Check `swap` is boolean.
             let bool_check = bool_check(swap);
 
-            array::IntoIter::new([a_check, b_check, bool_check])
-                .map(move |poly| q_swap.clone() * poly)
+            Constraints::with_selector(
+                q_swap,
+                array::IntoIter::new([
+                    ("a check", a_check),
+                    ("b check", b_check),
+                    ("swap is bool", bool_check),
+                ]),
+            )
         });
 
         config

--- a/halo2_gadgets/src/utilities/decompose_running_sum.rs
+++ b/halo2_gadgets/src/utilities/decompose_running_sum.rs
@@ -25,7 +25,7 @@
 use ff::PrimeFieldBits;
 use halo2_proofs::{
     circuit::{AssignedCell, Region},
-    plonk::{Advice, Column, ConstraintSystem, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
     poly::Rotation,
 };
 
@@ -92,7 +92,7 @@ impl<F: FieldExt + PrimeFieldBits, const WINDOW_NUM_BITS: usize>
             // => k_i = z_i - 2^{K}⋅z_{i + 1}
             let word = z_cur - z_next * F::from(1 << WINDOW_NUM_BITS);
 
-            vec![q_range_check * range_check(word, 1 << WINDOW_NUM_BITS)]
+            Constraints::with_selector(q_range_check, Some(range_check(word, 1 << WINDOW_NUM_BITS)))
         });
 
         config

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -3,7 +3,7 @@
 
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Region},
-    plonk::{Advice, Column, ConstraintSystem, Error, Selector, TableColumn},
+    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector, TableColumn},
     poly::Rotation,
 };
 use std::{convert::TryInto, marker::PhantomData};
@@ -109,7 +109,10 @@ impl<F: FieldExt + PrimeFieldBits, const K: usize> LookupRangeCheckConfig<F, K> 
 
             // shifted_word = word * 2^{K-s}
             //              = word * 2^K * inv_two_pow_s
-            vec![q_bitshift * (word * two_pow_k * inv_two_pow_s - shifted_word)]
+            Constraints::with_selector(
+                q_bitshift,
+                Some(word * two_pow_k * inv_two_pow_s - shifted_word),
+            )
         });
 
         config


### PR DESCRIPTION
Only one gate couldn't be migrated without altering the Orchard circuit.