### PR TITLE
[Book] Debian systems require more packages to run the dev tools

### DIFF
--- a/book/src/user/dev-tools.md
+++ b/book/src/user/dev-tools.md
@@ -18,7 +18,7 @@ representations of circuits.
 
 On Debian systems, you will need the following additional packages:
 ```plaintext
-sudo apt install cmake libexpat1-dev libfreetype6-dev
+sudo apt install cmake libexpat1-dev libfreetype6-dev libfontconfig libfontconfig1-dev
 ```
 
 ### Circuit layout


### PR DESCRIPTION
Two more packages are required to run dev tool on Ubuntu 20.04: 
```
sudo apt-get install libfontconfig libfontconfig1-dev
```
Reference: https://github.com/plotters-rs/plotters/issues/10