### PR TITLE
Introduce `halo2_proofs::circuit::Value`

### DIFF
--- a/halo2_gadgets/CHANGELOG.md
+++ b/halo2_gadgets/CHANGELOG.md
@@ -6,6 +6,48 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `halo2_gadgets::utilities::RangeConstrained<F, Value<F>>::bitrange_of`
+
+### Changed
+All APIs that represented witnessed values as `Option<V>` now represent them as
+`halo2_proofs::circuit::Value<V>`. The core API changes are listed below.
+
+- The following APIs now take `Value<_>` instead of `Option<_>`:
+  - `halo2_gadgets::ecc`:
+    - `EccInstructions::{witness_point, witness_point_non_id}`
+    - `EccInstructions::{witness_scalar_var, witness_scalar_fixed}`
+    - `ScalarVar::new`
+    - `ScalarFixed::new`
+    - `NonIdentityPoint::new`
+    - `Point::new`
+  - `halo2_gadgets::sinsemilla`:
+    - `SinsemillaInstructions::witness_message_piece`
+    - `MessagePiece::{from_field_elem, from_subpieces}`
+  - `halo2_gadgets::sinsemilla::merkle`:
+    - `MerklePath::construct`
+  - `halo2_gadgets::utilities`:
+    - `UtilitiesInstructions::load_private`
+    - `RangeConstrained::witness_short`
+  - `halo2_gadgets::utilities::cond_swap`:
+    - `CondSwapInstructions::swap`
+  - `halo2_gadgets::utilities::decompose_running_sum`:
+    - `RunningSumConfig::witness_decompose`
+  - `halo2_gadgets::utilities::lookup_range_check`:
+    - `LookupRangeCheckConfig::{witness_check, witness_short_check}`
+- The following APIs now return `Value<_>` instead of `Option<_>`:
+  - `halo2_gadgets::ecc::chip`:
+    - `EccPoint::{point, is_identity}`
+    - `NonIdentityEccPoint::point`
+  - `halo2_gadgets::utilities`:
+    - `FieldValue::value`
+    - `Var::value`
+    - `RangeConstrained::value`
+- `halo2_gadgets::sha256::BlockWord` is now a newtype wrapper around
+  `Value<u32>` instead of `Option<u32>`.
+
+### Removed
+- `halo2_gadgets::utilities::RangeConstrained<F, Option<F>>::bitrange_of`
 
 ## [0.1.0] - 2022-05-10
 ### Added

--- a/halo2_gadgets/benches/sha256.rs
+++ b/halo2_gadgets/benches/sha256.rs
@@ -1,5 +1,5 @@
 use halo2_proofs::{
-    circuit::{Layouter, SimpleFloorPlanner},
+    circuit::{Layouter, SimpleFloorPlanner, Value},
     pasta::{pallas, EqAffine},
     plonk::{
         create_proof, keygen_pk, keygen_vk, verify_proof, Circuit, ConstraintSystem, Error,
@@ -47,22 +47,22 @@ fn bench(name: &str, k: u32, c: &mut Criterion) {
 
             // Test vector: "abc"
             let test_input = [
-                BlockWord(Some(0b01100001011000100110001110000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000000000)),
-                BlockWord(Some(0b00000000000000000000000000011000)),
+                BlockWord(Value::known(0b01100001011000100110001110000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000000000)),
+                BlockWord(Value::known(0b00000000000000000000000000011000)),
             ];
 
             // Create a message of length 31 blocks

--- a/halo2_gadgets/src/ecc/chip/add_incomplete.rs
+++ b/halo2_gadgets/src/ecc/chip/add_incomplete.rs
@@ -95,20 +95,14 @@ impl Config {
         x_p.zip(y_p)
             .zip(x_q)
             .zip(y_q)
-            .map(|(((x_p, y_p), x_q), y_q)| {
+            .error_if_known_and(|(((x_p, y_p), x_q), y_q)| {
                 // P is point at infinity
-                if (x_p.is_zero_vartime() && y_p.is_zero_vartime())
+                (x_p.is_zero_vartime() && y_p.is_zero_vartime())
                 // Q is point at infinity
                 || (x_q.is_zero_vartime() && y_q.is_zero_vartime())
                 // x_p = x_q
                 || (x_p == x_q)
-                {
-                    Err(Error::Synthesis)
-                } else {
-                    Ok(())
-                }
-            })
-            .transpose()?;
+            })?;
 
         // Copy point `p` into `x_p`, `y_p` columns
         p.x.copy_advice(|| "x_p", region, self.x_p, offset)?;
@@ -137,20 +131,10 @@ impl Config {
 
         // Assign the sum to `x_qr`, `y_qr` columns in the next row
         let x_r = r.map(|r| r.0);
-        let x_r_var = region.assign_advice(
-            || "x_r",
-            self.x_qr,
-            offset + 1,
-            || x_r.ok_or(Error::Synthesis),
-        )?;
+        let x_r_var = region.assign_advice(|| "x_r", self.x_qr, offset + 1, || x_r)?;
 
         let y_r = r.map(|r| r.1);
-        let y_r_var = region.assign_advice(
-            || "y_r",
-            self.y_qr,
-            offset + 1,
-            || y_r.ok_or(Error::Synthesis),
-        )?;
+        let y_r_var = region.assign_advice(|| "y_r", self.y_qr, offset + 1, || y_r)?;
 
         let result = NonIdentityEccPoint {
             x: x_r_var,
@@ -164,7 +148,10 @@ impl Config {
 #[cfg(test)]
 pub mod tests {
     use group::Curve;
-    use halo2_proofs::{circuit::Layouter, plonk::Error};
+    use halo2_proofs::{
+        circuit::{Layouter, Value},
+        plonk::Error,
+    };
     use pasta_curves::pallas;
 
     use crate::ecc::{EccInstructions, NonIdentityPoint};
@@ -188,7 +175,7 @@ pub mod tests {
             let witnessed_result = NonIdentityPoint::new(
                 chip,
                 layouter.namespace(|| "witnessed P + Q"),
-                Some((p_val + q_val).to_affine()),
+                Value::known((p_val + q_val).to_affine()),
             )?;
             result.constrain_equal(layouter.namespace(|| "constrain P + Q"), &witnessed_result)?;
         }

--- a/halo2_gadgets/src/ecc/chip/mul/complete.rs
+++ b/halo2_gadgets/src/ecc/chip/mul/complete.rs
@@ -3,7 +3,7 @@ use super::{COMPLETE_RANGE, X, Y, Z};
 use crate::utilities::{bool_check, ternary};
 
 use halo2_proofs::{
-    circuit::Region,
+    circuit::{Region, Value},
     plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
@@ -88,7 +88,7 @@ impl Config {
         &self,
         region: &mut Region<'_, pallas::Base>,
         offset: usize,
-        bits: &[Option<bool>],
+        bits: &[Value<bool>],
         base: &EccPoint,
         x_a: X<pallas::Base>,
         y_a: Y<pallas::Base>,
@@ -139,15 +139,10 @@ impl Config {
             // Update `z`.
             z = {
                 // z_next = z_cur * 2 + k_next
-                let z_val = z.value().zip(k.as_ref()).map(|(z_val, k)| {
-                    pallas::Base::from(2) * z_val + pallas::Base::from(*k as u64)
-                });
-                let z_cell = region.assign_advice(
-                    || "z",
-                    self.z_complete,
-                    row + offset + 2,
-                    || z_val.ok_or(Error::Synthesis),
-                )?;
+                let z_val = z.value() * Value::known(pallas::Base::from(2))
+                    + k.map(|k| pallas::Base::from(k as u64));
+                let z_cell =
+                    region.assign_advice(|| "z", self.z_complete, row + offset + 2, || z_val)?;
                 Z(z_cell)
             };
             zs.push(z.clone());
@@ -177,12 +172,7 @@ impl Config {
                 // fine because we are just assigning the same value to the same cell
                 // twice, and then applying an equality constraint between the cell and
                 // itself (which the permutation argument treats as a no-op).
-                region.assign_advice(
-                    || "y_p",
-                    self.add_config.y_p,
-                    row + offset,
-                    || y_p.ok_or(Error::Synthesis),
-                )?
+                region.assign_advice(|| "y_p", self.add_config.y_p, row + offset, || y_p)?
             };
 
             // U = P if the bit is set; U = -P is the bit is not set.

--- a/halo2_gadgets/src/ecc/chip/mul/overflow.rs
+++ b/halo2_gadgets/src/ecc/chip/mul/overflow.rs
@@ -121,7 +121,7 @@ impl Config {
                         || "s = alpha + k_254 ⋅ 2^130",
                         self.advices[0],
                         0,
-                        || s_val.ok_or(Error::Synthesis),
+                        || s_val,
                     )
                 },
             )?
@@ -153,7 +153,7 @@ impl Config {
                         || "η = inv0(z_130)",
                         self.advices[0],
                         offset + 2,
-                        || eta.ok_or(Error::Synthesis),
+                        || eta,
                     )?;
                 }
 

--- a/halo2_gadgets/src/sha256/table16.rs
+++ b/halo2_gadgets/src/sha256/table16.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 
 use super::Sha256Instructions;
 use halo2_proofs::{
-    circuit::{AssignedCell, Chip, Layouter, Region},
+    circuit::{AssignedCell, Chip, Layouter, Region, Value},
     pasta::pallas,
     plonk::{Advice, Any, Assigned, Column, ConstraintSystem, Error},
 };
@@ -49,7 +49,7 @@ const IV: [u32; STATE] = [
 #[derive(Clone, Copy, Debug, Default)]
 /// A word in a `Table16` message block.
 // TODO: Make the internals of this struct private.
-pub struct BlockWord(pub Option<u32>);
+pub struct BlockWord(pub Value<u32>);
 
 #[derive(Clone, Debug)]
 /// Little-endian bits (up to 64 bits)
@@ -129,26 +129,26 @@ impl<const LEN: usize> AssignedBits<LEN> {
         annotation: A,
         column: impl Into<Column<Any>>,
         offset: usize,
-        value: Option<T>,
+        value: Value<T>,
     ) -> Result<Self, Error>
     where
         A: Fn() -> AR,
         AR: Into<String>,
         <T as TryInto<[bool; LEN]>>::Error: std::fmt::Debug,
     {
-        let value: Option<[bool; LEN]> = value.map(|v| v.try_into().unwrap());
-        let value: Option<Bits<LEN>> = value.map(|v| v.into());
+        let value: Value<[bool; LEN]> = value.map(|v| v.try_into().unwrap());
+        let value: Value<Bits<LEN>> = value.map(|v| v.into());
 
         let column: Column<Any> = column.into();
         match column.column_type() {
             Any::Advice => {
                 region.assign_advice(annotation, column.try_into().unwrap(), offset, || {
-                    value.clone().ok_or(Error::Synthesis)
+                    value.clone()
                 })
             }
             Any::Fixed => {
                 region.assign_fixed(annotation, column.try_into().unwrap(), offset, || {
-                    value.clone().ok_or(Error::Synthesis)
+                    value.clone()
                 })
             }
             _ => panic!("Cannot assign to instance column"),
@@ -158,7 +158,7 @@ impl<const LEN: usize> AssignedBits<LEN> {
 }
 
 impl AssignedBits<16> {
-    fn value_u16(&self) -> Option<u16> {
+    fn value_u16(&self) -> Value<u16> {
         self.value().map(|v| v.into())
     }
 
@@ -167,23 +167,23 @@ impl AssignedBits<16> {
         annotation: A,
         column: impl Into<Column<Any>>,
         offset: usize,
-        value: Option<u16>,
+        value: Value<u16>,
     ) -> Result<Self, Error>
     where
         A: Fn() -> AR,
         AR: Into<String>,
     {
         let column: Column<Any> = column.into();
-        let value: Option<Bits<16>> = value.map(|v| v.into());
+        let value: Value<Bits<16>> = value.map(|v| v.into());
         match column.column_type() {
             Any::Advice => {
                 region.assign_advice(annotation, column.try_into().unwrap(), offset, || {
-                    value.clone().ok_or(Error::Synthesis)
+                    value.clone()
                 })
             }
             Any::Fixed => {
                 region.assign_fixed(annotation, column.try_into().unwrap(), offset, || {
-                    value.clone().ok_or(Error::Synthesis)
+                    value.clone()
                 })
             }
             _ => panic!("Cannot assign to instance column"),
@@ -193,7 +193,7 @@ impl AssignedBits<16> {
 }
 
 impl AssignedBits<32> {
-    fn value_u32(&self) -> Option<u32> {
+    fn value_u32(&self) -> Value<u32> {
         self.value().map(|v| v.into())
     }
 
@@ -202,23 +202,23 @@ impl AssignedBits<32> {
         annotation: A,
         column: impl Into<Column<Any>>,
         offset: usize,
-        value: Option<u32>,
+        value: Value<u32>,
     ) -> Result<Self, Error>
     where
         A: Fn() -> AR,
         AR: Into<String>,
     {
         let column: Column<Any> = column.into();
-        let value: Option<Bits<32>> = value.map(|v| v.into());
+        let value: Value<Bits<32>> = value.map(|v| v.into());
         match column.column_type() {
             Any::Advice => {
                 region.assign_advice(annotation, column.try_into().unwrap(), offset, || {
-                    value.clone().ok_or(Error::Synthesis)
+                    value.clone()
                 })
             }
             Any::Fixed => {
                 region.assign_fixed(annotation, column.try_into().unwrap(), offset, || {
-                    value.clone().ok_or(Error::Synthesis)
+                    value.clone()
                 })
             }
             _ => panic!("Cannot assign to instance column"),
@@ -384,10 +384,10 @@ trait Table16Assignment {
         lookup: &SpreadInputs,
         a_3: Column<Advice>,
         row: usize,
-        r_0_even: Option<[bool; 16]>,
-        r_0_odd: Option<[bool; 16]>,
-        r_1_even: Option<[bool; 16]>,
-        r_1_odd: Option<[bool; 16]>,
+        r_0_even: Value<[bool; 16]>,
+        r_0_odd: Value<[bool; 16]>,
+        r_1_even: Value<[bool; 16]>,
+        r_1_odd: Value<[bool; 16]>,
     ) -> Result<
         (
             (AssignedBits<16>, AssignedBits<16>),
@@ -436,10 +436,10 @@ trait Table16Assignment {
         lookup: &SpreadInputs,
         a_3: Column<Advice>,
         row: usize,
-        r_0_even: Option<[bool; 16]>,
-        r_0_odd: Option<[bool; 16]>,
-        r_1_even: Option<[bool; 16]>,
-        r_1_odd: Option<[bool; 16]>,
+        r_0_even: Value<[bool; 16]>,
+        r_0_odd: Value<[bool; 16]>,
+        r_1_even: Value<[bool; 16]>,
+        r_1_odd: Value<[bool; 16]>,
     ) -> Result<(AssignedBits<16>, AssignedBits<16>), Error> {
         let (even, _odd) = self.assign_spread_outputs(
             region, lookup, a_3, row, r_0_even, r_0_odd, r_1_even, r_1_odd,

--- a/halo2_gadgets/src/sha256/table16/compression.rs
+++ b/halo2_gadgets/src/sha256/table16/compression.rs
@@ -4,7 +4,7 @@ use super::{
     AssignedBits, BlockWord, SpreadInputs, SpreadVar, Table16Assignment, ROUNDS, STATE,
 };
 use halo2_proofs::{
-    circuit::Layouter,
+    circuit::{Layouter, Value},
     pasta::pallas,
     plonk::{Advice, Column, ConstraintSystem, Error, Selector},
     poly::Rotation,
@@ -27,12 +27,12 @@ pub trait UpperSigmaVar<
     const D_LEN: usize,
 >
 {
-    fn spread_a(&self) -> Option<[bool; A_LEN]>;
-    fn spread_b(&self) -> Option<[bool; B_LEN]>;
-    fn spread_c(&self) -> Option<[bool; C_LEN]>;
-    fn spread_d(&self) -> Option<[bool; D_LEN]>;
+    fn spread_a(&self) -> Value<[bool; A_LEN]>;
+    fn spread_b(&self) -> Value<[bool; B_LEN]>;
+    fn spread_c(&self) -> Value<[bool; C_LEN]>;
+    fn spread_d(&self) -> Value<[bool; D_LEN]>;
 
-    fn xor_upper_sigma(&self) -> Option<[bool; 64]> {
+    fn xor_upper_sigma(&self) -> Value<[bool; 64]> {
         self.spread_a()
             .zip(self.spread_b())
             .zip(self.spread_c())
@@ -128,15 +128,15 @@ impl AbcdVar {
 }
 
 impl UpperSigmaVar<4, 22, 18, 20> for AbcdVar {
-    fn spread_a(&self) -> Option<[bool; 4]> {
+    fn spread_a(&self) -> Value<[bool; 4]> {
         self.a.spread.value().map(|v| v.0)
     }
 
-    fn spread_b(&self) -> Option<[bool; 22]> {
+    fn spread_b(&self) -> Value<[bool; 22]> {
         self.b.spread.value().map(|v| v.0)
     }
 
-    fn spread_c(&self) -> Option<[bool; 18]> {
+    fn spread_c(&self) -> Value<[bool; 18]> {
         self.c_lo
             .spread
             .value()
@@ -153,7 +153,7 @@ impl UpperSigmaVar<4, 22, 18, 20> for AbcdVar {
             })
     }
 
-    fn spread_d(&self) -> Option<[bool; 20]> {
+    fn spread_d(&self) -> Value<[bool; 20]> {
         self.d.spread.value().map(|v| v.0)
     }
 }
@@ -217,7 +217,7 @@ impl EfghVar {
 }
 
 impl UpperSigmaVar<12, 10, 28, 14> for EfghVar {
-    fn spread_a(&self) -> Option<[bool; 12]> {
+    fn spread_a(&self) -> Value<[bool; 12]> {
         self.a_lo
             .spread
             .value()
@@ -232,7 +232,7 @@ impl UpperSigmaVar<12, 10, 28, 14> for EfghVar {
             })
     }
 
-    fn spread_b(&self) -> Option<[bool; 10]> {
+    fn spread_b(&self) -> Value<[bool; 10]> {
         self.b_lo
             .spread
             .value()
@@ -247,11 +247,11 @@ impl UpperSigmaVar<12, 10, 28, 14> for EfghVar {
             })
     }
 
-    fn spread_c(&self) -> Option<[bool; 28]> {
+    fn spread_c(&self) -> Value<[bool; 28]> {
         self.c.spread.value().map(|v| v.0)
     }
 
-    fn spread_d(&self) -> Option<[bool; 14]> {
+    fn spread_d(&self) -> Value<[bool; 14]> {
         self.d.spread.value().map(|v| v.0)
     }
 }
@@ -266,7 +266,7 @@ impl From<(AssignedBits<16>, AssignedBits<16>)> for RoundWordDense {
 }
 
 impl RoundWordDense {
-    pub fn value(&self) -> Option<u32> {
+    pub fn value(&self) -> Value<u32> {
         self.0
             .value_u16()
             .zip(self.1.value_u16())
@@ -284,7 +284,7 @@ impl From<(AssignedBits<32>, AssignedBits<32>)> for RoundWordSpread {
 }
 
 impl RoundWordSpread {
-    pub fn value(&self) -> Option<u64> {
+    pub fn value(&self) -> Value<u64> {
         self.0
             .value_u32()
             .zip(self.1.value_u32())
@@ -922,7 +922,7 @@ impl CompressionConfig {
         layouter: &mut impl Layouter<pallas::Base>,
         state: State,
     ) -> Result<[BlockWord; DIGEST_SIZE], Error> {
-        let mut digest = [BlockWord(Some(0)); DIGEST_SIZE];
+        let mut digest = [BlockWord(Value::known(0)); DIGEST_SIZE];
         layouter.assign_region(
             || "digest",
             |mut region| {
@@ -984,10 +984,10 @@ mod tests {
 
                 let digest = config.compression.digest(&mut layouter, state)?;
                 for (idx, digest_word) in digest.iter().enumerate() {
-                    assert_eq!(
-                        (digest_word.0.unwrap() as u64 + IV[idx] as u64) as u32,
-                        super::compression_util::COMPRESSION_OUTPUT[idx]
-                    );
+                    digest_word.0.assert_if_known(|digest_word| {
+                        (*digest_word as u64 + IV[idx] as u64) as u32
+                            == super::compression_util::COMPRESSION_OUTPUT[idx]
+                    });
                 }
 
                 Ok(())

--- a/halo2_gadgets/src/sha256/table16/compression/subregion_digest.rs
+++ b/halo2_gadgets/src/sha256/table16/compression/subregion_digest.rs
@@ -1,7 +1,7 @@
 use super::super::{super::DIGEST_SIZE, BlockWord, RoundWordDense};
 use super::{compression_util::*, CompressionConfig, State};
 use halo2_proofs::{
-    circuit::Region,
+    circuit::{Region, Value},
     pasta::pallas,
     plonk::{Advice, Column, Error},
 };
@@ -39,10 +39,7 @@ impl CompressionConfig {
             || "a",
             a_5,
             abcd_row,
-            || {
-                a.map(|a| pallas::Base::from(a as u64))
-                    .ok_or(Error::Synthesis)
-            },
+            || a.map(|a| pallas::Base::from(a as u64)),
         )?;
 
         let b = self.assign_digest_word(region, abcd_row, a_6, a_7, a_8, b.dense_halves)?;
@@ -61,10 +58,7 @@ impl CompressionConfig {
             || "e",
             a_5,
             efgh_row,
-            || {
-                e.map(|e| pallas::Base::from(e as u64))
-                    .ok_or(Error::Synthesis)
-            },
+            || e.map(|e| pallas::Base::from(e as u64)),
         )?;
 
         let f = self.assign_digest_word(region, efgh_row, a_6, a_7, a_8, f.dense_halves)?;
@@ -91,7 +85,7 @@ impl CompressionConfig {
         hi_col: Column<Advice>,
         word_col: Column<Advice>,
         dense_halves: RoundWordDense,
-    ) -> Result<Option<u32>, Error> {
+    ) -> Result<Value<u32>, Error> {
         dense_halves.0.copy_advice(|| "lo", region, lo_col, row)?;
         dense_halves.1.copy_advice(|| "hi", region, hi_col, row)?;
 
@@ -100,10 +94,7 @@ impl CompressionConfig {
             || "word",
             word_col,
             row,
-            || {
-                val.map(|val| pallas::Base::from(val as u64))
-                    .ok_or(Error::Synthesis)
-            },
+            || val.map(|val| pallas::Base::from(val as u64)),
         )?;
 
         Ok(val)

--- a/halo2_gadgets/src/sha256/table16/compression/subregion_initial.rs
+++ b/halo2_gadgets/src/sha256/table16/compression/subregion_initial.rs
@@ -1,6 +1,10 @@
 use super::super::{RoundWord, StateWord, STATE};
 use super::{compression_util::*, CompressionConfig, State};
-use halo2_proofs::{circuit::Region, pasta::pallas, plonk::Error};
+use halo2_proofs::{
+    circuit::{Region, Value},
+    pasta::pallas,
+    plonk::Error,
+};
 
 impl CompressionConfig {
     #[allow(clippy::many_single_char_names)]
@@ -12,26 +16,28 @@ impl CompressionConfig {
         let a_7 = self.extras[3];
 
         // Decompose E into (6, 5, 14, 7)-bit chunks
-        let e = self.decompose_e(region, RoundIdx::Init, Some(iv[4]))?;
+        let e = self.decompose_e(region, RoundIdx::Init, Value::known(iv[4]))?;
 
         // Decompose F, G
-        let f = self.decompose_f(region, InitialRound, Some(iv[5]))?;
-        let g = self.decompose_g(region, InitialRound, Some(iv[6]))?;
+        let f = self.decompose_f(region, InitialRound, Value::known(iv[5]))?;
+        let g = self.decompose_g(region, InitialRound, Value::known(iv[6]))?;
 
         // Assign H
         let h_row = get_h_row(RoundIdx::Init);
-        let h = self.assign_word_halves_dense(region, h_row, a_7, h_row + 1, a_7, Some(iv[7]))?;
+        let h =
+            self.assign_word_halves_dense(region, h_row, a_7, h_row + 1, a_7, Value::known(iv[7]))?;
 
         // Decompose A into (2, 11, 9, 10)-bit chunks
-        let a = self.decompose_a(region, RoundIdx::Init, Some(iv[0]))?;
+        let a = self.decompose_a(region, RoundIdx::Init, Value::known(iv[0]))?;
 
         // Decompose B, C
-        let b = self.decompose_b(region, InitialRound, Some(iv[1]))?;
-        let c = self.decompose_c(region, InitialRound, Some(iv[2]))?;
+        let b = self.decompose_b(region, InitialRound, Value::known(iv[1]))?;
+        let c = self.decompose_c(region, InitialRound, Value::known(iv[2]))?;
 
         // Assign D
         let d_row = get_d_row(RoundIdx::Init);
-        let d = self.assign_word_halves_dense(region, d_row, a_7, d_row + 1, a_7, Some(iv[3]))?;
+        let d =
+            self.assign_word_halves_dense(region, d_row, a_7, d_row + 1, a_7, Value::known(iv[3]))?;
 
         Ok(State::new(
             StateWord::A(a),
@@ -100,7 +106,7 @@ impl CompressionConfig {
         &self,
         region: &mut Region<'_, pallas::Base>,
         round_idx: InitialRound,
-        b_val: Option<u32>,
+        b_val: Value<u32>,
     ) -> Result<RoundWord, Error> {
         let row = get_decompose_b_row(round_idx);
 
@@ -113,7 +119,7 @@ impl CompressionConfig {
         &self,
         region: &mut Region<'_, pallas::Base>,
         round_idx: InitialRound,
-        c_val: Option<u32>,
+        c_val: Value<u32>,
     ) -> Result<RoundWord, Error> {
         let row = get_decompose_c_row(round_idx);
 
@@ -126,7 +132,7 @@ impl CompressionConfig {
         &self,
         region: &mut Region<'_, pallas::Base>,
         round_idx: InitialRound,
-        f_val: Option<u32>,
+        f_val: Value<u32>,
     ) -> Result<RoundWord, Error> {
         let row = get_decompose_f_row(round_idx);
 
@@ -139,7 +145,7 @@ impl CompressionConfig {
         &self,
         region: &mut Region<'_, pallas::Base>,
         round_idx: InitialRound,
-        g_val: Option<u32>,
+        g_val: Value<u32>,
     ) -> Result<RoundWord, Error> {
         let row = get_decompose_g_row(round_idx);
 

--- a/halo2_gadgets/src/sha256/table16/message_schedule.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule.rs
@@ -435,8 +435,10 @@ mod tests {
                 // Run message_scheduler to get W_[0..64]
                 let (w, _) = config.message_schedule.process(&mut layouter, inputs)?;
                 for (word, test_word) in w.iter().zip(MSG_SCHEDULE_TEST_OUTPUT.iter()) {
-                    let word: u32 = lebs2ip(word.value().unwrap()) as u32;
-                    assert_eq!(word, *test_word);
+                    word.value().assert_if_known(|bits| {
+                        let word: u32 = lebs2ip(bits) as u32;
+                        word == *test_word
+                    });
                 }
                 Ok(())
             }

--- a/halo2_gadgets/src/sha256/table16/message_schedule/schedule_util.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule/schedule_util.rs
@@ -1,6 +1,10 @@
 use super::super::AssignedBits;
 use super::MessageScheduleConfig;
-use halo2_proofs::{circuit::Region, pasta::pallas, plonk::Error};
+use halo2_proofs::{
+    circuit::{Region, Value},
+    pasta::pallas,
+    plonk::Error,
+};
 
 #[cfg(test)]
 use super::super::{super::BLOCK_SIZE, BlockWord, ROUNDS};
@@ -57,22 +61,22 @@ pub fn get_word_row(word_idx: usize) -> usize {
 #[cfg(test)]
 pub fn msg_schedule_test_input() -> [BlockWord; BLOCK_SIZE] {
     [
-        BlockWord(Some(0b01100001011000100110001110000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000000000)),
-        BlockWord(Some(0b00000000000000000000000000011000)),
+        BlockWord(Value::known(0b01100001011000100110001110000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000000000)),
+        BlockWord(Value::known(0b00000000000000000000000000011000)),
     ]
 }
 
@@ -149,7 +153,7 @@ impl MessageScheduleConfig {
     pub fn assign_word_and_halves(
         &self,
         region: &mut Region<'_, pallas::Base>,
-        word: Option<u32>,
+        word: Value<u32>,
         word_idx: usize,
     ) -> Result<(AssignedBits<32>, (AssignedBits<16>, AssignedBits<16>)), Error> {
         // Rename these here for ease of matching the gates to the specification.

--- a/halo2_gadgets/src/sha256/table16/message_schedule/subregion1.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule/subregion1.rs
@@ -1,6 +1,10 @@
 use super::super::{util::*, AssignedBits, BlockWord, SpreadVar, SpreadWord, Table16Assignment};
 use super::{schedule_util::*, MessageScheduleConfig};
-use halo2_proofs::{circuit::Region, pasta::pallas, plonk::Error};
+use halo2_proofs::{
+    circuit::{Region, Value},
+    pasta::pallas,
+    plonk::Error,
+};
 use std::convert::TryInto;
 
 // A word in subregion 1
@@ -17,23 +21,23 @@ pub struct Subregion1Word {
 }
 
 impl Subregion1Word {
-    fn spread_a(&self) -> Option<[bool; 6]> {
+    fn spread_a(&self) -> Value<[bool; 6]> {
         self.a.value().map(|v| v.spread())
     }
 
-    fn spread_b(&self) -> Option<[bool; 8]> {
+    fn spread_b(&self) -> Value<[bool; 8]> {
         self.b.value().map(|v| v.spread())
     }
 
-    fn spread_c(&self) -> Option<[bool; 22]> {
+    fn spread_c(&self) -> Value<[bool; 22]> {
         self.spread_c.value().map(|v| v.0)
     }
 
-    fn spread_d(&self) -> Option<[bool; 28]> {
+    fn spread_d(&self) -> Value<[bool; 28]> {
         self.spread_d.value().map(|v| v.0)
     }
 
-    fn xor_lower_sigma_0(&self) -> Option<[bool; 64]> {
+    fn xor_lower_sigma_0(&self) -> Value<[bool; 64]> {
         self.spread_a()
             .zip(self.spread_b())
             .zip(self.spread_c())
@@ -100,7 +104,7 @@ impl MessageScheduleConfig {
     fn decompose_subregion1_word(
         &self,
         region: &mut Region<'_, pallas::Base>,
-        word: Option<[bool; 32]>,
+        word: Value<[bool; 32]>,
         index: usize,
     ) -> Result<Subregion1Word, Error> {
         let row = get_word_row(index);
@@ -117,7 +121,7 @@ impl MessageScheduleConfig {
                 word[18..32].to_vec(),
             ]
         });
-        let pieces = transpose_option_vec(pieces, 4);
+        let pieces = pieces.transpose_vec(4);
 
         // Assign `a` (3-bit piece)
         let a =
@@ -168,7 +172,7 @@ impl MessageScheduleConfig {
 
         // Split `b` (4-bit chunk) into `b_hi` and `b_lo`
         // Assign `b_lo`, `spread_b_lo`
-        let b_lo: Option<[bool; 2]> = word.b.value().map(|b| b.0[..2].try_into().unwrap());
+        let b_lo: Value<[bool; 2]> = word.b.value().map(|b| b.0[..2].try_into().unwrap());
         let spread_b_lo = b_lo.map(spread_bits);
         {
             AssignedBits::<2>::assign_bits(region, || "b_lo", a_3, row - 1, b_lo)?;
@@ -178,7 +182,7 @@ impl MessageScheduleConfig {
 
         // Split `b` (2-bit chunk) into `b_hi` and `b_lo`
         // Assign `b_hi`, `spread_b_hi`
-        let b_hi: Option<[bool; 2]> = word.b.value().map(|b| b.0[2..].try_into().unwrap());
+        let b_hi: Value<[bool; 2]> = word.b.value().map(|b| b.0[2..].try_into().unwrap());
         let spread_b_hi = b_hi.map(spread_bits);
         {
             AssignedBits::<2>::assign_bits(region, || "b_hi", a_5, row - 1, b_hi)?;
@@ -197,11 +201,11 @@ impl MessageScheduleConfig {
 
         // Calculate R_0^{even}, R_0^{odd}, R_1^{even}, R_1^{odd}
         let r = word.xor_lower_sigma_0();
-        let r_0: Option<[bool; 32]> = r.map(|r| r[..32].try_into().unwrap());
+        let r_0: Value<[bool; 32]> = r.map(|r| r[..32].try_into().unwrap());
         let r_0_even = r_0.map(even_bits);
         let r_0_odd = r_0.map(odd_bits);
 
-        let r_1: Option<[bool; 32]> = r.map(|r| r[32..].try_into().unwrap());
+        let r_1: Value<[bool; 32]> = r.map(|r| r[32..].try_into().unwrap());
         let r_1_even = r_1.map(even_bits);
         let r_1_odd = r_1.map(odd_bits);
 

--- a/halo2_gadgets/src/sha256/table16/message_schedule/subregion2.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule/subregion2.rs
@@ -1,6 +1,10 @@
 use super::super::{util::*, AssignedBits, Bits, SpreadVar, SpreadWord, Table16Assignment};
 use super::{schedule_util::*, MessageScheduleConfig, MessageWord};
-use halo2_proofs::{circuit::Region, pasta::pallas, plonk::Error};
+use halo2_proofs::{
+    circuit::{Region, Value},
+    pasta::pallas,
+    plonk::Error,
+};
 use std::convert::TryInto;
 
 /// A word in subregion 2
@@ -20,35 +24,35 @@ pub struct Subregion2Word {
 }
 
 impl Subregion2Word {
-    fn spread_a(&self) -> Option<[bool; 6]> {
+    fn spread_a(&self) -> Value<[bool; 6]> {
         self.a.value().map(|v| v.spread())
     }
 
-    fn spread_b(&self) -> Option<[bool; 8]> {
+    fn spread_b(&self) -> Value<[bool; 8]> {
         self.b.value().map(|v| v.spread())
     }
 
-    fn spread_c(&self) -> Option<[bool; 6]> {
+    fn spread_c(&self) -> Value<[bool; 6]> {
         self.c.value().map(|v| v.spread())
     }
 
-    fn spread_d(&self) -> Option<[bool; 14]> {
+    fn spread_d(&self) -> Value<[bool; 14]> {
         self.spread_d.value().map(|v| v.0)
     }
 
-    fn spread_e(&self) -> Option<[bool; 2]> {
+    fn spread_e(&self) -> Value<[bool; 2]> {
         self.e.value().map(|v| v.spread())
     }
 
-    fn spread_f(&self) -> Option<[bool; 2]> {
+    fn spread_f(&self) -> Value<[bool; 2]> {
         self.f.value().map(|v| v.spread())
     }
 
-    fn spread_g(&self) -> Option<[bool; 26]> {
+    fn spread_g(&self) -> Value<[bool; 26]> {
         self.spread_g.value().map(|v| v.0)
     }
 
-    fn xor_sigma_0(&self) -> Option<[bool; 64]> {
+    fn xor_sigma_0(&self) -> Value<[bool; 64]> {
         self.spread_a()
             .zip(self.spread_b())
             .zip(self.spread_c())
@@ -98,7 +102,7 @@ impl Subregion2Word {
             })
     }
 
-    fn xor_sigma_1(&self) -> Option<[bool; 64]> {
+    fn xor_sigma_1(&self) -> Value<[bool; 64]> {
         self.spread_a()
             .zip(self.spread_b())
             .zip(self.spread_c())
@@ -251,20 +255,13 @@ impl MessageScheduleConfig {
                 || format!("W_{}", new_word_idx),
                 a_5,
                 get_word_row(new_word_idx - 16) + 1,
-                || {
-                    word.map(|word| pallas::Base::from(word as u64))
-                        .ok_or(Error::Synthesis)
-                },
+                || word.map(|word| pallas::Base::from(word as u64)),
             )?;
             region.assign_advice(
                 || format!("carry_{}", new_word_idx),
                 a_9,
                 get_word_row(new_word_idx - 16) + 1,
-                || {
-                    carry
-                        .map(|carry| pallas::Base::from(carry as u64))
-                        .ok_or(Error::Synthesis)
-                },
+                || carry.map(|carry| pallas::Base::from(carry as u64)),
             )?;
             let (word, halves) = self.assign_word_and_halves(region, word, new_word_idx)?;
             w.push(MessageWord(word));
@@ -294,7 +291,7 @@ impl MessageScheduleConfig {
     fn decompose_word(
         &self,
         region: &mut Region<'_, pallas::Base>,
-        word: Option<&Bits<32>>,
+        word: Value<&Bits<32>>,
         index: usize,
     ) -> Result<Subregion2Word, Error> {
         let row = get_word_row(index);
@@ -310,7 +307,7 @@ impl MessageScheduleConfig {
                 word[19..32].to_vec(),
             ]
         });
-        let pieces = transpose_option_vec(pieces, 7);
+        let pieces = pieces.transpose_vec(7);
 
         // Rename these here for ease of matching the gates to the specification.
         let a_3 = self.extras[0];
@@ -320,14 +317,14 @@ impl MessageScheduleConfig {
         let a = AssignedBits::<3>::assign_bits(region, || "a", a_3, row - 1, pieces[0].clone())?;
 
         // Assign `b` (4-bit piece) lookup
-        let spread_b: Option<SpreadWord<4, 8>> = pieces[1].clone().map(SpreadWord::try_new);
+        let spread_b: Value<SpreadWord<4, 8>> = pieces[1].clone().map(SpreadWord::try_new);
         let spread_b = SpreadVar::with_lookup(region, &self.lookup, row + 1, spread_b)?;
 
         // Assign `c` (3-bit piece)
         let c = AssignedBits::<3>::assign_bits(region, || "c", a_4, row - 1, pieces[2].clone())?;
 
         // Assign `d` (7-bit piece) lookup
-        let spread_d: Option<SpreadWord<7, 14>> = pieces[3].clone().map(SpreadWord::try_new);
+        let spread_d: Value<SpreadWord<7, 14>> = pieces[3].clone().map(SpreadWord::try_new);
         let spread_d = SpreadVar::with_lookup(region, &self.lookup, row, spread_d)?;
 
         // Assign `e` (1-bit piece)
@@ -378,7 +375,7 @@ impl MessageScheduleConfig {
         // Split `b` (4-bit chunk) into `b_hi` and `b_lo`
         // Assign `b_lo`, `spread_b_lo`
 
-        let b_lo: Option<[bool; 2]> = word.b.value().map(|b| b.0[..2].try_into().unwrap());
+        let b_lo: Value<[bool; 2]> = word.b.value().map(|b| b.0[..2].try_into().unwrap());
         let spread_b_lo = b_lo.map(spread_bits);
         {
             AssignedBits::<2>::assign_bits(region, || "b_lo", a_3, row - 1, b_lo)?;
@@ -388,7 +385,7 @@ impl MessageScheduleConfig {
 
         // Split `b` (2-bit chunk) into `b_hi` and `b_lo`
         // Assign `b_hi`, `spread_b_hi`
-        let b_hi: Option<[bool; 2]> = word.b.value().map(|b| b.0[2..].try_into().unwrap());
+        let b_hi: Value<[bool; 2]> = word.b.value().map(|b| b.0[2..].try_into().unwrap());
         let spread_b_hi = b_hi.map(spread_bits);
         {
             AssignedBits::<2>::assign_bits(region, || "b_hi", a_5, row - 1, b_hi)?;
@@ -433,11 +430,11 @@ impl MessageScheduleConfig {
 
         // Calculate R_0^{even}, R_0^{odd}, R_1^{even}, R_1^{odd}
         let r = word.xor_sigma_0();
-        let r_0: Option<[bool; 32]> = r.map(|r| r[..32].try_into().unwrap());
+        let r_0: Value<[bool; 32]> = r.map(|r| r[..32].try_into().unwrap());
         let r_0_even = r_0.map(even_bits);
         let r_0_odd = r_0.map(odd_bits);
 
-        let r_1: Option<[bool; 32]> = r.map(|r| r[32..].try_into().unwrap());
+        let r_1: Value<[bool; 32]> = r.map(|r| r[32..].try_into().unwrap());
         let r_1_even = r_1.map(even_bits);
         let r_1_odd = r_1.map(odd_bits);
 
@@ -468,11 +465,11 @@ impl MessageScheduleConfig {
         // Calculate R_0^{even}, R_0^{odd}, R_1^{even}, R_1^{odd}
         // Calculate R_0^{even}, R_0^{odd}, R_1^{even}, R_1^{odd}
         let r = word.xor_sigma_1();
-        let r_0: Option<[bool; 32]> = r.map(|r| r[..32].try_into().unwrap());
+        let r_0: Value<[bool; 32]> = r.map(|r| r[..32].try_into().unwrap());
         let r_0_even = r_0.map(even_bits);
         let r_0_odd = r_0.map(odd_bits);
 
-        let r_1: Option<[bool; 32]> = r.map(|r| r[32..].try_into().unwrap());
+        let r_1: Value<[bool; 32]> = r.map(|r| r[32..].try_into().unwrap());
         let r_1_even = r_1.map(even_bits);
         let r_1_odd = r_1.map(odd_bits);
 

--- a/halo2_gadgets/src/sha256/table16/message_schedule/subregion3.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule/subregion3.rs
@@ -1,6 +1,10 @@
 use super::super::{util::*, AssignedBits, Bits, SpreadVar, SpreadWord, Table16Assignment};
 use super::{schedule_util::*, MessageScheduleConfig, MessageWord};
-use halo2_proofs::{circuit::Region, pasta::pallas, plonk::Error};
+use halo2_proofs::{
+    circuit::{Region, Value},
+    pasta::pallas,
+    plonk::Error,
+};
 use std::convert::TryInto;
 
 // A word in subregion 3
@@ -18,23 +22,23 @@ pub struct Subregion3Word {
 }
 
 impl Subregion3Word {
-    fn spread_a(&self) -> Option<[bool; 20]> {
+    fn spread_a(&self) -> Value<[bool; 20]> {
         self.spread_a.value().map(|v| v.0)
     }
 
-    fn spread_b(&self) -> Option<[bool; 14]> {
+    fn spread_b(&self) -> Value<[bool; 14]> {
         self.b.value().map(|v| v.spread())
     }
 
-    fn spread_c(&self) -> Option<[bool; 4]> {
+    fn spread_c(&self) -> Value<[bool; 4]> {
         self.c.value().map(|v| v.spread())
     }
 
-    fn spread_d(&self) -> Option<[bool; 26]> {
+    fn spread_d(&self) -> Value<[bool; 26]> {
         self.spread_d.value().map(|v| v.0)
     }
 
-    fn xor_lower_sigma_1(&self) -> Option<[bool; 64]> {
+    fn xor_lower_sigma_1(&self) -> Value<[bool; 64]> {
         self.spread_a()
             .zip(self.spread_b())
             .zip(self.spread_c())
@@ -167,20 +171,13 @@ impl MessageScheduleConfig {
                 || format!("W_{}", new_word_idx),
                 a_5,
                 get_word_row(new_word_idx - 16) + 1,
-                || {
-                    word.map(|word| pallas::Base::from(word as u64))
-                        .ok_or(Error::Synthesis)
-                },
+                || word.map(|word| pallas::Base::from(word as u64)),
             )?;
             region.assign_advice(
                 || format!("carry_{}", new_word_idx),
                 a_9,
                 get_word_row(new_word_idx - 16) + 1,
-                || {
-                    carry
-                        .map(|carry| pallas::Base::from(carry as u64))
-                        .ok_or(Error::Synthesis)
-                },
+                || carry.map(|carry| pallas::Base::from(carry as u64)),
             )?;
             let (word, halves) = self.assign_word_and_halves(region, word, new_word_idx)?;
             w.push(MessageWord(word));
@@ -200,7 +197,7 @@ impl MessageScheduleConfig {
     fn decompose_subregion3_word(
         &self,
         region: &mut Region<'_, pallas::Base>,
-        word: Option<&Bits<32>>,
+        word: Value<&Bits<32>>,
         index: usize,
     ) -> Result<Subregion3Word, Error> {
         let row = get_word_row(index);
@@ -217,7 +214,7 @@ impl MessageScheduleConfig {
                 word[19..32].to_vec(),
             ]
         });
-        let pieces = transpose_option_vec(pieces, 4);
+        let pieces = pieces.transpose_vec(4);
 
         // Assign `a` (10-bit piece)
         let spread_a = pieces[0].clone().map(SpreadWord::try_new);
@@ -264,21 +261,21 @@ impl MessageScheduleConfig {
 
         // b_lo (2-bit chunk)
         {
-            let b_lo: Option<[bool; 2]> = word.b.value().map(|v| v[0..2].try_into().unwrap());
+            let b_lo: Value<[bool; 2]> = word.b.value().map(|v| v[0..2].try_into().unwrap());
             let b_lo = b_lo.map(SpreadWord::<2, 4>::new);
             SpreadVar::without_lookup(region, a_3, row - 1, a_4, row - 1, b_lo)?;
         }
 
         // b_mid (2-bit chunk)
         {
-            let b_mid: Option<[bool; 2]> = word.b.value().map(|v| v[2..4].try_into().unwrap());
+            let b_mid: Value<[bool; 2]> = word.b.value().map(|v| v[2..4].try_into().unwrap());
             let b_mid = b_mid.map(SpreadWord::<2, 4>::new);
             SpreadVar::without_lookup(region, a_5, row - 1, a_6, row - 1, b_mid)?;
         }
 
         // b_hi (3-bit chunk)
         {
-            let b_hi: Option<[bool; 3]> = word.b.value().map(|v| v[4..7].try_into().unwrap());
+            let b_hi: Value<[bool; 3]> = word.b.value().map(|v| v[4..7].try_into().unwrap());
             let b_hi = b_hi.map(SpreadWord::<3, 6>::new);
             SpreadVar::without_lookup(region, a_5, row + 1, a_6, row + 1, b_hi)?;
         }
@@ -301,11 +298,11 @@ impl MessageScheduleConfig {
         // (10, 7, 2, 13)
         // Calculate R_0^{even}, R_0^{odd}, R_1^{even}, R_1^{odd}
         let r = word.xor_lower_sigma_1();
-        let r_0: Option<[bool; 32]> = r.map(|r| r[..32].try_into().unwrap());
+        let r_0: Value<[bool; 32]> = r.map(|r| r[..32].try_into().unwrap());
         let r_0_even = r_0.map(even_bits);
         let r_0_odd = r_0.map(odd_bits);
 
-        let r_1: Option<[bool; 32]> = r.map(|r| r[32..].try_into().unwrap());
+        let r_1: Value<[bool; 32]> = r.map(|r| r[32..].try_into().unwrap());
         let r_1_even = r_1.map(even_bits);
         let r_1_odd = r_1.map(odd_bits);
 

--- a/halo2_gadgets/src/sha256/table16/util.rs
+++ b/halo2_gadgets/src/sha256/table16/util.rs
@@ -1,3 +1,5 @@
+use halo2_proofs::circuit::Value;
+
 pub const MASK_EVEN_32: u32 = 0x55555555;
 
 /// The sequence of bits representing a u64 in little-endian order.
@@ -96,25 +98,15 @@ pub fn odd_bits<const LEN: usize, const HALF: usize>(bits: [bool; LEN]) -> [bool
     odd_bits
 }
 
-/// Helper function to transpose an Option<Vec<F>> to a Vec<Option<F>>.
-/// The length of the vector must be `len`.
-pub fn transpose_option_vec<T: Clone>(vec: Option<Vec<T>>, len: usize) -> Vec<Option<T>> {
-    if let Some(vec) = vec {
-        vec.into_iter().map(Some).collect()
-    } else {
-        vec![None; len]
-    }
-}
-
 /// Given a vector of words as vec![(lo: u16, hi: u16)], returns their sum: u32, along
 /// with a carry bit.
-pub fn sum_with_carry(words: Vec<(Option<u16>, Option<u16>)>) -> (Option<u32>, Option<u64>) {
-    let words_lo: Option<Vec<u64>> = words.iter().map(|(lo, _)| lo.map(|lo| lo as u64)).collect();
-    let words_hi: Option<Vec<u64>> = words.iter().map(|(_, hi)| hi.map(|hi| hi as u64)).collect();
+pub fn sum_with_carry(words: Vec<(Value<u16>, Value<u16>)>) -> (Value<u32>, Value<u64>) {
+    let words_lo: Value<Vec<u64>> = words.iter().map(|(lo, _)| lo.map(|lo| lo as u64)).collect();
+    let words_hi: Value<Vec<u64>> = words.iter().map(|(_, hi)| hi.map(|hi| hi as u64)).collect();
 
-    let sum: Option<u64> = {
-        let sum_lo: Option<u64> = words_lo.map(|vec| vec.iter().sum());
-        let sum_hi: Option<u64> = words_hi.map(|vec| vec.iter().sum());
+    let sum: Value<u64> = {
+        let sum_lo: Value<u64> = words_lo.map(|vec| vec.iter().sum());
+        let sum_hi: Value<u64> = words_hi.map(|vec| vec.iter().sum());
         sum_lo.zip(sum_hi).map(|(lo, hi)| lo + (1 << 16) * hi)
     };
 

--- a/halo2_gadgets/src/sinsemilla/chip.rs
+++ b/halo2_gadgets/src/sinsemilla/chip.rs
@@ -14,7 +14,7 @@ use crate::{
 use std::marker::PhantomData;
 
 use halo2_proofs::{
-    circuit::{AssignedCell, Chip, Layouter},
+    circuit::{AssignedCell, Chip, Layouter, Value},
     plonk::{
         Advice, Column, ConstraintSystem, Constraints, Error, Expression, Fixed, Selector,
         TableColumn, VirtualCells,
@@ -288,7 +288,7 @@ where
     fn witness_message_piece(
         &self,
         mut layouter: impl Layouter<pallas::Base>,
-        field_elem: Option<pallas::Base>,
+        field_elem: Value<pallas::Base>,
         num_words: usize,
     ) -> Result<Self::MessagePiece, Error> {
         let config = self.config().clone();
@@ -300,7 +300,7 @@ where
                     || "witness message piece",
                     config.witness_pieces,
                     0,
-                    || field_elem.ok_or(Error::Synthesis),
+                    || field_elem,
                 )
             },
         )?;

--- a/halo2_gadgets/src/sinsemilla/chip/generator_table.rs
+++ b/halo2_gadgets/src/sinsemilla/chip/generator_table.rs
@@ -1,5 +1,5 @@
 use halo2_proofs::{
-    circuit::Layouter,
+    circuit::{Layouter, Value},
     plonk::{ConstraintSystem, Error, Expression, TableColumn},
     poly::Rotation,
 };
@@ -85,10 +85,10 @@ impl GeneratorTableConfig {
                         || "table_idx",
                         self.table_idx,
                         index,
-                        || Ok(pallas::Base::from(index as u64)),
+                        || Value::known(pallas::Base::from(index as u64)),
                     )?;
-                    table.assign_cell(|| "table_x", self.table_x, index, || Ok(*x))?;
-                    table.assign_cell(|| "table_y", self.table_y, index, || Ok(*y))?;
+                    table.assign_cell(|| "table_x", self.table_x, index, || Value::known(*x))?;
+                    table.assign_cell(|| "table_y", self.table_y, index, || Value::known(*y))?;
                 }
                 Ok(())
             },

--- a/halo2_gadgets/src/sinsemilla/message.rs
+++ b/halo2_gadgets/src/sinsemilla/message.rs
@@ -2,7 +2,7 @@
 use ff::PrimeFieldBits;
 use halo2_proofs::{
     arithmetic::FieldExt,
-    circuit::{AssignedCell, Cell},
+    circuit::{AssignedCell, Cell, Value},
 };
 use std::fmt::Debug;
 
@@ -58,7 +58,7 @@ impl<F: FieldExt + PrimeFieldBits, const K: usize> MessagePiece<F, K> {
         self.cell_value.cell()
     }
 
-    pub fn field_elem(&self) -> Option<F> {
+    pub fn field_elem(&self) -> Value<F> {
         self.cell_value.value().cloned()
     }
 

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `halo2_proofs::circuit::Value`, a more usable and type-safe replacement for
+  `Option<V>` in circuit synthesis.
 
 ## [0.1.0] - 2022-05-10
 ### Added

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to Rust's notion of
 ### Added
 - `halo2_proofs::circuit::Value`, a more usable and type-safe replacement for
   `Option<V>` in circuit synthesis.
+- `impl Mul<F: Field> for &Assigned<F>`
+
+### Changed
+All APIs that represented witnessed values as `Option<V>` now represent them as
+`halo2_proofs::circuit::Value<V>`. The core API changes are listed below.
+
+- The following APIs now take `Value<_>` instead of `Option<_>`:
+  - `halo2_proofs::plonk`:
+    - `Assignment::fill_from_row`
+- The following APIs now take value closures that return `Value<V>` instead of
+  `Result<V, Error>`:
+  - `halo2_proofs::circuit`:
+    - `Region::{assign_advice, assign_fixed}`
+    - `Table::assign_cell`
+  - `halo2_proofs::circuit::layouter`:
+    - `RegionLayouter::{assign_advice, assign_fixed}`
+    - `TableLayouter::assign_cell`
+  - `halo2_proofs::plonk`:
+    - `Assignment::{assign_advice, assign_fixed}`
+- The following APIs now return `Value<_>` instead of `Option<_>`:
+  - `halo2_proofs::circuit`:
+    - `AssignedCell::{value, value_field}`
+- The following APIs now return `Result<Value<F>, Error>` instead of
+  `Result<Option<F>, Error>`:
+  - `halo2_proofs::plonk`:
+    - `Assignment::query_instance`
+- The following APIs now return `Result<(Cell, Value<F>), Error>` instead of
+  `Result<(Cell, Option<F>), Error>`:
+  - `halo2_proofs::circuit::layouter`:
+    - `RegionLayouter::assign_advice_from_instance`
 
 ## [0.1.0] - 2022-05-10
 ### Added

--- a/halo2_proofs/benches/dev_lookup.rs
+++ b/halo2_proofs/benches/dev_lookup.rs
@@ -2,7 +2,7 @@
 extern crate criterion;
 
 use halo2_proofs::arithmetic::FieldExt;
-use halo2_proofs::circuit::{Layouter, SimpleFloorPlanner};
+use halo2_proofs::circuit::{Layouter, SimpleFloorPlanner, Value};
 use halo2_proofs::dev::MockProver;
 use halo2_proofs::plonk::*;
 use halo2_proofs::poly::Rotation;
@@ -63,7 +63,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             || format!("row {}", row),
                             config.table,
                             row as usize,
-                            || Ok(F::from(row + 1)),
+                            || Value::known(F::from(row + 1)),
                         )?;
                     }
 
@@ -80,7 +80,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                             || format!("offset {}", offset),
                             config.advice,
                             offset as usize,
-                            || Ok(F::from((offset % 256) + 1)),
+                            || Value::known(F::from((offset % 256) + 1)),
                         )?;
                     }
 

--- a/halo2_proofs/examples/circuit-layout.rs
+++ b/halo2_proofs/examples/circuit-layout.rs
@@ -1,9 +1,9 @@
 use ff::Field;
 use halo2_proofs::{
     arithmetic::FieldExt,
-    circuit::{Cell, Layouter, Region, SimpleFloorPlanner},
+    circuit::{Cell, Layouter, Region, SimpleFloorPlanner, Value},
     pasta::Fp,
-    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, TableColumn},
+    plonk::{Advice, Assigned, Circuit, Column, ConstraintSystem, Error, Fixed, TableColumn},
     poly::Rotation,
 };
 use rand_core::OsRng;
@@ -31,16 +31,16 @@ struct PlonkConfig {
 trait StandardCs<FF: FieldExt> {
     fn raw_multiply<F>(&self, region: &mut Region<FF>, f: F) -> Result<(Cell, Cell, Cell), Error>
     where
-        F: FnMut() -> Result<(FF, FF, FF), Error>;
+        F: FnMut() -> Value<(Assigned<FF>, Assigned<FF>, Assigned<FF>)>;
     fn raw_add<F>(&self, region: &mut Region<FF>, f: F) -> Result<(Cell, Cell, Cell), Error>
     where
-        F: FnMut() -> Result<(FF, FF, FF), Error>;
+        F: FnMut() -> Value<(Assigned<FF>, Assigned<FF>, Assigned<FF>)>;
     fn copy(&self, region: &mut Region<FF>, a: Cell, b: Cell) -> Result<(), Error>;
     fn lookup_table(&self, layouter: &mut impl Layouter<FF>, values: &[FF]) -> Result<(), Error>;
 }
 
 struct MyCircuit<F: FieldExt> {
-    a: Option<F>,
+    a: Value<F>,
     lookup_table: Vec<F>,
 }
 
@@ -65,7 +65,7 @@ impl<FF: FieldExt> StandardCs<FF> for StandardPlonk<FF> {
         mut f: F,
     ) -> Result<(Cell, Cell, Cell), Error>
     where
-        F: FnMut() -> Result<(FF, FF, FF), Error>,
+        F: FnMut() -> Value<(Assigned<FF>, Assigned<FF>, Assigned<FF>)>,
     {
         let mut value = None;
         let lhs = region.assign_advice(
@@ -73,44 +73,36 @@ impl<FF: FieldExt> StandardCs<FF> for StandardPlonk<FF> {
             self.config.a,
             0,
             || {
-                value = Some(f()?);
-                Ok(value.ok_or(Error::Synthesis)?.0)
+                value = Some(f());
+                value.unwrap().map(|v| v.0)
             },
         )?;
         region.assign_advice(
             || "lhs^4",
             self.config.d,
             0,
-            || Ok(value.ok_or(Error::Synthesis)?.0.square().square()),
+            || value.unwrap().map(|v| v.0).square().square(),
         )?;
-        let rhs = region.assign_advice(
-            || "rhs",
-            self.config.b,
-            0,
-            || Ok(value.ok_or(Error::Synthesis)?.1),
-        )?;
+        let rhs =
+            region.assign_advice(|| "rhs", self.config.b, 0, || value.unwrap().map(|v| v.1))?;
         region.assign_advice(
             || "rhs^4",
             self.config.e,
             0,
-            || Ok(value.ok_or(Error::Synthesis)?.1.square().square()),
+            || value.unwrap().map(|v| v.1).square().square(),
         )?;
-        let out = region.assign_advice(
-            || "out",
-            self.config.c,
-            0,
-            || Ok(value.ok_or(Error::Synthesis)?.2),
-        )?;
+        let out =
+            region.assign_advice(|| "out", self.config.c, 0, || value.unwrap().map(|v| v.2))?;
 
-        region.assign_fixed(|| "a", self.config.sa, 0, || Ok(FF::zero()))?;
-        region.assign_fixed(|| "b", self.config.sb, 0, || Ok(FF::zero()))?;
-        region.assign_fixed(|| "c", self.config.sc, 0, || Ok(FF::one()))?;
-        region.assign_fixed(|| "a * b", self.config.sm, 0, || Ok(FF::one()))?;
+        region.assign_fixed(|| "a", self.config.sa, 0, || Value::known(FF::zero()))?;
+        region.assign_fixed(|| "b", self.config.sb, 0, || Value::known(FF::zero()))?;
+        region.assign_fixed(|| "c", self.config.sc, 0, || Value::known(FF::one()))?;
+        region.assign_fixed(|| "a * b", self.config.sm, 0, || Value::known(FF::one()))?;
         Ok((lhs.cell(), rhs.cell(), out.cell()))
     }
     fn raw_add<F>(&self, region: &mut Region<FF>, mut f: F) -> Result<(Cell, Cell, Cell), Error>
     where
-        F: FnMut() -> Result<(FF, FF, FF), Error>,
+        F: FnMut() -> Value<(Assigned<FF>, Assigned<FF>, Assigned<FF>)>,
     {
         let mut value = None;
         let lhs = region.assign_advice(
@@ -118,39 +110,31 @@ impl<FF: FieldExt> StandardCs<FF> for StandardPlonk<FF> {
             self.config.a,
             0,
             || {
-                value = Some(f()?);
-                Ok(value.ok_or(Error::Synthesis)?.0)
+                value = Some(f());
+                value.unwrap().map(|v| v.0)
             },
         )?;
         region.assign_advice(
             || "lhs^4",
             self.config.d,
             0,
-            || Ok(value.ok_or(Error::Synthesis)?.0.square().square()),
+            || value.unwrap().map(|v| v.0.square().square()),
         )?;
-        let rhs = region.assign_advice(
-            || "rhs",
-            self.config.b,
-            0,
-            || Ok(value.ok_or(Error::Synthesis)?.1),
-        )?;
+        let rhs =
+            region.assign_advice(|| "rhs", self.config.b, 0, || value.unwrap().map(|v| v.1))?;
         region.assign_advice(
             || "rhs^4",
             self.config.e,
             0,
-            || Ok(value.ok_or(Error::Synthesis)?.1.square().square()),
+            || value.unwrap().map(|v| v.1.square().square()),
         )?;
-        let out = region.assign_advice(
-            || "out",
-            self.config.c,
-            0,
-            || Ok(value.ok_or(Error::Synthesis)?.2),
-        )?;
+        let out =
+            region.assign_advice(|| "out", self.config.c, 0, || value.unwrap().map(|v| v.2))?;
 
-        region.assign_fixed(|| "a", self.config.sa, 0, || Ok(FF::one()))?;
-        region.assign_fixed(|| "b", self.config.sb, 0, || Ok(FF::one()))?;
-        region.assign_fixed(|| "c", self.config.sc, 0, || Ok(FF::one()))?;
-        region.assign_fixed(|| "a * b", self.config.sm, 0, || Ok(FF::zero()))?;
+        region.assign_fixed(|| "a", self.config.sa, 0, || Value::known(FF::one()))?;
+        region.assign_fixed(|| "b", self.config.sb, 0, || Value::known(FF::one()))?;
+        region.assign_fixed(|| "c", self.config.sc, 0, || Value::known(FF::one()))?;
+        region.assign_fixed(|| "a * b", self.config.sm, 0, || Value::known(FF::zero()))?;
         Ok((lhs.cell(), rhs.cell(), out.cell()))
     }
     fn copy(&self, region: &mut Region<FF>, left: Cell, right: Cell) -> Result<(), Error> {
@@ -161,7 +145,12 @@ impl<FF: FieldExt> StandardCs<FF> for StandardPlonk<FF> {
             || "",
             |mut table| {
                 for (index, &value) in values.iter().enumerate() {
-                    table.assign_cell(|| "table col", self.config.sl, index, || Ok(value))?;
+                    table.assign_cell(
+                        || "table col",
+                        self.config.sl,
+                        index,
+                        || Value::known(value),
+                    )?;
                 }
                 Ok(())
             },
@@ -176,7 +165,7 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
 
     fn without_witnesses(&self) -> Self {
         Self {
-            a: None,
+            a: Value::unknown(),
             lookup_table: self.lookup_table.clone(),
         }
     }
@@ -257,22 +246,17 @@ impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
             layouter.assign_region(
                 || format!("region_{}", i),
                 |mut region| {
-                    let mut a_squared = None;
+                    let a: Value<Assigned<_>> = self.a.into();
+                    let mut a_squared = Value::unknown();
                     let (a0, _, c0) = cs.raw_multiply(&mut region, || {
-                        a_squared = self.a.map(|a| a.square());
-                        Ok((
-                            self.a.ok_or(Error::Synthesis)?,
-                            self.a.ok_or(Error::Synthesis)?,
-                            a_squared.ok_or(Error::Synthesis)?,
-                        ))
+                        a_squared = a.square();
+                        a.zip(a_squared).map(|(a, a_squared)| (a, a, a_squared))
                     })?;
                     let (a1, b1, _) = cs.raw_add(&mut region, || {
-                        let fin = a_squared.and_then(|a2| self.a.map(|a| a + a2));
-                        Ok((
-                            self.a.ok_or(Error::Synthesis)?,
-                            a_squared.ok_or(Error::Synthesis)?,
-                            fin.ok_or(Error::Synthesis)?,
-                        ))
+                        let fin = a_squared + a;
+                        a.zip(a_squared)
+                            .zip(fin)
+                            .map(|((a, a_squared), fin)| (a, a_squared, fin))
                     })?;
                     cs.copy(&mut region, a0, a1)?;
                     cs.copy(&mut region, b1, c0)
@@ -294,7 +278,7 @@ fn main() {
     let instance = Fp::one() + Fp::one();
     let lookup_table = vec![instance, a, a, Fp::zero()];
     let circuit: MyCircuit<Fp> = MyCircuit {
-        a: None,
+        a: Value::unknown(),
         lookup_table,
     };
 

--- a/halo2_proofs/examples/simple-example.rs
+++ b/halo2_proofs/examples/simple-example.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use halo2_proofs::{
     arithmetic::FieldExt,
-    circuit::{AssignedCell, Chip, Layouter, Region, SimpleFloorPlanner},
+    circuit::{AssignedCell, Chip, Layouter, Region, SimpleFloorPlanner, Value},
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Instance, Selector},
     poly::Rotation,
 };
@@ -13,7 +13,7 @@ trait NumericInstructions<F: FieldExt>: Chip<F> {
     type Num;
 
     /// Loads a number into the circuit as a private input.
-    fn load_private(&self, layouter: impl Layouter<F>, a: Option<F>) -> Result<Self::Num, Error>;
+    fn load_private(&self, layouter: impl Layouter<F>, a: Value<F>) -> Result<Self::Num, Error>;
 
     /// Loads a number into the circuit as a fixed constant.
     fn load_constant(&self, layouter: impl Layouter<F>, constant: F) -> Result<Self::Num, Error>;
@@ -151,7 +151,7 @@ impl<F: FieldExt> NumericInstructions<F> for FieldChip<F> {
     fn load_private(
         &self,
         mut layouter: impl Layouter<F>,
-        value: Option<F>,
+        value: Value<F>,
     ) -> Result<Self::Num, Error> {
         let config = self.config();
 
@@ -159,12 +159,7 @@ impl<F: FieldExt> NumericInstructions<F> for FieldChip<F> {
             || "load private",
             |mut region| {
                 region
-                    .assign_advice(
-                        || "private input",
-                        config.advice[0],
-                        0,
-                        || value.ok_or(Error::Synthesis),
-                    )
+                    .assign_advice(|| "private input", config.advice[0], 0, || value)
                     .map(Number)
             },
         )
@@ -212,17 +207,12 @@ impl<F: FieldExt> NumericInstructions<F> for FieldChip<F> {
 
                 // Now we can assign the multiplication result, which is to be assigned
                 // into the output position.
-                let value = a.0.value().and_then(|a| b.0.value().map(|b| *a * *b));
+                let value = a.0.value().copied() * b.0.value();
 
                 // Finally, we do the assignment to the output, returning a
                 // variable to be used in another part of the circuit.
                 region
-                    .assign_advice(
-                        || "lhs * rhs",
-                        config.advice[0],
-                        1,
-                        || value.ok_or(Error::Synthesis),
-                    )
+                    .assign_advice(|| "lhs * rhs", config.advice[0], 1, || value)
                     .map(Number)
             },
         )
@@ -250,8 +240,8 @@ impl<F: FieldExt> NumericInstructions<F> for FieldChip<F> {
 #[derive(Default)]
 struct MyCircuit<F: FieldExt> {
     constant: F,
-    a: Option<F>,
-    b: Option<F>,
+    a: Value<F>,
+    b: Value<F>,
 }
 
 impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
@@ -329,8 +319,8 @@ fn main() {
     // Instantiate the circuit with the private inputs.
     let circuit = MyCircuit {
         constant,
-        a: Some(a),
-        b: Some(b),
+        a: Value::known(a),
+        b: Value::known(b),
     };
 
     // Arrange the public input. We expose the multiplication result in row 0

--- a/halo2_proofs/examples/two-chip.rs
+++ b/halo2_proofs/examples/two-chip.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use halo2_proofs::{
     arithmetic::FieldExt,
-    circuit::{AssignedCell, Chip, Layouter, Region, SimpleFloorPlanner},
+    circuit::{AssignedCell, Chip, Layouter, Region, SimpleFloorPlanner, Value},
     plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Instance, Selector},
     poly::Rotation,
 };
@@ -20,7 +20,7 @@ trait FieldInstructions<F: FieldExt>: AddInstructions<F> + MulInstructions<F> {
     fn load_private(
         &self,
         layouter: impl Layouter<F>,
-        a: Option<F>,
+        a: Value<F>,
     ) -> Result<<Self as FieldInstructions<F>>::Num, Error>;
 
     /// Returns `d = (a + b) * c`.
@@ -217,17 +217,12 @@ impl<F: FieldExt> AddInstructions<F> for AddChip<F> {
 
                 // Now we can compute the addition result, which is to be assigned
                 // into the output position.
-                let value = a.0.value().and_then(|a| b.0.value().map(|b| *a + *b));
+                let value = a.0.value().copied() + b.0.value();
 
                 // Finally, we do the assignment to the output, returning a
                 // variable to be used in another part of the circuit.
                 region
-                    .assign_advice(
-                        || "lhs + rhs",
-                        config.advice[0],
-                        1,
-                        || value.ok_or(Error::Synthesis),
-                    )
+                    .assign_advice(|| "lhs + rhs", config.advice[0], 1, || value)
                     .map(Number)
             },
         )
@@ -343,17 +338,12 @@ impl<F: FieldExt> MulInstructions<F> for MulChip<F> {
 
                 // Now we can compute the multiplication result, which is to be assigned
                 // into the output position.
-                let value = a.0.value().and_then(|a| b.0.value().map(|b| *a * *b));
+                let value = a.0.value().copied() * b.0.value();
 
                 // Finally, we do the assignment to the output, returning a
                 // variable to be used in another part of the circuit.
                 region
-                    .assign_advice(
-                        || "lhs * rhs",
-                        config.advice[0],
-                        1,
-                        || value.ok_or(Error::Synthesis),
-                    )
+                    .assign_advice(|| "lhs * rhs", config.advice[0], 1, || value)
                     .map(Number)
             },
         )
@@ -412,7 +402,7 @@ impl<F: FieldExt> FieldInstructions<F> for FieldChip<F> {
     fn load_private(
         &self,
         mut layouter: impl Layouter<F>,
-        value: Option<F>,
+        value: Value<F>,
     ) -> Result<<Self as FieldInstructions<F>>::Num, Error> {
         let config = self.config();
 
@@ -420,12 +410,7 @@ impl<F: FieldExt> FieldInstructions<F> for FieldChip<F> {
             || "load private",
             |mut region| {
                 region
-                    .assign_advice(
-                        || "private input",
-                        config.advice[0],
-                        0,
-                        || value.ok_or(Error::Synthesis),
-                    )
+                    .assign_advice(|| "private input", config.advice[0], 0, || value)
                     .map(Number)
             },
         )
@@ -459,14 +444,14 @@ impl<F: FieldExt> FieldInstructions<F> for FieldChip<F> {
 // ANCHOR: circuit
 /// The full circuit implementation.
 ///
-/// In this struct we store the private input variables. We use `Option<F>` because
+/// In this struct we store the private input variables. We use `Value<F>` because
 /// they won't have any value during key generation. During proving, if any of these
-/// were `None` we would get an error.
+/// were `Value::unknown()` we would get an error.
 #[derive(Default)]
 struct MyCircuit<F: FieldExt> {
-    a: Option<F>,
-    b: Option<F>,
-    c: Option<F>,
+    a: Value<F>,
+    b: Value<F>,
+    c: Value<F>,
 }
 
 impl<F: FieldExt> Circuit<F> for MyCircuit<F> {
@@ -529,9 +514,9 @@ fn main() {
 
     // Instantiate the circuit with the private inputs.
     let circuit = MyCircuit {
-        a: Some(a),
-        b: Some(b),
-        c: Some(c),
+        a: Value::known(a),
+        b: Value::known(b),
+        c: Value::known(c),
     };
 
     // Arrange the public input. We expose the multiplication result in row 0

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -9,6 +9,9 @@ use crate::{
     plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector, TableColumn},
 };
 
+mod value;
+pub use value::Value;
+
 pub mod floor_planner;
 pub use floor_planner::single_pass::SimpleFloorPlanner;
 

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -6,7 +6,7 @@ use crate::{
     circuit::{
         floor_planner::single_pass::SimpleTableLayouter,
         layouter::{RegionColumn, RegionLayouter, RegionShape, TableLayouter},
-        Cell, Layouter, Region, RegionIndex, RegionStart, Table,
+        Cell, Layouter, Region, RegionIndex, RegionStart, Table, Value,
     },
     plonk::{
         Advice, Any, Assigned, Assignment, Circuit, Column, Error, Fixed, FloorPlanner, Instance,
@@ -126,7 +126,7 @@ impl FloorPlanner for V1 {
                 || format!("Constant({:?})", value.evaluate()),
                 fixed_column,
                 fixed_row,
-                || Ok(value),
+                || Value::known(value),
             )?;
             plan.cs.copy(
                 fixed_column.into(),
@@ -396,7 +396,7 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
         annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Advice>,
         offset: usize,
-        to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
+        to: &'v mut (dyn FnMut() -> Value<Assigned<F>> + 'v),
     ) -> Result<Cell, Error> {
         self.plan.cs.assign_advice(
             annotation,
@@ -419,7 +419,8 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
         offset: usize,
         constant: Assigned<F>,
     ) -> Result<Cell, Error> {
-        let advice = self.assign_advice(annotation, column, offset, &mut || Ok(constant))?;
+        let advice =
+            self.assign_advice(annotation, column, offset, &mut || Value::known(constant))?;
         self.constrain_constant(advice, constant)?;
 
         Ok(advice)
@@ -432,12 +433,10 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
         row: usize,
         advice: Column<Advice>,
         offset: usize,
-    ) -> Result<(Cell, Option<F>), Error> {
+    ) -> Result<(Cell, Value<F>), Error> {
         let value = self.plan.cs.query_instance(instance, row)?;
 
-        let cell = self.assign_advice(annotation, advice, offset, &mut || {
-            value.ok_or(Error::Synthesis).map(|v| v.into())
-        })?;
+        let cell = self.assign_advice(annotation, advice, offset, &mut || value.to_field())?;
 
         self.plan.cs.copy(
             cell.column,
@@ -454,7 +453,7 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
         annotation: &'v (dyn Fn() -> String + 'v),
         column: Column<Fixed>,
         offset: usize,
-        to: &'v mut (dyn FnMut() -> Result<Assigned<F>, Error> + 'v),
+        to: &'v mut (dyn FnMut() -> Value<Assigned<F>> + 'v),
     ) -> Result<Cell, Error> {
         self.plan.cs.assign_fixed(
             annotation,

--- a/halo2_proofs/src/circuit/value.rs
+++ b/halo2_proofs/src/circuit/value.rs
@@ -25,7 +25,7 @@ impl<V> Default for Value<V> {
 
 impl<V> Value<V> {
     /// Constructs an unwitnessed value.
-    pub fn unknown() -> Self {
+    pub const fn unknown() -> Self {
         Self { inner: None }
     }
 
@@ -38,7 +38,7 @@ impl<V> Value<V> {
     ///
     /// let v = Value::known(37);
     /// ```
-    pub fn known(value: V) -> Self {
+    pub const fn known(value: V) -> Self {
         Self { inner: Some(value) }
     }
 

--- a/halo2_proofs/src/circuit/value.rs
+++ b/halo2_proofs/src/circuit/value.rs
@@ -263,6 +263,23 @@ where
     }
 }
 
+impl<V, O> Add for &Value<V>
+where
+    for<'v> &'v V: Add<Output = O>,
+{
+    type Output = Value<O>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Value {
+            inner: self
+                .inner
+                .as_ref()
+                .zip(rhs.inner.as_ref())
+                .map(|(a, b)| a + b),
+        }
+    }
+}
+
 impl<V, O> Add<Value<&V>> for Value<V>
 where
     for<'v> V: Add<&'v V, Output = O>,
@@ -328,6 +345,23 @@ where
     }
 }
 
+impl<V, O> Sub for &Value<V>
+where
+    for<'v> &'v V: Sub<Output = O>,
+{
+    type Output = Value<O>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Value {
+            inner: self
+                .inner
+                .as_ref()
+                .zip(rhs.inner.as_ref())
+                .map(|(a, b)| a - b),
+        }
+    }
+}
+
 impl<V, O> Sub<Value<&V>> for Value<V>
 where
     for<'v> V: Sub<&'v V, Output = O>,
@@ -389,6 +423,23 @@ where
     fn mul(self, rhs: Self) -> Self::Output {
         Value {
             inner: self.inner.zip(rhs.inner).map(|(a, b)| a * b),
+        }
+    }
+}
+
+impl<V, O> Mul for &Value<V>
+where
+    for<'v> &'v V: Mul<Output = O>,
+{
+    type Output = Value<O>;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Value {
+            inner: self
+                .inner
+                .as_ref()
+                .zip(rhs.inner.as_ref())
+                .map(|(a, b)| a * b),
         }
     }
 }

--- a/halo2_proofs/src/circuit/value.rs
+++ b/halo2_proofs/src/circuit/value.rs
@@ -1,0 +1,647 @@
+use std::borrow::Borrow;
+use std::ops::{Add, Mul, Neg, Sub};
+
+use group::ff::Field;
+
+use crate::plonk::{Assigned, Error};
+
+/// A value that might exist within a circuit.
+///
+/// This behaves like `Option<V>` but differs in two key ways:
+/// - It does not expose the enum cases, or provide an `Option::unwrap` equivalent. This
+///   helps to ensure that unwitnessed values correctly propagate.
+/// - It provides pass-through implementations of common traits such as `Add` and `Mul`,
+///   for improved usability.
+#[derive(Clone, Copy, Debug)]
+pub struct Value<V> {
+    inner: Option<V>,
+}
+
+impl<V> Default for Value<V> {
+    fn default() -> Self {
+        Self::unknown()
+    }
+}
+
+impl<V> Value<V> {
+    /// Constructs an unwitnessed value.
+    pub fn unknown() -> Self {
+        Self { inner: None }
+    }
+
+    /// Constructs a known value.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use halo2_proofs::circuit::Value;
+    ///
+    /// let v = Value::known(37);
+    /// ```
+    pub fn known(value: V) -> Self {
+        Self { inner: Some(value) }
+    }
+
+    /// Obtains the inner value for assigning into the circuit.
+    ///
+    /// Returns `Error::Synthesis` if this is [`Value::unknown()`].
+    pub(crate) fn assign(self) -> Result<V, Error> {
+        self.inner.ok_or(Error::Synthesis)
+    }
+
+    /// Converts from `&Value<V>` to `Value<&V>`.
+    pub fn as_ref(&self) -> Value<&V> {
+        Value {
+            inner: self.inner.as_ref(),
+        }
+    }
+
+    /// Converts from `&mut Value<V>` to `Value<&mut V>`.
+    pub fn as_mut(&mut self) -> Value<&mut V> {
+        Value {
+            inner: self.inner.as_mut(),
+        }
+    }
+
+    /// Enforces an assertion on the contained value, if known.
+    ///
+    /// The assertion is ignored if `self` is [`Value::unknown()`]. Do not try to enforce
+    /// circuit constraints with this method!
+    ///
+    /// # Panics
+    ///
+    /// Panics if `f` returns `false`.
+    pub fn assert_if_known<F: FnOnce(&V) -> bool>(&self, f: F) {
+        if let Some(value) = self.inner.as_ref() {
+            assert!(f(value));
+        }
+    }
+
+    /// Checks the contained value for an error condition, if known.
+    ///
+    /// The error check is ignored if `self` is [`Value::unknown()`]. Do not try to
+    /// enforce circuit constraints with this method!
+    pub fn error_if_known_and<F: FnOnce(&V) -> bool>(&self, f: F) -> Result<(), Error> {
+        match self.inner.as_ref() {
+            Some(value) if f(value) => Err(Error::Synthesis),
+            _ => Ok(()),
+        }
+    }
+
+    /// Maps a `Value<V>` to `Value<W>` by applying a function to the contained value.
+    pub fn map<W, F: FnOnce(V) -> W>(self, f: F) -> Value<W> {
+        Value {
+            inner: self.inner.map(f),
+        }
+    }
+
+    /// Returns [`Value::unknown()`] if the value is [`Value::unknown()`], otherwise calls
+    /// `f` with the wrapped value and returns the result.
+    pub fn and_then<W, F: FnOnce(V) -> Value<W>>(self, f: F) -> Value<W> {
+        match self.inner {
+            Some(v) => f(v),
+            None => Value::unknown(),
+        }
+    }
+
+    /// Zips `self` with another `Value`.
+    ///
+    /// If `self` is `Value::known(s)` and `other` is `Value::known(o)`, this method
+    /// returns `Value::known((s, o))`. Otherwise, [`Value::unknown()`] is returned.
+    pub fn zip<W>(self, other: Value<W>) -> Value<(V, W)> {
+        Value {
+            inner: self.inner.zip(other.inner),
+        }
+    }
+}
+
+impl<V, W> Value<(V, W)> {
+    /// Unzips a value containing a tuple of two values.
+    ///
+    /// If `self` is `Value::known((a, b)), this method returns
+    /// `(Value::known(s), Value::known(o))`. Otherwise,
+    /// `(Value::unknown(), Value::unknown())` is returned.
+    pub fn unzip(self) -> (Value<V>, Value<W>) {
+        match self.inner {
+            Some((a, b)) => (Value::known(a), Value::known(b)),
+            None => (Value::unknown(), Value::unknown()),
+        }
+    }
+}
+
+impl<V> Value<&V> {
+    /// Maps a `Value<&V>` to a `Value<V>` by copying the contents of the value.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    pub fn copied(self) -> Value<V>
+    where
+        V: Copy,
+    {
+        Value {
+            inner: self.inner.copied(),
+        }
+    }
+
+    /// Maps a `Value<&V>` to a `Value<V>` by cloning the contents of the value.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    pub fn cloned(self) -> Value<V>
+    where
+        V: Clone,
+    {
+        Value {
+            inner: self.inner.cloned(),
+        }
+    }
+}
+
+impl<V> Value<&mut V> {
+    /// Maps a `Value<&mut V>` to a `Value<V>` by copying the contents of the value.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    pub fn copied(self) -> Value<V>
+    where
+        V: Copy,
+    {
+        Value {
+            inner: self.inner.copied(),
+        }
+    }
+
+    /// Maps a `Value<&mut V>` to a `Value<V>` by cloning the contents of the value.
+    #[must_use = "`self` will be dropped if the result is not used"]
+    pub fn cloned(self) -> Value<V>
+    where
+        V: Clone,
+    {
+        Value {
+            inner: self.inner.cloned(),
+        }
+    }
+}
+
+impl<V: Copy, const LEN: usize> Value<[V; LEN]> {
+    /// Transposes a `Value<[V; LEN]>` into a `[Value<V>; LEN]`.
+    ///
+    /// [`Value::unknown()`] will be mapped to `[Value::unknown(); LEN]`.
+    pub fn transpose_array(self) -> [Value<V>; LEN] {
+        let mut ret = [Value::unknown(); LEN];
+        if let Some(arr) = self.inner {
+            for (entry, value) in ret.iter_mut().zip(arr) {
+                *entry = Value::known(value);
+            }
+        }
+        ret
+    }
+}
+
+impl<V, I> Value<I>
+where
+    I: IntoIterator<Item = V>,
+    I::IntoIter: ExactSizeIterator,
+{
+    /// Transposes a `Value<impl IntoIterator<Item = V>>` into a `Vec<Value<V>>`.
+    ///
+    /// [`Value::unknown()`] will be mapped to `vec![Value::unknown(); length]`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `self` is `Value::known(values)` and `values.len() != length`.
+    pub fn transpose_vec(self, length: usize) -> Vec<Value<V>> {
+        match self.inner {
+            Some(values) => {
+                let values = values.into_iter();
+                assert_eq!(values.len(), length);
+                values.map(Value::known).collect()
+            }
+            None => (0..length).map(|_| Value::unknown()).collect(),
+        }
+    }
+}
+
+//
+// FromIterator
+//
+
+impl<A, V: FromIterator<A>> FromIterator<Value<A>> for Value<V> {
+    /// Takes each element in the [`Iterator`]: if it is [`Value::unknown()`], no further
+    /// elements are taken, and the [`Value::unknown()`] is returned. Should no
+    /// [`Value::unknown()`] occur, a container of type `V` containing the values of each
+    /// [`Value`] is returned.
+    fn from_iter<I: IntoIterator<Item = Value<A>>>(iter: I) -> Self {
+        Self {
+            inner: iter.into_iter().map(|v| v.inner).collect(),
+        }
+    }
+}
+
+//
+// Neg
+//
+
+impl<V: Neg> Neg for Value<V> {
+    type Output = Value<V::Output>;
+
+    fn neg(self) -> Self::Output {
+        Value {
+            inner: self.inner.map(|v| -v),
+        }
+    }
+}
+
+//
+// Add
+//
+
+impl<V, O> Add for Value<V>
+where
+    V: Add<Output = O>,
+{
+    type Output = Value<O>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a + b),
+        }
+    }
+}
+
+impl<V, O> Add<Value<&V>> for Value<V>
+where
+    for<'v> V: Add<&'v V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn add(self, rhs: Value<&V>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a + b),
+        }
+    }
+}
+
+impl<V, O> Add<Value<V>> for Value<&V>
+where
+    for<'v> &'v V: Add<V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn add(self, rhs: Value<V>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a + b),
+        }
+    }
+}
+
+impl<V, O> Add<&Value<V>> for Value<V>
+where
+    for<'v> V: Add<&'v V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn add(self, rhs: &Self) -> Self::Output {
+        self + rhs.as_ref()
+    }
+}
+
+impl<V, O> Add<Value<V>> for &Value<V>
+where
+    for<'v> &'v V: Add<V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn add(self, rhs: Value<V>) -> Self::Output {
+        self.as_ref() + rhs
+    }
+}
+
+//
+// Sub
+//
+
+impl<V, O> Sub for Value<V>
+where
+    V: Sub<Output = O>,
+{
+    type Output = Value<O>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a - b),
+        }
+    }
+}
+
+impl<V, O> Sub<Value<&V>> for Value<V>
+where
+    for<'v> V: Sub<&'v V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn sub(self, rhs: Value<&V>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a - b),
+        }
+    }
+}
+
+impl<V, O> Sub<Value<V>> for Value<&V>
+where
+    for<'v> &'v V: Sub<V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn sub(self, rhs: Value<V>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a - b),
+        }
+    }
+}
+
+impl<V, O> Sub<&Value<V>> for Value<V>
+where
+    for<'v> V: Sub<&'v V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn sub(self, rhs: &Self) -> Self::Output {
+        self - rhs.as_ref()
+    }
+}
+
+impl<V, O> Sub<Value<V>> for &Value<V>
+where
+    for<'v> &'v V: Sub<V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn sub(self, rhs: Value<V>) -> Self::Output {
+        self.as_ref() - rhs
+    }
+}
+
+//
+// Mul
+//
+
+impl<V, O> Mul for Value<V>
+where
+    V: Mul<Output = O>,
+{
+    type Output = Value<O>;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a * b),
+        }
+    }
+}
+
+impl<V, O> Mul<Value<&V>> for Value<V>
+where
+    for<'v> V: Mul<&'v V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn mul(self, rhs: Value<&V>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a * b),
+        }
+    }
+}
+
+impl<V, O> Mul<Value<V>> for Value<&V>
+where
+    for<'v> &'v V: Mul<V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn mul(self, rhs: Value<V>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a * b),
+        }
+    }
+}
+
+impl<V, O> Mul<&Value<V>> for Value<V>
+where
+    for<'v> V: Mul<&'v V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn mul(self, rhs: &Self) -> Self::Output {
+        self * rhs.as_ref()
+    }
+}
+
+impl<V, O> Mul<Value<V>> for &Value<V>
+where
+    for<'v> &'v V: Mul<V, Output = O>,
+{
+    type Output = Value<O>;
+
+    fn mul(self, rhs: Value<V>) -> Self::Output {
+        self.as_ref() * rhs
+    }
+}
+
+//
+// Assigned<Field>
+//
+
+impl<F: Field> From<Value<F>> for Value<Assigned<F>> {
+    fn from(value: Value<F>) -> Self {
+        Self {
+            inner: value.inner.map(Assigned::from),
+        }
+    }
+}
+
+impl<F: Field> Add<Value<F>> for Value<Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn add(self, rhs: Value<F>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a + b),
+        }
+    }
+}
+
+impl<F: Field> Add<F> for Value<Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn add(self, rhs: F) -> Self::Output {
+        self + Value::known(rhs)
+    }
+}
+
+impl<F: Field> Add<Value<F>> for Value<&Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn add(self, rhs: Value<F>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a + b),
+        }
+    }
+}
+
+impl<F: Field> Add<F> for Value<&Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn add(self, rhs: F) -> Self::Output {
+        self + Value::known(rhs)
+    }
+}
+
+impl<F: Field> Sub<Value<F>> for Value<Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn sub(self, rhs: Value<F>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a - b),
+        }
+    }
+}
+
+impl<F: Field> Sub<F> for Value<Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn sub(self, rhs: F) -> Self::Output {
+        self - Value::known(rhs)
+    }
+}
+
+impl<F: Field> Sub<Value<F>> for Value<&Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn sub(self, rhs: Value<F>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a - b),
+        }
+    }
+}
+
+impl<F: Field> Sub<F> for Value<&Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn sub(self, rhs: F) -> Self::Output {
+        self - Value::known(rhs)
+    }
+}
+
+impl<F: Field> Mul<Value<F>> for Value<Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn mul(self, rhs: Value<F>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a * b),
+        }
+    }
+}
+
+impl<F: Field> Mul<F> for Value<Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn mul(self, rhs: F) -> Self::Output {
+        self * Value::known(rhs)
+    }
+}
+
+impl<F: Field> Mul<Value<F>> for Value<&Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn mul(self, rhs: Value<F>) -> Self::Output {
+        Value {
+            inner: self.inner.zip(rhs.inner).map(|(a, b)| a * b),
+        }
+    }
+}
+
+impl<F: Field> Mul<F> for Value<&Assigned<F>> {
+    type Output = Value<Assigned<F>>;
+
+    fn mul(self, rhs: F) -> Self::Output {
+        self * Value::known(rhs)
+    }
+}
+
+impl<V> Value<V> {
+    /// Returns the field element corresponding to this value.
+    pub fn to_field<F: Field>(&self) -> Value<Assigned<F>>
+    where
+        for<'v> Assigned<F>: From<&'v V>,
+    {
+        Value {
+            inner: self.inner.as_ref().map(|v| v.into()),
+        }
+    }
+
+    /// Returns the field element corresponding to this value.
+    pub fn into_field<F: Field>(self) -> Value<Assigned<F>>
+    where
+        V: Into<Assigned<F>>,
+    {
+        Value {
+            inner: self.inner.map(|v| v.into()),
+        }
+    }
+
+    /// Doubles this field element.
+    ///
+    /// # Examples
+    ///
+    /// If you have a `Value<F: Field>`, convert it to `Value<Assigned<F>>` first:
+    /// ```
+    /// # use pasta_curves::pallas::Base as F;
+    /// use halo2_proofs::{circuit::Value, plonk::Assigned};
+    ///
+    /// let v = Value::known(F::from(2));
+    /// let v: Value<Assigned<F>> = v.into();
+    /// v.double();
+    /// ```
+    pub fn double<F: Field>(&self) -> Value<Assigned<F>>
+    where
+        V: Borrow<Assigned<F>>,
+    {
+        Value {
+            inner: self.inner.as_ref().map(|v| v.borrow().double()),
+        }
+    }
+
+    /// Squares this field element.
+    pub fn square<F: Field>(&self) -> Value<Assigned<F>>
+    where
+        V: Borrow<Assigned<F>>,
+    {
+        Value {
+            inner: self.inner.as_ref().map(|v| v.borrow().square()),
+        }
+    }
+
+    /// Cubes this field element.
+    pub fn cube<F: Field>(&self) -> Value<Assigned<F>>
+    where
+        V: Borrow<Assigned<F>>,
+    {
+        Value {
+            inner: self.inner.as_ref().map(|v| v.borrow().cube()),
+        }
+    }
+
+    /// Inverts this assigned value (taking the inverse of zero to be zero).
+    pub fn invert<F: Field>(&self) -> Value<Assigned<F>>
+    where
+        V: Borrow<Assigned<F>>,
+    {
+        Value {
+            inner: self.inner.as_ref().map(|v| v.borrow().invert()),
+        }
+    }
+}
+
+impl<F: Field> Value<Assigned<F>> {
+    /// Evaluates this value directly, performing an unbatched inversion if necessary.
+    ///
+    /// If the denominator is zero, the returned value is zero.
+    pub fn evaluate(self) -> Value<F> {
+        Value {
+            inner: self.inner.map(|v| v.evaluate()),
+        }
+    }
+}

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -11,6 +11,7 @@ use ff::{Field, PrimeField};
 use group::prime::PrimeGroup;
 
 use crate::{
+    circuit::Value,
     plonk::{
         Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
         FloorPlanner, Instance, Selector,
@@ -68,8 +69,8 @@ impl<F: Field> Assignment<F> for Assembly {
         Ok(())
     }
 
-    fn query_instance(&self, _: Column<Instance>, _: usize) -> Result<Option<F>, Error> {
-        Ok(None)
+    fn query_instance(&self, _: Column<Instance>, _: usize) -> Result<Value<F>, Error> {
+        Ok(Value::unknown())
     }
 
     fn assign_advice<V, VR, A, AR>(
@@ -80,7 +81,7 @@ impl<F: Field> Assignment<F> for Assembly {
         _: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<VR, Error>,
+        V: FnOnce() -> Value<VR>,
         VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
@@ -96,7 +97,7 @@ impl<F: Field> Assignment<F> for Assembly {
         _: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<VR, Error>,
+        V: FnOnce() -> Value<VR>,
         VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
@@ -112,7 +113,7 @@ impl<F: Field> Assignment<F> for Assembly {
         &mut self,
         _: Column<Fixed>,
         _: usize,
-        _: Option<Assigned<F>>,
+        _: Value<Assigned<F>>,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -1,9 +1,12 @@
 use ff::Field;
 use tabbycat::{AttrList, Edge, GraphBuilder, GraphType, Identity, StmtList};
 
-use crate::plonk::{
-    Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
-    FloorPlanner, Instance, Selector,
+use crate::{
+    circuit::Value,
+    plonk::{
+        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
+        FloorPlanner, Instance, Selector,
+    },
 };
 
 pub mod layout;
@@ -96,8 +99,8 @@ impl<F: Field> Assignment<F> for Graph {
         Ok(())
     }
 
-    fn query_instance(&self, _: Column<Instance>, _: usize) -> Result<Option<F>, Error> {
-        Ok(None)
+    fn query_instance(&self, _: Column<Instance>, _: usize) -> Result<Value<F>, Error> {
+        Ok(Value::unknown())
     }
 
     fn assign_advice<V, VR, A, AR>(
@@ -108,7 +111,7 @@ impl<F: Field> Assignment<F> for Graph {
         _: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<VR, Error>,
+        V: FnOnce() -> Value<VR>,
         VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
@@ -125,7 +128,7 @@ impl<F: Field> Assignment<F> for Graph {
         _: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<VR, Error>,
+        V: FnOnce() -> Value<VR>,
         VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
@@ -149,7 +152,7 @@ impl<F: Field> Assignment<F> for Graph {
         &mut self,
         _: Column<Fixed>,
         _: usize,
-        _: Option<Assigned<F>>,
+        _: Value<Assigned<F>>,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -7,10 +7,12 @@ use std::cmp;
 use std::collections::HashSet;
 use std::ops::Range;
 
-use crate::circuit::layouter::RegionColumn;
-use crate::plonk::{
-    Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
-    FloorPlanner, Instance, Selector,
+use crate::{
+    circuit::{layouter::RegionColumn, Value},
+    plonk::{
+        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
+        FloorPlanner, Instance, Selector,
+    },
 };
 
 /// Graphical renderer for circuit layouts.
@@ -430,8 +432,8 @@ impl<F: Field> Assignment<F> for Layout {
         Ok(())
     }
 
-    fn query_instance(&self, _: Column<Instance>, _: usize) -> Result<Option<F>, Error> {
-        Ok(None)
+    fn query_instance(&self, _: Column<Instance>, _: usize) -> Result<Value<F>, Error> {
+        Ok(Value::unknown())
     }
 
     fn assign_advice<V, VR, A, AR>(
@@ -442,7 +444,7 @@ impl<F: Field> Assignment<F> for Layout {
         _: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<VR, Error>,
+        V: FnOnce() -> Value<VR>,
         VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
@@ -459,7 +461,7 @@ impl<F: Field> Assignment<F> for Layout {
         _: V,
     ) -> Result<(), Error>
     where
-        V: FnOnce() -> Result<VR, Error>,
+        V: FnOnce() -> Value<VR>,
         VR: Into<Assigned<F>>,
         A: FnOnce() -> AR,
         AR: Into<String>,
@@ -483,7 +485,7 @@ impl<F: Field> Assignment<F> for Layout {
         &mut self,
         _: Column<Fixed>,
         _: usize,
-        _: Option<Assigned<F>>,
+        _: Value<Assigned<F>>,
     ) -> Result<(), Error> {
         Ok(())
     }

--- a/halo2_proofs/src/plonk/assigned.rs
+++ b/halo2_proofs/src/plonk/assigned.rs
@@ -250,6 +250,13 @@ impl<F: Field> Mul<F> for Assigned<F> {
     }
 }
 
+impl<F: Field> Mul<F> for &Assigned<F> {
+    type Output = Assigned<F>;
+    fn mul(self, rhs: F) -> Assigned<F> {
+        *self * rhs
+    }
+}
+
 impl<F: Field> Mul<&Assigned<F>> for Assigned<F> {
     type Output = Assigned<F>;
     fn mul(self, rhs: &Assigned<F>) -> Assigned<F> {


### PR DESCRIPTION
This replaces every usage of `Option<V>` for representing witnessed values that may not have a known value (e.g. advice cells during keygen).

This is a very big breaking change to the public API, but does not alter circuit compatibility.

Closes #509.