### PR TITLE
Allow `enable_equality` on `TableColumn`

### DIFF
--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -295,6 +295,11 @@ impl TableColumn {
     pub(crate) fn inner(&self) -> Column<Fixed> {
         self.inner
     }
+
+    /// Enable equality on this TableColumn.
+    pub fn enable_equality<F: Field>(&self, meta: &mut ConstraintSystem<F>) {
+        meta.enable_equality(self.inner)
+    }
 }
 
 /// This trait allows a [`Circuit`] to direct some backend to assign a witness


### PR DESCRIPTION
The `TableColumn` should not be used in the `enable_constant` API, since that would introduce global constants not in the logical lookup table. However, there is no reason to disallow copy constraints on already-assigned table cells.