### PR TITLE
CI: Pass the correct `katex-header.html` path to rustdoc

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -35,7 +35,7 @@ jobs:
           command: doc
           args: --no-deps --workspace --all-features
         env:
-          RUSTDOCFLAGS: -Z unstable-options --enable-index-page --cfg docsrs --html-in-header ${{ github.workspace }}/katex-header.html
+          RUSTDOCFLAGS: -Z unstable-options --enable-index-page --cfg docsrs --html-in-header ${{ github.workspace }}/halo2_proofs/katex-header.html
 
       - name: Move latest rustdocs into book
         run: |


### PR DESCRIPTION
The header was moved to fix docs.rs deployment, but the CI workflow wasn't updated to account for this.