### PR TITLE
halo2: Disable default benchmark harness

### DIFF
--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -20,3 +20,6 @@ rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 
 [dependencies]
 halo2_proofs = { version = "0.1.0-beta.2", path = "../halo2_proofs" }
+
+[lib]
+bench = false


### PR DESCRIPTION
See 55364f0d998b5752b9edfbafb5847b8d3306e3fb for why this is necessary.