### PR TITLE
Remove `UtilitiesInstructions` trait

### DIFF
--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -4,18 +4,14 @@ use std::fmt::Debug;
 
 use halo2_proofs::{
     arithmetic::CurveAffine,
-    circuit::{Chip, Layouter},
+    circuit::{AssignedCell, Chip, Layouter},
     plonk::Error,
 };
-
-use crate::utilities::UtilitiesInstructions;
 
 pub mod chip;
 
 /// The set of circuit instructions required to use the ECC gadgets.
-pub trait EccInstructions<C: CurveAffine>:
-    Chip<C::Base> + UtilitiesInstructions<C::Base> + Clone + Debug + Eq
-{
+pub trait EccInstructions<C: CurveAffine>: Chip<C::Base> + Clone + Debug + Eq {
     /// Variable representing a scalar used in variable-base scalar mul.
     ///
     /// This type is treated as a full-width scalar. However, if `Self` implements
@@ -84,10 +80,14 @@ pub trait EccInstructions<C: CurveAffine>:
 
     /// Converts a magnitude and sign that exists as variables in the circuit into a
     /// signed short scalar to be used in fixed-base scalar multiplication.
+    #[allow(clippy::type_complexity)]
     fn scalar_fixed_from_signed_short(
         &self,
         layouter: &mut impl Layouter<C::Base>,
-        magnitude_sign: (Self::Var, Self::Var),
+        magnitude_sign: (
+            AssignedCell<C::Base, C::Base>,
+            AssignedCell<C::Base, C::Base>,
+        ),
     ) -> Result<Self::ScalarFixedShort, Error>;
 
     /// Extracts the x-coordinate of a point.
@@ -142,7 +142,7 @@ pub trait EccInstructions<C: CurveAffine>:
     fn mul_fixed_base_field_elem(
         &self,
         layouter: &mut impl Layouter<C::Base>,
-        base_field_elem: Self::Var,
+        base_field_elem: AssignedCell<C::Base, C::Base>,
         base: &<Self::FixedPoints as FixedPoints<C>>::Base,
     ) -> Result<Self::Point, Error>;
 }
@@ -155,7 +155,7 @@ pub trait BaseFitsInScalarInstructions<C: CurveAffine>: EccInstructions<C> {
     fn scalar_var_from_base(
         &self,
         layouter: &mut impl Layouter<C::Base>,
-        base: &Self::Var,
+        base: &AssignedCell<C::Base, C::Base>,
     ) -> Result<Self::ScalarVar, Error>;
 }
 
@@ -196,7 +196,7 @@ impl<C: CurveAffine, EccChip: BaseFitsInScalarInstructions<C>> ScalarVar<C, EccC
     pub fn from_base(
         chip: EccChip,
         mut layouter: impl Layouter<C::Base>,
-        base: &EccChip::Var,
+        base: &AssignedCell<C::Base, C::Base>,
     ) -> Result<Self, Error> {
         let scalar = chip.scalar_var_from_base(&mut layouter, base);
         scalar.map(|inner| ScalarVar { chip, inner })
@@ -244,10 +244,14 @@ impl<C: CurveAffine, EccChip: EccInstructions<C>> ScalarFixedShort<C, EccChip> {
     /// Depending on the `EccChip` implementation, the scalar may either be constrained
     /// immediately by this constructor, or lazily constrained when it is first used in
     /// [`FixedPointShort::mul`].
+    #[allow(clippy::type_complexity)]
     pub fn new(
         chip: EccChip,
         mut layouter: impl Layouter<C::Base>,
-        magnitude_sign: (EccChip::Var, EccChip::Var),
+        magnitude_sign: (
+            AssignedCell<C::Base, C::Base>,
+            AssignedCell<C::Base, C::Base>,
+        ),
     ) -> Result<Self, Error> {
         let scalar = chip.scalar_fixed_from_signed_short(&mut layouter, magnitude_sign);
         scalar.map(|inner| ScalarFixedShort { chip, inner })
@@ -522,7 +526,7 @@ impl<C: CurveAffine, EccChip: EccInstructions<C>> FixedPointBaseField<C, EccChip
     pub fn mul(
         &self,
         mut layouter: impl Layouter<C::Base>,
-        by: EccChip::Var,
+        by: AssignedCell<C::Base, C::Base>,
     ) -> Result<Point<C, EccChip>, Error> {
         self.chip
             .mul_fixed_base_field_elem(&mut layouter, by, &self.inner)

--- a/halo2_gadgets/src/ecc/chip.rs
+++ b/halo2_gadgets/src/ecc/chip.rs
@@ -2,8 +2,7 @@
 
 use super::{BaseFitsInScalarInstructions, EccInstructions, FixedPoints};
 use crate::{
-    sinsemilla::primitives as sinsemilla,
-    utilities::{lookup_range_check::LookupRangeCheckConfig, UtilitiesInstructions},
+    sinsemilla::primitives as sinsemilla, utilities::lookup_range_check::LookupRangeCheckConfig,
 };
 use arrayvec::ArrayVec;
 
@@ -241,12 +240,6 @@ impl<FixedPoints: super::FixedPoints<pallas::Affine>> Chip<pallas::Base> for Ecc
     fn loaded(&self) -> &Self::Loaded {
         &()
     }
-}
-
-impl<Fixed: super::FixedPoints<pallas::Affine>> UtilitiesInstructions<pallas::Base>
-    for EccChip<Fixed>
-{
-    type Var = AssignedCell<pallas::Base, pallas::Base>;
 }
 
 impl<FixedPoints: super::FixedPoints<pallas::Affine>> EccChip<FixedPoints> {
@@ -605,7 +598,7 @@ where
     fn scalar_var_from_base(
         &self,
         _layouter: &mut impl Layouter<pallas::Base>,
-        base: &Self::Var,
+        base: &AssignedCell<pallas::Base, pallas::Base>,
     ) -> Result<Self::ScalarVar, Error> {
         Ok(ScalarVar::BaseFieldElem(base.clone()))
     }

--- a/halo2_gadgets/src/ecc/chip/mul.rs
+++ b/halo2_gadgets/src/ecc/chip/mul.rs
@@ -491,7 +491,7 @@ pub mod tests {
             tests::TestFixedBases,
             EccInstructions, NonIdentityPoint, Point, ScalarVar,
         },
-        utilities::UtilitiesInstructions,
+        utilities::load_private,
     };
 
     pub(crate) fn test_mul(
@@ -526,7 +526,7 @@ pub mod tests {
         {
             let scalar_val = pallas::Base::random(OsRng);
             let (result, _) = {
-                let scalar = chip.load_private(
+                let scalar = load_private(
                     layouter.namespace(|| "random scalar"),
                     column,
                     Some(scalar_val),
@@ -552,8 +552,7 @@ pub mod tests {
         {
             let scalar_val = pallas::Base::zero();
             let (result, _) = {
-                let scalar =
-                    chip.load_private(layouter.namespace(|| "zero"), column, Some(scalar_val))?;
+                let scalar = load_private(layouter.namespace(|| "zero"), column, Some(scalar_val))?;
                 let scalar = ScalarVar::from_base(
                     chip.clone(),
                     layouter.namespace(|| "ScalarVar from_base"),
@@ -570,8 +569,7 @@ pub mod tests {
         {
             let scalar_val = -pallas::Base::one();
             let (result, _) = {
-                let scalar =
-                    chip.load_private(layouter.namespace(|| "-1"), column, Some(scalar_val))?;
+                let scalar = load_private(layouter.namespace(|| "-1"), column, Some(scalar_val))?;
                 let scalar = ScalarVar::from_base(
                     chip.clone(),
                     layouter.namespace(|| "ScalarVar from_base"),

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/base_field_elem.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/base_field_elem.rs
@@ -393,7 +393,7 @@ pub mod tests {
             tests::{BaseField, TestFixedBases},
             FixedPointBaseField, NonIdentityPoint, Point,
         },
-        utilities::UtilitiesInstructions,
+        utilities::load_private,
     };
 
     pub(crate) fn test_mul_fixed_base_field(
@@ -440,7 +440,7 @@ pub mod tests {
         {
             let scalar_fixed = pallas::Base::random(rng);
             let result = {
-                let scalar_fixed = chip.load_private(
+                let scalar_fixed = load_private(
                     layouter.namespace(|| "random base field element"),
                     column,
                     Some(scalar_fixed),
@@ -468,7 +468,7 @@ pub mod tests {
                             acc * &h + &pallas::Base::from(c.to_digit(8).unwrap() as u64)
                         });
             let result = {
-                let scalar_fixed = chip.load_private(
+                let scalar_fixed = load_private(
                     layouter.namespace(|| "mul with double"),
                     column,
                     Some(scalar_fixed),
@@ -490,7 +490,7 @@ pub mod tests {
             let scalar_fixed = pallas::Base::zero();
             let result = {
                 let scalar_fixed =
-                    chip.load_private(layouter.namespace(|| "zero"), column, Some(scalar_fixed))?;
+                    load_private(layouter.namespace(|| "zero"), column, Some(scalar_fixed))?;
                 base.mul(layouter.namespace(|| "mul by zero"), scalar_fixed)?
             };
             if let Some(is_identity) = result.inner().is_identity() {
@@ -503,7 +503,7 @@ pub mod tests {
             let scalar_fixed = -pallas::Base::one();
             let result = {
                 let scalar_fixed =
-                    chip.load_private(layouter.namespace(|| "-1"), column, Some(scalar_fixed))?;
+                    load_private(layouter.namespace(|| "-1"), column, Some(scalar_fixed))?;
                 base.mul(layouter.namespace(|| "mul by -1"), scalar_fixed)?
             };
             constrain_equal_non_id(

--- a/halo2_gadgets/src/poseidon/pow5.rs
+++ b/halo2_gadgets/src/poseidon/pow5.rs
@@ -3,7 +3,7 @@ use std::iter;
 
 use halo2_proofs::{
     arithmetic::FieldExt,
-    circuit::{AssignedCell, Cell, Chip, Layouter, Region},
+    circuit::{AssignedCell, Chip, Layouter, Region},
     plonk::{
         Advice, Any, Column, ConstraintSystem, Constraints, Error, Expression, Fixed, Selector,
     },
@@ -14,7 +14,6 @@ use super::{
     primitives::{Absorbing, Domain, Mds, Spec, Squeezing, State},
     PaddedWord, PoseidonInstructions, PoseidonSpongeInstructions,
 };
-use crate::utilities::Var;
 
 /// Configuration for a [`Pow5Chip`].
 #[derive(Clone, Debug)]
@@ -416,16 +415,6 @@ impl<F: FieldExt> From<StateWord<F>> for AssignedCell<F, F> {
 impl<F: FieldExt> From<AssignedCell<F, F>> for StateWord<F> {
     fn from(cell_value: AssignedCell<F, F>) -> StateWord<F> {
         StateWord(cell_value)
-    }
-}
-
-impl<F: FieldExt> Var<F> for StateWord<F> {
-    fn cell(&self) -> Cell {
-        self.0.cell()
-    }
-
-    fn value(&self) -> Option<F> {
-        self.0.value().cloned()
     }
 }
 

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -3,7 +3,7 @@
 //! [Sinsemilla]: https://zips.z.cash/protocol/protocol.pdf#concretesinsemillahash
 use crate::{
     ecc::{self, EccInstructions, FixedPoints},
-    utilities::{FieldValue, RangeConstrained, Var},
+    utilities::{FieldValue, RangeConstrained},
 };
 use group::ff::{Field, PrimeField};
 use halo2_proofs::{circuit::Layouter, plonk::Error};
@@ -20,9 +20,6 @@ pub mod primitives;
 /// in each word accepted by the Sinsemilla hash, and `MAX_WORDS`, the maximum
 /// number of words that a single hash instance can process.
 pub trait SinsemillaInstructions<C: CurveAffine, const K: usize, const MAX_WORDS: usize> {
-    /// A variable in the circuit.
-    type CellValue: Var<C::Base>;
-
     /// A message composed of [`Self::MessagePiece`]s.
     type Message: From<Vec<Self::MessagePiece>>;
 

--- a/halo2_gadgets/src/sinsemilla/chip.rs
+++ b/halo2_gadgets/src/sinsemilla/chip.rs
@@ -269,12 +269,10 @@ where
     F: FixedPoints<pallas::Affine>,
     Commit: CommitDomains<pallas::Affine, F, Hash>,
 {
-    type CellValue = AssignedCell<pallas::Base, pallas::Base>;
-
     type Message = Message<pallas::Base, { sinsemilla::K }, { sinsemilla::C }>;
     type MessagePiece = MessagePiece<pallas::Base, { sinsemilla::K }>;
 
-    type RunningSum = Vec<Self::CellValue>;
+    type RunningSum = Vec<AssignedCell<pallas::Base, pallas::Base>>;
 
     type X = AssignedCell<pallas::Base, pallas::Base>;
     type NonIdentityPoint = NonIdentityEccPoint;

--- a/halo2_gadgets/src/sinsemilla/merkle.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle.rs
@@ -1,16 +1,14 @@
 //! Gadgets for implementing a Merkle tree with Sinsemilla.
 
 use halo2_proofs::{
-    circuit::{Chip, Layouter},
+    circuit::{AssignedCell, Chip, Layouter},
     plonk::Error,
 };
 use pasta_curves::arithmetic::CurveAffine;
 
 use super::{HashDomains, SinsemillaInstructions};
 
-use crate::utilities::{
-    cond_swap::CondSwapInstructions, i2lebsp, transpose_option_array, UtilitiesInstructions,
-};
+use crate::utilities::{cond_swap::CondSwapInstructions, i2lebsp, transpose_option_array};
 
 pub mod chip;
 
@@ -25,11 +23,7 @@ pub trait MerkleInstructions<
     const PATH_LENGTH: usize,
     const K: usize,
     const MAX_WORDS: usize,
->:
-    SinsemillaInstructions<C, K, MAX_WORDS>
-    + CondSwapInstructions<C::Base>
-    + UtilitiesInstructions<C::Base>
-    + Chip<C::Base>
+>: SinsemillaInstructions<C, K, MAX_WORDS> + CondSwapInstructions<C::Base> + Chip<C::Base>
 {
     /// Compute MerkleCRH for a given `layer`. The hash that computes the root
     /// is at layer 0, and the hashes that are applied to two leaves are at
@@ -40,9 +34,9 @@ pub trait MerkleInstructions<
         layouter: impl Layouter<C::Base>,
         Q: C,
         l: usize,
-        left: Self::Var,
-        right: Self::Var,
-    ) -> Result<Self::Var, Error>;
+        left: AssignedCell<C::Base, C::Base>,
+        right: AssignedCell<C::Base, C::Base>,
+    ) -> Result<AssignedCell<C::Base, C::Base>, Error>;
 }
 
 /// Gadget representing a Merkle path that proves a leaf exists in a Merkle tree at a
@@ -119,8 +113,8 @@ where
     pub fn calculate_root(
         &self,
         mut layouter: impl Layouter<C::Base>,
-        leaf: MerkleChip::Var,
-    ) -> Result<MerkleChip::Var, Error> {
+        leaf: AssignedCell<C::Base, C::Base>,
+    ) -> Result<AssignedCell<C::Base, C::Base>, Error> {
         // Each chip processes `ceil(PATH_LENGTH / PAR)` layers.
         let layers_per_chip = (PATH_LENGTH + PAR - 1) / PAR;
 
@@ -186,7 +180,7 @@ pub mod tests {
             tests::{TestCommitDomain, TestHashDomain},
             HashDomains,
         },
-        utilities::{i2lebsp, lookup_range_check::LookupRangeCheckConfig, UtilitiesInstructions},
+        utilities::{i2lebsp, load_private, lookup_range_check::LookupRangeCheckConfig},
     };
 
     use group::ff::{Field, PrimeField, PrimeFieldBits};
@@ -290,7 +284,7 @@ pub mod tests {
             let chip_1 = MerkleChip::construct(config.0.clone());
             let chip_2 = MerkleChip::construct(config.1.clone());
 
-            let leaf = chip_1.load_private(
+            let leaf = load_private(
                 layouter.namespace(|| ""),
                 config.0.cond_swap_config.a(),
                 self.leaf,

--- a/halo2_gadgets/src/sinsemilla/merkle/chip.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle/chip.rs
@@ -18,10 +18,7 @@ use crate::{
             chip::{SinsemillaChip, SinsemillaConfig},
             CommitDomains, HashDomains, SinsemillaInstructions,
         },
-        utilities::{
-            cond_swap::{CondSwapChip, CondSwapConfig, CondSwapInstructions},
-            UtilitiesInstructions,
-        },
+        utilities::cond_swap::{CondSwapChip, CondSwapConfig, CondSwapInstructions},
     },
 };
 use group::ff::PrimeField;
@@ -208,9 +205,9 @@ where
         Q: pallas::Affine,
         // l = MERKLE_DEPTH - layer - 1
         l: usize,
-        left: Self::Var,
-        right: Self::Var,
-    ) -> Result<Self::Var, Error> {
+        left: AssignedCell<pallas::Base, pallas::Base>,
+        right: AssignedCell<pallas::Base, pallas::Base>,
+    ) -> Result<AssignedCell<pallas::Base, pallas::Base>, Error> {
         let config = self.config().clone();
 
         // <https://zips.z.cash/protocol/protocol.pdf#orchardmerklecrh>
@@ -406,15 +403,6 @@ where
     }
 }
 
-impl<Hash, Commit, F> UtilitiesInstructions<pallas::Base> for MerkleChip<Hash, Commit, F>
-where
-    Hash: HashDomains<pallas::Affine>,
-    F: FixedPoints<pallas::Affine>,
-    Commit: CommitDomains<pallas::Affine, F, Hash>,
-{
-    type Var = AssignedCell<pallas::Base, pallas::Base>;
-}
-
 impl<Hash, Commit, F> CondSwapInstructions<pallas::Base> for MerkleChip<Hash, Commit, F>
 where
     Hash: HashDomains<pallas::Affine>,
@@ -425,9 +413,18 @@ where
     fn swap(
         &self,
         layouter: impl Layouter<pallas::Base>,
-        pair: (Self::Var, Option<pallas::Base>),
+        pair: (
+            AssignedCell<pallas::Base, pallas::Base>,
+            Option<pallas::Base>,
+        ),
         swap: Option<bool>,
-    ) -> Result<(Self::Var, Self::Var), Error> {
+    ) -> Result<
+        (
+            AssignedCell<pallas::Base, pallas::Base>,
+            AssignedCell<pallas::Base, pallas::Base>,
+        ),
+        Error,
+    > {
         let config = self.config().cond_swap_config.clone();
         let chip = CondSwapChip::<pallas::Base>::construct(config);
         chip.swap(layouter, pair, swap)
@@ -441,12 +438,6 @@ where
     F: FixedPoints<pallas::Affine>,
     Commit: CommitDomains<pallas::Affine, F, Hash>,
 {
-    type CellValue = <SinsemillaChip<Hash, Commit, F> as SinsemillaInstructions<
-        pallas::Affine,
-        { sinsemilla::K },
-        { sinsemilla::C },
-    >>::CellValue;
-
     type Message = <SinsemillaChip<Hash, Commit, F> as SinsemillaInstructions<
         pallas::Affine,
         { sinsemilla::K },
@@ -508,7 +499,13 @@ where
         layouter: impl Layouter<pallas::Base>,
         Q: pallas::Affine,
         message: Self::Message,
-    ) -> Result<(Self::NonIdentityPoint, Vec<Vec<Self::CellValue>>), Error> {
+    ) -> Result<
+        (
+            Self::NonIdentityPoint,
+            Vec<Vec<AssignedCell<pallas::Base, pallas::Base>>>,
+        ),
+        Error,
+    > {
         let config = self.config().sinsemilla_config.clone();
         let chip = SinsemillaChip::<Hash, Commit, F>::construct(config);
         chip.hash_to_point(layouter, Q, message)

--- a/halo2_gadgets/src/utilities/cond_swap.rs
+++ b/halo2_gadgets/src/utilities/cond_swap.rs
@@ -1,6 +1,6 @@
 //! Gadget and chip for a conditional swap utility.
 
-use super::{bool_check, ternary, UtilitiesInstructions};
+use super::{bool_check, ternary};
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter},
     plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
@@ -10,7 +10,7 @@ use pasta_curves::arithmetic::FieldExt;
 use std::marker::PhantomData;
 
 /// Instructions for a conditional swap gadget.
-pub trait CondSwapInstructions<F: FieldExt>: UtilitiesInstructions<F> {
+pub trait CondSwapInstructions<F: FieldExt> {
     #[allow(clippy::type_complexity)]
     /// Given an input pair (a,b) and a `swap` boolean flag, returns
     /// (b,a) if `swap` is set, else (a,b) if `swap` is not set.
@@ -20,9 +20,9 @@ pub trait CondSwapInstructions<F: FieldExt>: UtilitiesInstructions<F> {
     fn swap(
         &self,
         layouter: impl Layouter<F>,
-        pair: (Self::Var, Option<F>),
+        pair: (AssignedCell<F, F>, Option<F>),
         swap: Option<bool>,
-    ) -> Result<(Self::Var, Self::Var), Error>;
+    ) -> Result<(AssignedCell<F, F>, AssignedCell<F, F>), Error>;
 }
 
 /// A chip implementing a conditional swap.
@@ -63,18 +63,14 @@ impl CondSwapConfig {
     }
 }
 
-impl<F: FieldExt> UtilitiesInstructions<F> for CondSwapChip<F> {
-    type Var = AssignedCell<F, F>;
-}
-
 impl<F: FieldExt> CondSwapInstructions<F> for CondSwapChip<F> {
     #[allow(clippy::type_complexity)]
     fn swap(
         &self,
         mut layouter: impl Layouter<F>,
-        pair: (Self::Var, Option<F>),
+        pair: (AssignedCell<F, F>, Option<F>),
         swap: Option<bool>,
-    ) -> Result<(Self::Var, Self::Var), Error> {
+    ) -> Result<(AssignedCell<F, F>, AssignedCell<F, F>), Error> {
         let config = self.config();
 
         layouter.assign_region(
@@ -213,7 +209,7 @@ impl<F: FieldExt> CondSwapChip<F> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::UtilitiesInstructions;
+    use super::super::load_private;
     use super::{CondSwapChip, CondSwapConfig, CondSwapInstructions};
     use group::ff::Field;
     use halo2_proofs::{
@@ -261,7 +257,7 @@ mod tests {
                 let chip = CondSwapChip::<F>::construct(config.clone());
 
                 // Load the pair and the swap flag into the circuit.
-                let a = chip.load_private(layouter.namespace(|| "a"), config.a, self.a)?;
+                let a = load_private(layouter.namespace(|| "a"), config.a, self.a)?;
                 // Return the swapped pair.
                 let swapped_pair = chip.swap(
                     layouter.namespace(|| "swap"),


### PR DESCRIPTION
The UtilitiesInstructions trait had an associated type Var, and a
helper method load_private().

In practice, Var is always AssignedCell, and all instances of
Self::Var have now been replaced with AssignedCell.

The load_private() method was only ever used in tests, and has
been flagged off as a standalone method under #cfg[(test)].