### PR TITLE
Halo2 Proof Fixes

### DIFF
--- a/book/src/design/protocol.md
+++ b/book/src/design/protocol.md
@@ -83,7 +83,7 @@ notions.
   correct, does the prover actually possess ("know") a valid witness? We refer
   to the probability that a cheating prover falsely convinces the verifier of
   this knowledge as the _knowledge error_.
-* **Zero knowledge:** Does the prover learn anything besides that which can be
+* **Zero knowledge:** Does the verifier learn anything besides that which can be
   inferred from the correctness of the statement and the prover's knowledge of a
   valid witness?
 

--- a/book/src/design/protocol.md
+++ b/book/src/design/protocol.md
@@ -154,7 +154,7 @@ $$
 &\underline{\bold{Oracle} \, \oracle_\srs(\tau = (a_1, c_1, ..., a_{i - 1}, c_{i - 1}), a_i):} \\
 & \textnormal{If} \, \tau \in \tr \, \textnormal{then} \\
 & \, \, \textnormal{If} \, i \leq r \, \textnormal{then} \\
-& \, \, \, \, c_i \gets \ch_i; \tr \gets \tr || (\tau, a_i, c_i); \textnormal{Return} \, c_i \\
+& \, \, \, \, c_i \gets \ch_i; \tr \gets \tr || (a_i, c_i); \textnormal{Return} \, c_i \\
 & \, \, \textnormal{Else if} \, i = r + 1 \, \textnormal{then} \\
 & \, \, \, \, d \gets \ip.\verifier (\pp, x, (\tau, a_i)); \tr \gets (\tau, a_i) \\
 & \, \, \, \, \textnormal{If} \, d = 1 \, \textnormal{then win} \gets \tt{true} \\
@@ -232,7 +232,7 @@ $$
 &\underline{\bold{Oracle} \, \oracle_\real(\tau = (a_1, c_1, ..., a_{i - 1}, c_{i - 1}), a_i):} \\
 & \textnormal{If} \, \tau \in \tr \, \textnormal{then} \\
 & \, \, \textnormal{If} \, i \leq r \, \textnormal{then} \\
-& \, \, \, \, c_i \gets \ch_i; \tr \gets \tr || (\tau, a_i, c_i); \textnormal{Return} \, c_i \\
+& \, \, \, \, c_i \gets \ch_i; \tr \gets \tr || (a_i, c_i); \textnormal{Return} \, c_i \\
 & \, \, \textnormal{Else if} \, i = r + 1 \, \textnormal{then} \\
 & \, \, \, \, d \gets \ip.\verifier (\pp, x, (\tau, a_i)); \tr \gets (\tau, a_i) \\
 & \, \, \, \, \textnormal{If} \, d = 1 \, \textnormal{then win} \gets \tt{true} \\
@@ -243,7 +243,7 @@ $$
 &\underline{\bold{Oracle} \, \oracle_\ideal(\tau, a):} \\
 & \textnormal{If} \, \tau \in \tr \, \textnormal{then} \\
 & \, \, (r, \state{\extractor}) \gets \extractor(\state{\extractor}, \left[(\tau, a)\right]) \\
-& \, \, \tr \gets \tr || (\tau, a, r) \\
+& \, \, \tr \gets \tr || (a, r) \\
 & \, \, \textnormal{Return} \, r \\
 &\textnormal{Return} \, \bottom
 \end{array}

--- a/book/src/design/protocol.md
+++ b/book/src/design/protocol.md
@@ -7,6 +7,8 @@ algorithms and adversaries are probabilistic (interactive) Turing machines that
 run in polynomial time in this security parameter. We use $\negl$ to denote a
 function that is negligible in $\sec$.
 
+When $a$ and $b$ are strings, $a \in b$ means $a$ is a prefix of $b$.
+
 ### Cryptographic Groups
 
 We let $\group$ denote a cyclic group of prime order $p$. The identity of a

--- a/book/src/design/protocol.md
+++ b/book/src/design/protocol.md
@@ -153,7 +153,7 @@ $$
 &\textnormal{Return win}
 \end{array} &
 \begin{array}{ll}
-&\underline{\bold{Oracle} \, \oracle_\srs(\tau = (a_1, c_1, ..., a_{i - 1}, c_{i - 1}), a_i):} \\
+&\underline{\bold{Oracle} \, \oracle_\srs(\tau = ((a_1, c_1), ..., (a_{i - 1}, c_{i - 1})), a_i):} \\
 & \textnormal{If} \, \tau \in \tr \, \textnormal{then} \\
 & \, \, \textnormal{If} \, i \leq r \, \textnormal{then} \\
 & \, \, \, \, c_i \gets \ch_i; \tr \gets \tr || (a_i, c_i); \textnormal{Return} \, c_i \\
@@ -231,7 +231,7 @@ $$
 &\, \, \land (\textnormal{Acc}(\tr) \implies (x, w) \in \relation) \\
 \end{array} &
 \begin{array}{ll}
-&\underline{\bold{Oracle} \, \oracle_\real(\tau = (a_1, c_1, ..., a_{i - 1}, c_{i - 1}), a_i):} \\
+&\underline{\bold{Oracle} \, \oracle_\real(\tau = ((a_1, c_1), ..., (a_{i - 1}, c_{i - 1})), a_i):} \\
 & \textnormal{If} \, \tau \in \tr \, \textnormal{then} \\
 & \, \, \textnormal{If} \, i \leq r \, \textnormal{then} \\
 & \, \, \, \, c_i \gets \ch_i; \tr \gets \tr || (a_i, c_i); \textnormal{Return} \, c_i \\


### PR DESCRIPTION
This fixes three problems:

- The informal description of zero knowledge should worry about what the verifier learns, not the prover.
- $\in$ is undefined for the transcript strings.
- $\tau$ is appended to the transcript after $\tau$ has already been checked to be a prefix of the transcript, which doesn't seem right.
