### PR TITLE
Move `Params` from field to function

### DIFF
--- a/halo2_gadgets/benches/poseidon.rs
+++ b/halo2_gadgets/benches/poseidon.rs
@@ -230,7 +230,7 @@ fn bench_poseidon<S, const WIDTH: usize, const RATE: usize, const L: usize>(
 
     c.bench_function(&verifier_name, |b| {
         b.iter(|| {
-            let strategy = SingleVerifier::new(&params);
+            let strategy = SingleVerifier::new(params.n());
             let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
             assert!(verify_proof(&params, pk.get_vk(), strategy, &[&[]], &mut transcript).is_ok());
         });

--- a/halo2_gadgets/benches/sha256.rs
+++ b/halo2_gadgets/benches/sha256.rs
@@ -134,7 +134,7 @@ fn bench(name: &str, k: u32, c: &mut Criterion) {
 
     c.bench_function(&verifier_name, |b| {
         b.iter(|| {
-            let strategy = SingleVerifier::new(&params);
+            let strategy = SingleVerifier::new(params.n());
             let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
             assert!(verify_proof(&params, pk.get_vk(), strategy, &[], &mut transcript).is_ok());
         });

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -279,7 +279,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     }
 
     fn verifier(params: &Params<EqAffine>, vk: &VerifyingKey<EqAffine>, proof: &[u8]) {
-        let strategy = SingleVerifier::new(params);
+        let strategy = SingleVerifier::new(params.n());
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(proof);
         assert!(verify_proof(params, vk, strategy, &[&[]], &mut transcript).is_ok());
     }

--- a/halo2_proofs/src/plonk/lookup/verifier.rs
+++ b/halo2_proofs/src/plonk/lookup/verifier.rs
@@ -165,11 +165,11 @@ impl<C: CurveAffine> Evaluated<C> {
             ))
     }
 
-    pub(in crate::plonk) fn queries<'r, 'params: 'r>(
+    pub(in crate::plonk) fn queries<'r>(
         &'r self,
         vk: &'r VerifyingKey<C>,
         x: ChallengeX<C>,
-    ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone {
+    ) -> impl Iterator<Item = VerifierQuery<'r, C>> + Clone {
         let x_inv = vk.domain.rotate_omega(*x, Rotation::prev());
         let x_next = vk.domain.rotate_omega(*x, Rotation::next());
 

--- a/halo2_proofs/src/plonk/permutation/verifier.rs
+++ b/halo2_proofs/src/plonk/permutation/verifier.rs
@@ -199,11 +199,11 @@ impl<C: CurveAffine> Evaluated<C> {
             )
     }
 
-    pub(in crate::plonk) fn queries<'r, 'params: 'r>(
+    pub(in crate::plonk) fn queries<'r>(
         &'r self,
         vk: &'r plonk::VerifyingKey<C>,
         x: ChallengeX<C>,
-    ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone {
+    ) -> impl Iterator<Item = VerifierQuery<'r, C>> + Clone {
         let blinding_factors = vk.cs.blinding_factors();
         let x_next = vk.domain.rotate_omega(*x, Rotation::next());
         let x_last = vk
@@ -238,11 +238,11 @@ impl<C: CurveAffine> Evaluated<C> {
 }
 
 impl<C: CurveAffine> CommonEvaluated<C> {
-    pub(in crate::plonk) fn queries<'r, 'params: 'r>(
+    pub(in crate::plonk) fn queries<'r>(
         &'r self,
         vkey: &'r VerifyingKey<C>,
         x: ChallengeX<C>,
-    ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone {
+    ) -> impl Iterator<Item = VerifierQuery<'r, C>> + Clone {
         // Open permutation commitments for each permutation argument at x
         vkey.commitments
             .iter()

--- a/halo2_proofs/src/plonk/vanishing/verifier.rs
+++ b/halo2_proofs/src/plonk/vanishing/verifier.rs
@@ -30,8 +30,8 @@ pub struct PartiallyEvaluated<C: CurveAffine> {
     random_eval: C::Scalar,
 }
 
-pub struct Evaluated<'params, C: CurveAffine> {
-    h_commitment: MSM<'params, C>,
+pub struct Evaluated<C: CurveAffine> {
+    h_commitment: MSM<C>,
     random_poly_commitment: C,
     expected_h_eval: C::Scalar,
     random_eval: C::Scalar,
@@ -116,14 +116,11 @@ impl<C: CurveAffine> PartiallyEvaluated<C> {
     }
 }
 
-impl<'params, C: CurveAffine> Evaluated<'params, C> {
+impl<C: CurveAffine> Evaluated<C> {
     pub(in crate::plonk) fn queries<'r>(
         &'r self,
         x: ChallengeX<C>,
-    ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone
-    where
-        'params: 'r,
-    {
+    ) -> impl Iterator<Item = VerifierQuery<'r, C>> + Clone {
         iter::empty()
             .chain(Some(VerifierQuery::new_msm(
                 &self.h_commitment,

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -20,7 +20,7 @@ mod batch;
 pub use batch::BatchVerifier;
 
 /// Trait representing a strategy for verifying Halo 2 proofs.
-pub trait VerificationStrategy<'params, C: CurveAffine> {
+pub trait VerificationStrategy<C: CurveAffine> {
     /// The output type of this verification strategy after processing a proof.
     type Output;
 
@@ -28,35 +28,35 @@ pub trait VerificationStrategy<'params, C: CurveAffine> {
     /// output.
     fn process<E: EncodedChallenge<C>>(
         self,
-        f: impl FnOnce(MSM<'params, C>) -> Result<Guard<'params, C, E>, Error>,
+        params: &Params<C>,
+        f: impl FnOnce(MSM<C>) -> Result<Guard<C, E>, Error>,
     ) -> Result<Self::Output, Error>;
 }
 
 /// A verifier that checks a single proof at a time.
 #[derive(Debug)]
-pub struct SingleVerifier<'params, C: CurveAffine> {
-    msm: MSM<'params, C>,
+pub struct SingleVerifier<C: CurveAffine> {
+    msm: MSM<C>,
 }
 
-impl<'params, C: CurveAffine> SingleVerifier<'params, C> {
+impl<C: CurveAffine> SingleVerifier<C> {
     /// Constructs a new single proof verifier.
-    pub fn new(params: &'params Params<C>) -> Self {
-        SingleVerifier {
-            msm: MSM::new(params),
-        }
+    pub fn new(n: u64) -> Self {
+        SingleVerifier { msm: MSM::new(n) }
     }
 }
 
-impl<'params, C: CurveAffine> VerificationStrategy<'params, C> for SingleVerifier<'params, C> {
+impl<C: CurveAffine> VerificationStrategy<C> for SingleVerifier<C> {
     type Output = ();
 
     fn process<E: EncodedChallenge<C>>(
         self,
-        f: impl FnOnce(MSM<'params, C>) -> Result<Guard<'params, C, E>, Error>,
+        params: &Params<C>,
+        f: impl FnOnce(MSM<C>) -> Result<Guard<C, E>, Error>,
     ) -> Result<Self::Output, Error> {
         let guard = f(self.msm)?;
         let msm = guard.use_challenges();
-        if msm.eval() {
+        if msm.eval(params) {
             Ok(())
         } else {
             Err(Error::ConstraintSystemFailure)
@@ -70,7 +70,7 @@ pub fn verify_proof<
     C: CurveAffine,
     E: EncodedChallenge<C>,
     T: TranscriptRead<C, E>,
-    V: VerificationStrategy<'params, C>,
+    V: VerificationStrategy<C>,
 >(
     params: &'params Params<C>,
     vk: &VerifyingKey<C>,
@@ -342,7 +342,7 @@ pub fn verify_proof<
 
     // We are now convinced the circuit is satisfied so long as the
     // polynomial commitments open to the correct values.
-    strategy.process(|msm| {
+    strategy.process(params,|msm| {
         multiopen::verify_proof(params, transcript, queries, msm).map_err(|_| Error::Opening)
     })
 }

--- a/halo2_proofs/src/plonk/verifier/batch.rs
+++ b/halo2_proofs/src/plonk/verifier/batch.rs
@@ -17,24 +17,23 @@ use crate::{
 ///
 /// `BatchVerifier` handles the accumulation of the MSMs for the batched proofs.
 #[derive(Debug)]
-struct BatchStrategy<'params, C: CurveAffine> {
-    msm: MSM<'params, C>,
+struct BatchStrategy<C: CurveAffine> {
+    msm: MSM<C>,
 }
 
-impl<'params, C: CurveAffine> BatchStrategy<'params, C> {
-    fn new(params: &'params Params<C>) -> Self {
-        BatchStrategy {
-            msm: MSM::new(params),
-        }
+impl<C: CurveAffine> BatchStrategy<C> {
+    fn new(n: u64) -> Self {
+        BatchStrategy { msm: MSM::new(n) }
     }
 }
 
-impl<'params, C: CurveAffine> VerificationStrategy<'params, C> for BatchStrategy<'params, C> {
-    type Output = MSM<'params, C>;
+impl<C: CurveAffine> VerificationStrategy<C> for BatchStrategy<C> {
+    type Output = MSM<C>;
 
     fn process<E: EncodedChallenge<C>>(
         self,
-        f: impl FnOnce(MSM<'params, C>) -> Result<Guard<'params, C, E>, Error>,
+        _: &Params<C>,
+        f: impl FnOnce(MSM<C>) -> Result<Guard<C, E>, Error>,
     ) -> Result<Self::Output, Error> {
         let guard = f(self.msm)?;
         Ok(guard.use_challenges())
@@ -74,10 +73,7 @@ impl<C: CurveAffine> BatchVerifier<C> {
     /// the internal parallelization requires access to a RNG that is guaranteed to not
     /// clone its internal state when shared between threads.
     pub fn finalize(self, params: &Params<C>, vk: &VerifyingKey<C>) -> bool {
-        fn accumulate_msm<'params, C: CurveAffine>(
-            mut acc: MSM<'params, C>,
-            msm: MSM<'params, C>,
-        ) -> MSM<'params, C> {
+        fn accumulate_msm<C: CurveAffine>(mut acc: MSM<C>, msm: MSM<C>) -> MSM<C> {
             // Scale the MSM by a random factor to ensure that if the existing MSM has
             // `is_zero() == false` then this argument won't be able to interfere with it
             // to make it true, with high probability.
@@ -99,7 +95,7 @@ impl<C: CurveAffine> BatchVerifier<C> {
                     .collect();
                 let instances: Vec<_> = instances.iter().map(|i| &i[..]).collect();
 
-                let strategy = BatchStrategy::new(params);
+                let strategy = BatchStrategy::new(params.n);
                 let mut transcript = Blake2bRead::init(&item.proof[..]);
                 verify_proof(params, vk, strategy, &instances, &mut transcript).map_err(|e| {
                     tracing::debug!("Batch item {} failed verification: {}", i, e);
@@ -113,7 +109,7 @@ impl<C: CurveAffine> BatchVerifier<C> {
             .try_reduce(|| params.empty_msm(), |a, b| Ok(accumulate_msm(a, b)));
 
         match final_msm {
-            Ok(msm) => msm.eval(),
+            Ok(msm) => msm.eval(params),
             Err(_) => false,
         }
     }

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -115,6 +115,11 @@ impl<C: CurveAffine> Params<C> {
         }
     }
 
+    /// Returns size of coefficients
+    pub fn n(&self) -> u64 {
+        self.n
+    }
+
     /// This computes a commitment to a polynomial described by the provided
     /// slice of coefficients. The commitment will be blinded by the blinding
     /// factor `r`.
@@ -154,7 +159,7 @@ impl<C: CurveAffine> Params<C> {
     /// Generates an empty multiscalar multiplication struct using the
     /// appropriate params.
     pub fn empty_msm(&self) -> MSM<C> {
-        MSM::new(self)
+        MSM::new(self.n)
     }
 
     /// Getter for g generators
@@ -366,11 +371,11 @@ fn test_opening_proof() {
     {
         // Test use_challenges()
         let msm_challenges = guard.clone().use_challenges();
-        assert!(msm_challenges.eval());
+        assert!(msm_challenges.eval(&params));
 
         // Test use_g()
-        let g = guard.compute_g();
-        let (msm_g, _accumulator) = guard.clone().use_g(g);
-        assert!(msm_g.eval());
+        let g = guard.compute_g(&params);
+        let (msm_g, _accumulator) = guard.use_g(g);
+        assert!(msm_g.eval(&params));
     }
 }

--- a/halo2_proofs/src/poly/commitment/msm.rs
+++ b/halo2_proofs/src/poly/commitment/msm.rs
@@ -7,8 +7,9 @@ use std::collections::BTreeMap;
 
 /// A multiscalar multiplication in the polynomial commitment scheme
 #[derive(Debug, Clone)]
-pub struct MSM<'a, C: CurveAffine> {
-    pub(crate) params: &'a Params<C>,
+pub struct MSM<C: CurveAffine> {
+    n: u64,
+
     g_scalars: Option<Vec<C::Scalar>>,
     w_scalar: Option<C::Scalar>,
     u_scalar: Option<C::Scalar>,
@@ -16,16 +17,17 @@ pub struct MSM<'a, C: CurveAffine> {
     other: BTreeMap<C::Base, (C::Scalar, C::Base)>,
 }
 
-impl<'a, C: CurveAffine> MSM<'a, C> {
+impl<C: CurveAffine> MSM<C> {
     /// Create a new, empty MSM using the provided parameters.
-    pub fn new(params: &'a Params<C>) -> Self {
+    pub fn new(n: u64) -> Self {
         let g_scalars = None;
         let w_scalar = None;
         let u_scalar = None;
         let other = BTreeMap::new();
 
         MSM {
-            params,
+            n,
+
             g_scalars,
             w_scalar,
             u_scalar,
@@ -88,7 +90,7 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
         if let Some(g_scalars) = self.g_scalars.as_mut() {
             g_scalars[0] += &constant;
         } else {
-            let mut g_scalars = vec![C::Scalar::zero(); self.params.n as usize];
+            let mut g_scalars = vec![C::Scalar::zero(); self.n as usize];
             g_scalars[0] += &constant;
             self.g_scalars = Some(g_scalars);
         }
@@ -97,7 +99,7 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
     /// Add a vector of scalars to `g_scalars`. This function will panic if the
     /// caller provides a slice of scalars that is not of length `params.n`.
     pub fn add_to_g_scalars(&mut self, scalars: &[C::Scalar]) {
-        assert_eq!(scalars.len(), self.params.n as usize);
+        assert_eq!(scalars.len(), self.n as usize);
         if let Some(g_scalars) = &mut self.g_scalars {
             for (g_scalar, scalar) in g_scalars.iter_mut().zip(scalars.iter()) {
                 *g_scalar += scalar;
@@ -134,7 +136,7 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
     }
 
     /// Perform multiexp and check that it results in zero
-    pub fn eval(self) -> bool {
+    pub fn eval(self, params: &Params<C>) -> bool {
         let len = self.g_scalars.as_ref().map(|v| v.len()).unwrap_or(0)
             + self.w_scalar.map(|_| 1).unwrap_or(0)
             + self.u_scalar.map(|_| 1).unwrap_or(0)
@@ -151,17 +153,17 @@ impl<'a, C: CurveAffine> MSM<'a, C> {
 
         if let Some(w_scalar) = self.w_scalar {
             scalars.push(w_scalar);
-            bases.push(self.params.w);
+            bases.push(params.w);
         }
 
         if let Some(u_scalar) = self.u_scalar {
             scalars.push(u_scalar);
-            bases.push(self.params.u);
+            bases.push(params.u);
         }
 
         if let Some(g_scalars) = &self.g_scalars {
             scalars.extend(g_scalars);
-            bases.extend(self.params.g.iter());
+            bases.extend(params.g.iter());
         }
 
         assert_eq!(scalars.len(), len);
@@ -182,39 +184,39 @@ mod tests {
         let base_viol = (base + base).to_affine();
 
         let params = Params::new(4);
-        let mut a: MSM<EpAffine> = MSM::new(&params);
+        let mut a: MSM<EpAffine> = MSM::new(params.n);
         a.append_term(Fq::one(), base);
         // a = [1] P
-        assert!(!a.clone().eval());
+        assert!(!a.clone().eval(&params));
         a.append_term(Fq::one(), base);
         // a = [1+1] P
-        assert!(!a.clone().eval());
+        assert!(!a.clone().eval(&params));
         a.append_term(-Fq::one(), base_viol);
         // a = [1+1] P + [-1] 2P
-        assert!(a.clone().eval());
+        assert!(a.clone().eval(&params));
         let b = a.clone();
 
         // Append a point that is the negation of an existing one.
         a.append_term(Fq::from(4), -base);
         // a = [1+1-4] P + [-1] 2P
-        assert!(!a.clone().eval());
+        assert!(!a.clone().eval(&params));
         a.append_term(Fq::from(2), base_viol);
         // a = [1+1-4] P + [-1+2] 2P
-        assert!(a.clone().eval());
+        assert!(a.clone().eval(&params));
 
         // Add two MSMs with common bases.
         a.scale(Fq::from(3));
         a.add_msm(&b);
         // a = [3*(1+1)+(1+1-4)] P + [3*(-1)+(-1+2)] 2P
-        assert!(a.clone().eval());
+        assert!(a.clone().eval(&params));
 
-        let mut c: MSM<EpAffine> = MSM::new(&params);
+        let mut c: MSM<EpAffine> = MSM::new(params.n);
         c.append_term(Fq::from(2), base);
         c.append_term(Fq::one(), -base_viol);
         // c = [2] P + [1] (-2P)
-        assert!(c.clone().eval());
+        assert!(c.clone().eval(&params));
         // Add two MSMs with bases that differ only in sign.
         a.add_msm(&c);
-        assert!(a.eval());
+        assert!(a.eval(&params));
     }
 }

--- a/halo2_proofs/src/poly/multiopen.rs
+++ b/halo2_proofs/src/poly/multiopen.rs
@@ -51,16 +51,16 @@ pub struct ProverQuery<'a, C: CurveAffine> {
 
 /// A polynomial query at a point
 #[derive(Debug, Clone)]
-pub struct VerifierQuery<'r, 'params: 'r, C: CurveAffine> {
+pub struct VerifierQuery<'r, C: CurveAffine> {
     /// point at which polynomial is queried
     point: C::Scalar,
     /// commitment to polynomial
-    commitment: CommitmentReference<'r, 'params, C>,
+    commitment: CommitmentReference<'r, C>,
     /// evaluation of polynomial at query point
     eval: C::Scalar,
 }
 
-impl<'r, 'params: 'r, C: CurveAffine> VerifierQuery<'r, 'params, C> {
+impl<'r, C: CurveAffine> VerifierQuery<'r, C> {
     /// Create a new verifier query based on a commitment
     pub fn new_commitment(commitment: &'r C, point: C::Scalar, eval: C::Scalar) -> Self {
         VerifierQuery {
@@ -71,11 +71,7 @@ impl<'r, 'params: 'r, C: CurveAffine> VerifierQuery<'r, 'params, C> {
     }
 
     /// Create a new verifier query based on a linear combination of commitments
-    pub fn new_msm(
-        msm: &'r commitment::MSM<'params, C>,
-        point: C::Scalar,
-        eval: C::Scalar,
-    ) -> Self {
+    pub fn new_msm(msm: &'r commitment::MSM<C>, point: C::Scalar, eval: C::Scalar) -> Self {
         VerifierQuery {
             point,
             eval,
@@ -85,12 +81,12 @@ impl<'r, 'params: 'r, C: CurveAffine> VerifierQuery<'r, 'params, C> {
 }
 
 #[derive(Copy, Clone, Debug)]
-enum CommitmentReference<'r, 'params: 'r, C: CurveAffine> {
+enum CommitmentReference<'r, C: CurveAffine> {
     Commitment(&'r C),
-    MSM(&'r commitment::MSM<'params, C>),
+    MSM(&'r commitment::MSM<C>),
 }
 
-impl<'r, 'params: 'r, C: CurveAffine> PartialEq for CommitmentReference<'r, 'params, C> {
+impl<'r, C: CurveAffine> PartialEq for CommitmentReference<'r, C> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (&CommitmentReference::Commitment(a), &CommitmentReference::Commitment(b)) => {
@@ -333,7 +329,7 @@ fn test_roundtrip() {
         .unwrap();
 
         // Should fail.
-        assert!(!guard.use_challenges().eval());
+        assert!(!guard.use_challenges().eval(&params));
     }
 
     {
@@ -355,7 +351,7 @@ fn test_roundtrip() {
         .unwrap();
 
         // Should succeed.
-        assert!(guard.use_challenges().eval());
+        assert!(guard.use_challenges().eval(&params));
     }
 }
 

--- a/halo2_proofs/src/poly/multiopen/verifier.rs
+++ b/halo2_proofs/src/poly/multiopen/verifier.rs
@@ -24,10 +24,10 @@ pub fn verify_proof<
     params: &'params Params<C>,
     transcript: &mut T,
     queries: I,
-    mut msm: MSM<'params, C>,
-) -> Result<Guard<'params, C, E>, Error>
+    mut msm: MSM<C>,
+) -> Result<Guard<C, E>, Error>
 where
-    I: IntoIterator<Item = VerifierQuery<'r, 'params, C>> + Clone,
+    I: IntoIterator<Item = VerifierQuery<'r, C>> + Clone,
 {
     // Sample x_1 for compressing openings at the same point sets together
     let x_1: ChallengeX1<_> = transcript.squeeze_challenge_scalar();
@@ -127,8 +127,8 @@ where
     super::commitment::verify_proof(params, msm, transcript, *x_3, v)
 }
 
-impl<'a, 'b, C: CurveAffine> Query<C::Scalar> for VerifierQuery<'a, 'b, C> {
-    type Commitment = CommitmentReference<'a, 'b, C>;
+impl<'a, C: CurveAffine> Query<C::Scalar> for VerifierQuery<'a, C> {
+    type Commitment = CommitmentReference<'a, C>;
     type Eval = C::Scalar;
 
     fn get_point(&self) -> C::Scalar {


### PR DESCRIPTION
This PR basically moves the `Params` field from `MSM` and adds it as an argument to `eval` function of `MSM`. With this change reference to ecc point parameters are passed only when they are actually used. So that we can get rid of `'params` bound for good.

Not implemented in this PR but I observe that `params` argument can be also replaced with parameter `k` at `plonk::verify_proof`, `poly::multiopen::verify_proof` and `poly::commitment::verify_proof`functions if it is found as a simplification.
