### PR TITLE
halo2_proofs: Avoid caching rotated polynomials in `poly::Evaluator`

### DIFF
--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -247,6 +247,7 @@ impl<F: Clone + Copy, B> Polynomial<F, B> {
         // coefficients move to the end, and the last `k` coefficients move to the front.
         // The coefficient previously at `mid` will be the first coefficient in the
         // rotated polynomial, and the position from which chunk indexing begins.
+        #[allow(clippy::branches_sharing_code)]
         let (mid, k) = if rotation_is_negative {
             let k = rotation_abs;
             assert!(k <= self.len());

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -323,3 +323,43 @@ impl Rotation {
         Rotation(1)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use ff::Field;
+    use pasta_curves::pallas;
+    use rand_core::OsRng;
+
+    use super::{EvaluationDomain, Polynomial, Rotation};
+
+    #[test]
+    fn test_get_chunk_of_rotated() {
+        let k = 11;
+        let domain = EvaluationDomain::<pallas::Base>::new(1, k);
+
+        // Create a random polynomial.
+        let mut poly = domain.empty_lagrange();
+        for coefficient in poly.iter_mut() {
+            *coefficient = pallas::Base::random(OsRng);
+        }
+
+        // Pick a chunk size that is guaranteed to not be a multiple of the polynomial
+        // length.
+        let chunk_size = 7;
+
+        for rotation in [
+            Rotation(-6),
+            Rotation::prev(),
+            Rotation::cur(),
+            Rotation::next(),
+            Rotation(12),
+        ] {
+            for (chunk_index, chunk) in poly.rotate(rotation).chunks(chunk_size).enumerate() {
+                assert_eq!(
+                    poly.get_chunk_of_rotated(rotation, chunk_size, chunk_index),
+                    chunk
+                );
+            }
+        }
+    }
+}

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -566,3 +566,41 @@ fn test_l_i() {
         assert_eq!(eval_polynomial(&l[(8 - i) % 8][..], x), evaluations[7 - i]);
     }
 }
+
+#[test]
+fn test_get_chunk_of_rotated_extended() {
+    use pasta_curves::pallas;
+    use rand_core::OsRng;
+
+    let k = 11;
+    let domain = EvaluationDomain::<pallas::Base>::new(3, k);
+
+    // Create a random polynomial.
+    let mut poly = domain.empty_extended();
+    for coefficient in poly.iter_mut() {
+        *coefficient = pallas::Base::random(OsRng);
+    }
+
+    // Pick a chunk size that is guaranteed to not be a multiple of the polynomial
+    // length.
+    let chunk_size = 7;
+
+    for rotation in [
+        Rotation(-6),
+        Rotation::prev(),
+        Rotation::cur(),
+        Rotation::next(),
+        Rotation(12),
+    ] {
+        for (chunk_index, chunk) in domain
+            .rotate_extended(&poly, rotation)
+            .chunks(chunk_size)
+            .enumerate()
+        {
+            assert_eq!(
+                domain.get_chunk_of_rotated_extended(&poly, rotation, chunk_size, chunk_index),
+                chunk
+            );
+        }
+    }
+}

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -272,6 +272,27 @@ impl<G: Group> EvaluationDomain<G> {
         poly
     }
 
+    /// Gets the specified chunk of the rotated version of this polynomial.
+    ///
+    /// Equivalent to:
+    /// ```ignore
+    /// self.rotate_extended(poly, rotation)
+    ///     .chunks(chunk_size)
+    ///     .nth(chunk_index)
+    ///     .unwrap()
+    ///     .to_vec()
+    /// ```
+    pub(crate) fn get_chunk_of_rotated_extended(
+        &self,
+        poly: &Polynomial<G, ExtendedLagrangeCoeff>,
+        rotation: Rotation,
+        chunk_size: usize,
+        chunk_index: usize,
+    ) -> Vec<G> {
+        let new_rotation = ((1 << (self.extended_k - self.k)) * rotation.0.abs()) as usize;
+        poly.get_chunk_of_rotated_helper(rotation.0 < 0, new_rotation, chunk_size, chunk_index)
+    }
+
     /// This takes us from the extended evaluation domain and gets us the
     /// quotient polynomial coefficients.
     ///


### PR DESCRIPTION
Previously we used the existing `Polynomial::rotate` and `EvaluationDomain::rotate_extended` APIs to rotate the polynomials we query at non-zero rotations, and then stored references to the chunks of each (rotated and unrotated) polynomial as slices. When we reached an `AstLeaf`, we would then clone the corresponding polynomial chunk.

We now avoid all of this with combined "rotate-and-chunk" APIs, making use of the observation that a rotation is simply a renumbering of the indices of the polynomial coefficients. Given that when we reach an `AstLeaf` we already needed to allocate, these new APIs have the same number of allocations during AST evaluation, but enable us to completely avoid caching any information about the rotations or rotated polynomials ahead of time.