### PR TITLE
Implement Dynamic lookups

### DIFF
--- a/halo2_proofs/examples/dynamic_lookup.rs
+++ b/halo2_proofs/examples/dynamic_lookup.rs
@@ -1,0 +1,146 @@
+use halo2_proofs::{
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    dev::MockProver,
+    pasta::Fp,
+    plonk::{
+        create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Circuit, Column,
+        ConstraintSystem, DynamicTable, DynamicTableMap, Error, Selector, SingleVerifier,
+    },
+    poly::{commitment::Params, Rotation},
+    transcript::{Blake2bRead, Blake2bWrite},
+};
+use pasta_curves::{vesta, EqAffine};
+use rand_core::OsRng;
+
+#[derive(Clone)]
+struct EvenOddCircuitConfig {
+    is_even: Selector,
+    is_odd: Selector,
+    a: Column<Advice>,
+    // starts at zero to use as default
+    table_vals: Column<Advice>,
+    even: DynamicTable,
+    odd: DynamicTable,
+}
+
+struct DynLookupCircuit {}
+impl Circuit<Fp> for DynLookupCircuit {
+    type Config = EvenOddCircuitConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+        let a = meta.advice_column();
+        let table_vals = meta.advice_column();
+        let is_even = meta.complex_selector();
+        let is_odd = meta.complex_selector();
+        let even = meta.create_dynamic_table("even", &[], &[table_vals]);
+        let odd = meta.create_dynamic_table("odd", &[], &[table_vals]);
+
+        meta.lookup_dynamic(&even, |cells| {
+            let a = cells.query_advice(a, Rotation::cur());
+            let is_even = cells.query_selector(is_even);
+
+            DynamicTableMap {
+                selector: is_even,
+                table_map: vec![(a.clone(), table_vals.into())],
+            }
+        });
+
+        meta.lookup_dynamic(&odd, |cells| {
+            let a = cells.query_advice(a, Rotation::cur());
+            let is_odd = cells.query_selector(is_odd);
+
+            DynamicTableMap {
+                selector: is_odd,
+                table_map: vec![(a.clone(), table_vals.into())],
+            }
+        });
+
+        EvenOddCircuitConfig {
+            a,
+            table_vals,
+            is_even,
+            is_odd,
+            even,
+            odd,
+        }
+    }
+
+    fn without_witnesses(&self) -> Self {
+        Self {}
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<Fp>,
+    ) -> Result<(), Error> {
+        for i in 0..=5 {
+            layouter.assign_region(
+                || format!("lookup: {}", i),
+                |mut region| {
+                    // Enable the lookup on rows
+                    if i % 2 == 0 {
+                        config.is_even.enable(&mut region, 0)?;
+                    } else {
+                        config.is_odd.enable(&mut region, 0)?;
+                    };
+
+                    region.assign_advice(|| "", config.a, 0, || Value::known(Fp::from(i as u64)))
+                },
+            )?;
+        }
+        layouter.assign_region(
+            || "table",
+            |mut region| {
+                for i in 0..=5 {
+                    region.assign_advice(
+                        || "",
+                        config.table_vals,
+                        i,
+                        || Value::known(Fp::from(i as u64)),
+                    )?;
+
+                    let table = if i % 2 == 0 {
+                        &config.even
+                    } else {
+                        &config.odd
+                    };
+                    table.add_row(&mut region, i)?;
+                }
+                Ok(())
+            },
+        )?;
+        Ok(())
+    }
+}
+
+fn main() {
+    let k = 5;
+
+    MockProver::run(k, &DynLookupCircuit {}, vec![])
+        .unwrap()
+        .verify()
+        .unwrap();
+
+    let params: Params<EqAffine> = Params::new(k);
+    let verifier = SingleVerifier::new(&params);
+    let vk = keygen_vk(&params, &DynLookupCircuit {}).unwrap();
+    let pk = keygen_pk(&params, vk.clone(), &DynLookupCircuit {}).unwrap();
+    let mut transcript = Blake2bWrite::<_, vesta::Affine, _>::init(vec![]);
+    create_proof(
+        &params,
+        &pk,
+        &[DynLookupCircuit {}],
+        &[],
+        &mut OsRng,
+        &mut transcript,
+    )
+    .expect("Failed to create proof");
+
+    let proof: Vec<u8> = transcript.finalize();
+
+    let mut transcript = Blake2bRead::init(&proof[..]);
+    verify_proof(&params, pk.get_vk(), verifier, &[], &mut transcript)
+        .expect("could not verify_proof");
+}

--- a/halo2_proofs/examples/dynamic_lookup.rs
+++ b/halo2_proofs/examples/dynamic_lookup.rs
@@ -42,7 +42,7 @@ impl Circuit<Fp> for DynLookupCircuit {
 
             DynamicTableMap {
                 selector: is_even,
-                table_map: vec![(a.clone(), table_vals.into())],
+                table_map: vec![(a, table_vals.into())],
             }
         });
 
@@ -52,7 +52,7 @@ impl Circuit<Fp> for DynLookupCircuit {
 
             DynamicTableMap {
                 selector: is_odd,
-                table_map: vec![(a.clone(), table_vals.into())],
+                table_map: vec![(a, table_vals.into())],
             }
         });
 
@@ -126,13 +126,13 @@ fn main() {
     let params: Params<EqAffine> = Params::new(k);
     let verifier = SingleVerifier::new(&params);
     let vk = keygen_vk(&params, &DynLookupCircuit {}).unwrap();
-    let pk = keygen_pk(&params, vk.clone(), &DynLookupCircuit {}).unwrap();
+    let pk = keygen_pk(&params, vk, &DynLookupCircuit {}).unwrap();
     let mut transcript = Blake2bWrite::<_, vesta::Affine, _>::init(vec![]);
     create_proof(
         &params,
         &pk,
         &[DynLookupCircuit {}],
-        &[],
+        &[&[]],
         &mut OsRng,
         &mut transcript,
     )
@@ -141,6 +141,6 @@ fn main() {
     let proof: Vec<u8> = transcript.finalize();
 
     let mut transcript = Blake2bRead::init(&proof[..]);
-    verify_proof(&params, pk.get_vk(), verifier, &[], &mut transcript)
+    verify_proof(&params, pk.get_vk(), verifier, &[&[]], &mut transcript)
         .expect("could not verify_proof");
 }

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -6,7 +6,9 @@ use ff::Field;
 
 use crate::{
     arithmetic::FieldExt,
-    plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector, TableColumn},
+    plonk::{
+        Advice, Any, Assigned, Column, DynamicTable, Error, Fixed, Instance, Selector, TableColumn,
+    },
 };
 
 mod value;
@@ -202,6 +204,15 @@ impl<'r, F: Field> Region<'r, F> {
     {
         self.region
             .enable_selector(&|| annotation().into(), selector, offset)
+    }
+
+    /// Includes a row at `offset` in this dynamic lookup table.
+    pub(crate) fn add_row_to_table(
+        &mut self,
+        table: &DynamicTable,
+        offset: usize,
+    ) -> Result<(), Error> {
+        self.region.add_to_lookup(table, offset)
     }
 
     /// Assign an advice column value (witness).

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -209,7 +209,7 @@ impl<'r, F: Field> Region<'r, F> {
     /// Includes a row at `offset` in this dynamic lookup table.
     pub(crate) fn add_row_to_table(
         &mut self,
-        table: &DynamicTable,
+        table: DynamicTable,
         offset: usize,
     ) -> Result<(), Error> {
         self.region.add_to_lookup(table, offset)

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -275,6 +275,16 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F>
         )
     }
 
+    fn add_to_lookup(
+        &mut self,
+        table: &crate::plonk::DynamicTable,
+        offset: usize,
+    ) -> Result<(), Error> {
+        self.layouter
+            .cs
+            .add_row_to_table(table, *self.layouter.regions[*self.region_index] + offset)
+    }
+
     fn assign_advice<'v>(
         &'v mut self,
         annotation: &'v (dyn Fn() -> String + 'v),

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -11,8 +11,8 @@ use crate::{
         Cell, Layouter, Region, RegionIndex, RegionStart, Table, Value,
     },
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, Error, Fixed, FloorPlanner, Instance,
-        Selector, TableColumn,
+        Advice, Any, Assigned, Assignment, Circuit, Column, DynamicTable, Error, Fixed,
+        FloorPlanner, Instance, Selector, TableColumn,
     },
 };
 
@@ -275,11 +275,7 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F>
         )
     }
 
-    fn add_to_lookup(
-        &mut self,
-        table: &crate::plonk::DynamicTable,
-        offset: usize,
-    ) -> Result<(), Error> {
+    fn add_to_lookup(&mut self, table: DynamicTable, offset: usize) -> Result<(), Error> {
         self.layouter
             .cs
             .add_row_to_table(table, *self.layouter.regions[*self.region_index] + offset)

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -391,6 +391,16 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
         )
     }
 
+    fn add_to_lookup(
+        &mut self,
+        table: &crate::plonk::DynamicTable,
+        offset: usize,
+    ) -> Result<(), Error> {
+        self.plan
+            .cs
+            .add_row_to_table(table, *self.plan.regions[*self.region_index] + offset)
+    }
+
     fn assign_advice<'v>(
         &'v mut self,
         annotation: &'v (dyn Fn() -> String + 'v),

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -393,7 +393,7 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F> for V1Region<'r
 
     fn add_to_lookup(
         &mut self,
-        table: &crate::plonk::DynamicTable,
+        table: crate::plonk::DynamicTable,
         offset: usize,
     ) -> Result<(), Error> {
         self.plan

--- a/halo2_proofs/src/circuit/layouter.rs
+++ b/halo2_proofs/src/circuit/layouter.rs
@@ -7,7 +7,10 @@ use std::fmt;
 use ff::Field;
 
 use super::{Cell, RegionIndex, Value};
-use crate::plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector, TableColumn};
+use crate::plonk::{
+    Advice, Any, Assigned, Column, DynamicTable, DynamicTableIndex, Error, Fixed, Instance,
+    Selector, TableColumn,
+};
 
 /// Helper trait for implementing a custom [`Layouter`].
 ///
@@ -47,6 +50,9 @@ pub trait RegionLayouter<F: Field>: fmt::Debug {
         selector: &Selector,
         offset: usize,
     ) -> Result<(), Error>;
+
+    /// Enables a selector at the given offset.
+    fn add_to_lookup(&mut self, table: &DynamicTable, offset: usize) -> Result<(), Error>;
 
     /// Assign an advice column value (witness)
     fn assign_advice<'v>(
@@ -139,6 +145,8 @@ pub enum RegionColumn {
     Column(Column<Any>),
     /// Virtual column representing a (boolean) selector
     Selector(Selector),
+    /// Virtual column used for storing dynamic table tags
+    TableTag(DynamicTableIndex),
 }
 
 impl From<Column<Any>> for RegionColumn {
@@ -153,13 +161,22 @@ impl From<Selector> for RegionColumn {
     }
 }
 
+impl From<&DynamicTable> for RegionColumn {
+    fn from(table: &DynamicTable) -> RegionColumn {
+        RegionColumn::TableTag(table.index)
+    }
+}
+
 impl Ord for RegionColumn {
     fn cmp(&self, other: &Self) -> cmp::Ordering {
         match (self, other) {
             (Self::Column(ref a), Self::Column(ref b)) => a.cmp(b),
             (Self::Selector(ref a), Self::Selector(ref b)) => a.0.cmp(&b.0),
-            (Self::Column(_), Self::Selector(_)) => cmp::Ordering::Less,
+            (Self::TableTag(ref a), Self::TableTag(ref b)) => a.cmp(b),
+            (Self::Column(_), _) => cmp::Ordering::Less,
             (Self::Selector(_), Self::Column(_)) => cmp::Ordering::Greater,
+            (Self::TableTag(_), _) => cmp::Ordering::Greater,
+            (_, Self::TableTag(_)) => cmp::Ordering::Less,
         }
     }
 }
@@ -205,6 +222,13 @@ impl<F: Field> RegionLayouter<F> for RegionShape {
     ) -> Result<(), Error> {
         // Track the selector's fixed column as part of the region's shape.
         self.columns.insert((*selector).into());
+        self.row_count = cmp::max(self.row_count, offset + 1);
+        Ok(())
+    }
+
+    fn add_to_lookup(&mut self, table: &DynamicTable, offset: usize) -> Result<(), Error> {
+        // Track the tag's fixed column as part of the region's shape.
+        self.columns.insert(table.into());
         self.row_count = cmp::max(self.row_count, offset + 1);
         Ok(())
     }

--- a/halo2_proofs/src/circuit/layouter.rs
+++ b/halo2_proofs/src/circuit/layouter.rs
@@ -8,8 +8,7 @@ use ff::Field;
 
 use super::{Cell, RegionIndex, Value};
 use crate::plonk::{
-    Advice, Any, Assigned, Column, DynamicTable, DynamicTableIndex, Error, Fixed, Instance,
-    Selector, TableColumn,
+    Advice, Any, Assigned, Column, DynamicTable, Error, Fixed, Instance, Selector, TableColumn,
 };
 
 /// Helper trait for implementing a custom [`Layouter`].
@@ -52,7 +51,7 @@ pub trait RegionLayouter<F: Field>: fmt::Debug {
     ) -> Result<(), Error>;
 
     /// Enables a selector at the given offset.
-    fn add_to_lookup(&mut self, table: &DynamicTable, offset: usize) -> Result<(), Error>;
+    fn add_to_lookup(&mut self, table: DynamicTable, offset: usize) -> Result<(), Error>;
 
     /// Assign an advice column value (witness)
     fn assign_advice<'v>(
@@ -146,7 +145,7 @@ pub enum RegionColumn {
     /// Virtual column representing a (boolean) selector
     Selector(Selector),
     /// Virtual column used for storing dynamic table tags
-    TableTag(DynamicTableIndex),
+    TableTag(DynamicTable),
 }
 
 impl From<Column<Any>> for RegionColumn {
@@ -161,9 +160,9 @@ impl From<Selector> for RegionColumn {
     }
 }
 
-impl From<&DynamicTable> for RegionColumn {
-    fn from(table: &DynamicTable) -> RegionColumn {
-        RegionColumn::TableTag(table.index)
+impl From<DynamicTable> for RegionColumn {
+    fn from(table: DynamicTable) -> RegionColumn {
+        RegionColumn::TableTag(table)
     }
 }
 
@@ -226,7 +225,7 @@ impl<F: Field> RegionLayouter<F> for RegionShape {
         Ok(())
     }
 
-    fn add_to_lookup(&mut self, table: &DynamicTable, offset: usize) -> Result<(), Error> {
+    fn add_to_lookup(&mut self, table: DynamicTable, offset: usize) -> Result<(), Error> {
         // Track the tag's fixed column as part of the region's shape.
         self.columns.insert(table.into());
         self.row_count = cmp::max(self.row_count, offset + 1);

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1467,10 +1467,6 @@ mod tests {
 
             let errs = MockProver::run(K, &DynLookupCircuit {}, vec![])
                 .unwrap()
-                .assert_satisfied();
-
-            let errs = MockProver::run(K, &DynLookupCircuit {}, vec![])
-                .unwrap()
                 .verify()
                 .expect_err("The table only contains 0..=5, but lookups on 0..=6 succeeded");
 

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1467,6 +1467,10 @@ mod tests {
 
             let errs = MockProver::run(K, &DynLookupCircuit {}, vec![])
                 .unwrap()
+                .assert_satisfied();
+
+            let errs = MockProver::run(K, &DynLookupCircuit {}, vec![])
+                .unwrap()
                 .verify()
                 .expect_err("The table only contains 0..=5, but lookups on 0..=6 succeeded");
 

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -1742,7 +1742,7 @@ mod tests {
 
                         DynamicTableMap {
                             selector: is_even,
-                            table_map: vec![(a.clone(), table_vals.into())],
+                            table_map: vec![(a, table_vals.into())],
                         }
                     });
 
@@ -1752,7 +1752,7 @@ mod tests {
 
                         DynamicTableMap {
                             selector: is_odd,
-                            table_map: vec![(a.clone(), table_vals.into())],
+                            table_map: vec![(a, table_vals.into())],
                         }
                     });
 

--- a/halo2_proofs/src/dev.rs
+++ b/halo2_proofs/src/dev.rs
@@ -8,6 +8,7 @@ use ff::Field;
 
 use crate::plonk::Assigned;
 use crate::plonk::DynamicTable;
+use crate::plonk::DynamicTableInfo;
 use crate::{
     arithmetic::{FieldExt, Group},
     circuit,
@@ -339,11 +340,11 @@ impl<F: Field + Group> Assignment<F> for MockProver<F> {
         Ok(())
     }
 
-    fn add_row_to_table(&mut self, table: &DynamicTable, row: usize) -> Result<(), Error> {
-        self.dynamic_tables[table.index.index()][row] = true;
+    fn add_row_to_table(&mut self, table: DynamicTable, row: usize) -> Result<(), Error> {
+        self.dynamic_tables[table.index()][row] = true;
 
         if let Some(region) = self.current_region.as_mut() {
-            for column in table.columns.iter() {
+            for column in self.cs.dynamic_tables[table.index()].columns.iter() {
                 region.update_extent(*column, row);
             }
         }
@@ -560,7 +561,7 @@ impl<F: FieldExt> MockProver<F> {
 
         let (cs, tag_polys) = prover
             .cs
-            .compress_dynamic_table_tags(prover.dynamic_tables.clone());
+            .compress_dynamic_table_tags(&prover.dynamic_tables);
         prover.cs = cs;
         prover.fixed.extend(tag_polys.into_iter().map(|poly| {
             let mut v = vec![CellValue::Unassigned; n];
@@ -865,7 +866,7 @@ impl<F: FieldExt> MockProver<F> {
             fn unassigned_error<F: FieldExt>(
                 regions: &[Region],
                 cell: CellValue<F>,
-                dynamic_table: &DynamicTable,
+                dynamic_table: &DynamicTableInfo,
                 column: Column<Any>,
                 row: usize,
             ) -> Option<VerifyFailure> {
@@ -969,7 +970,7 @@ mod tests {
     use crate::{
         circuit::{Layouter, SimpleFloorPlanner, Value},
         plonk::{
-            Advice, Any, Circuit, Column, ConstraintSystem, DynamicTable, Error, Expression,
+            Advice, Any, Circuit, Column, ConstraintSystem, DynamicTableInfo, Error, Expression,
             Selector, TableColumn,
         },
         poly::Rotation,
@@ -1179,7 +1180,7 @@ mod tests {
 
     #[cfg(test)]
     mod dynamic_lookups {
-        use crate::plonk::{DynamicTableIndex, DynamicTableMap};
+        use crate::plonk::{DynamicTable, DynamicTableMap};
 
         use super::*;
 
@@ -1277,7 +1278,7 @@ mod tests {
                                     i,
                                     || Value::known(Fp::from(i as u64)),
                                 )?;
-                                region.add_row_to_table(&config.table, i)?;
+                                region.add_row_to_table(config.table, i)?;
                             }
                             Ok(())
                         },
@@ -1345,7 +1346,7 @@ mod tests {
                                     0,
                                     || Value::known(Fp::from(i as u64)),
                                 )?;
-                                region.add_row_to_table(&config.table, 0)?;
+                                region.add_row_to_table(config.table, 0)?;
                                 Ok(())
                             },
                         )?;
@@ -1614,9 +1615,9 @@ mod tests {
             assert_eq!(
                 res,
                 Err(vec![VerifyFailure::DynamicTableCellNotAssigned {
-                    dynamic_table: DynamicTable {
+                    dynamic_table: DynamicTableInfo {
                         name: "table".to_string(),
-                        index: DynamicTableIndex::from_index(0),
+                        index: DynamicTable::from_index(0),
                         columns: vec![Column::new(1, Any::Advice)],
                     },
                     region: (0, "table".to_string(),).into(),
@@ -1689,9 +1690,9 @@ mod tests {
             assert_eq!(
                 res,
                 Err(vec![VerifyFailure::DynamicTableCellNotAssigned {
-                    dynamic_table: DynamicTable {
+                    dynamic_table: DynamicTableInfo {
                         name: "table".to_string(),
-                        index: DynamicTableIndex::from_index(0),
+                        index: DynamicTable::from_index(0),
                         columns: vec![Column::new(1, Any::Advice)],
                     },
                     region: (0, "table".to_string(),).into(),
@@ -1704,7 +1705,7 @@ mod tests {
 
     #[cfg(test)]
     mod even_odd_dyn_tables {
-        use crate::plonk::DynamicTableMap;
+        use crate::plonk::{DynamicTable, DynamicTableMap};
 
         use super::*;
 

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -71,8 +71,8 @@ impl<F: Field> Assignment<F> for Assembly {
         Ok(())
     }
 
-    fn add_row_to_table(&mut self, table: &DynamicTable, row: usize) -> Result<(), Error> {
-        self.dynamic_tables[table.index.index()][row] = true;
+    fn add_row_to_table(&mut self, table: DynamicTable, row: usize) -> Result<(), Error> {
+        self.dynamic_tables[table.index()][row] = true;
 
         Ok(())
     }
@@ -159,7 +159,7 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
         )
         .unwrap();
         let (cs, _) = cs.compress_selectors(assembly.selectors);
-        let (cs, _) = cs.compress_dynamic_table_tags(assembly.dynamic_tables);
+        let (cs, _) = cs.compress_dynamic_table_tags(&assembly.dynamic_tables);
 
         assert!((1 << k) >= cs.minimum_rows());
 

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -436,19 +436,20 @@ fn render_lookup<F: FieldExt>(
         FailureLocation::OutsideRegion { row } => *row,
     } as i32;
 
-    // Recover the fixed columns from the table expressions. We don't allow composite
-    // expressions for the table side of lookups.
+    // Recover the fixed columns from the table expressions.
+    // We don't allow composite expressions for the table side of fixed lookups.
+    // The table side of Dynamic lookups have a tag column.
     let table_columns = lookup.table_expressions.iter().map(|expr| {
         expr.evaluate(
             &|_| panic!("no constants in table expressions"),
             &|_| panic!("no selectors in table expressions"),
             &|_| panic!("no virtual columns in table expressions"),
             &|query| format!("F{}", query.column_index),
-            &|_| panic!("no advice columns in table expressions"),
+            &|query| format!("A{}", query.column_index),
             &|_| panic!("no instance columns in table expressions"),
             &|_| panic!("no negations in table expressions"),
             &|_, _| panic!("no sums in table expressions"),
-            &|_, _| panic!("no products in table expressions"),
+            &|a, b| format!("{} * {}", a, b),
             &|_, _| panic!("no scaling in table expressions"),
         )
     });

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -9,7 +9,7 @@ use super::{
     util::{self, AnyQuery},
     MockProver, Region,
 };
-use crate::plonk::DynamicTable;
+use crate::plonk::DynamicTableInfo;
 use crate::{
     dev::Value,
     plonk::{Any, Column, ConstraintSystem, Expression, Gate},
@@ -113,7 +113,7 @@ pub enum VerifyFailure {
     /// A cell used in an active gate was not assigned to.
     DynamicTableCellNotAssigned {
         /// The tag of the table containing a unassigned cell.
-        dynamic_table: DynamicTable,
+        dynamic_table: DynamicTableInfo,
         /// The region in which this cell should be assigned.
         region: metadata::Region,
         /// The column in which this cell should be assigned.

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -103,6 +103,7 @@ pub(super) fn expression_to_string<F: Field>(
     expr.evaluate(
         &util::format_value,
         &|_| panic!("virtual selectors are removed during optimization"),
+        &|_| panic!("virtual columns are removed during optimization"),
         &|query| {
             if let Some(label) = layout
                 .get(&query.rotation.0)

--- a/halo2_proofs/src/dev/gates.rs
+++ b/halo2_proofs/src/dev/gates.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::BTreeSet,
     fmt::{self, Write},
+    iter,
 };
 
 use ff::PrimeField;
@@ -119,6 +120,7 @@ impl CircuitGates {
                         expression: constraint.evaluate(
                             &util::format_value,
                             &|selector| format!("S{}", selector.0),
+                            &|virtual_col| format!("T{}", virtual_col.0.index()),
                             &|query| format!("F{}@{}", query.column_index, query.rotation.0),
                             &|query| format!("A{}@{}", query.column_index, query.rotation.0),
                             &|query| format!("I{}@{}", query.column_index, query.rotation.0),
@@ -152,7 +154,10 @@ impl CircuitGates {
                         ),
                         queries: constraint.evaluate(
                             &|_| BTreeSet::default(),
-                            &|selector| vec![format!("S{}", selector.0)].into_iter().collect(),
+                            &|selector| iter::once(format!("S{}", selector.0)).collect(),
+                            &|virtual_col| {
+                                iter::once(format!("V{}", virtual_col.0.index())).collect()
+                            },
                             &|query| {
                                 vec![format!("F{}@{}", query.column_index, query.rotation.0)]
                                     .into_iter()
@@ -190,6 +195,7 @@ impl CircuitGates {
             .flat_map(|gate| {
                 gate.polynomials().iter().map(|poly| {
                     poly.evaluate(
+                        &|_| (0, 0, 0),
                         &|_| (0, 0, 0),
                         &|_| (0, 0, 0),
                         &|_| (0, 0, 0),

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -4,8 +4,8 @@ use tabbycat::{AttrList, Edge, GraphBuilder, GraphType, Identity, StmtList};
 use crate::{
     circuit::Value,
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
-        FloorPlanner, Instance, Selector,
+        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, DynamicTable, Error,
+        Fixed, FloorPlanner, Instance, Selector,
     },
 };
 
@@ -78,11 +78,7 @@ struct Graph {
 }
 
 impl<F: Field> Assignment<F> for Graph {
-    fn enter_region<NR, N>(&mut self, _: N)
-    where
-        NR: Into<String>,
-        N: FnOnce() -> NR,
-    {
+    fn enter_region<NR, N>(&mut self, _: N) {
         // Do nothing; we don't care about regions in this context.
     }
 
@@ -96,6 +92,10 @@ impl<F: Field> Assignment<F> for Graph {
         AR: Into<String>,
     {
         // Do nothing; we don't care about cells in this context.
+        Ok(())
+    }
+
+    fn add_row_to_table(&mut self, _: &DynamicTable, _: usize) -> Result<(), Error> {
         Ok(())
     }
 

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -95,7 +95,7 @@ impl<F: Field> Assignment<F> for Graph {
         Ok(())
     }
 
-    fn add_row_to_table(&mut self, _: &DynamicTable, _: usize) -> Result<(), Error> {
+    fn add_row_to_table(&mut self, _: DynamicTable, _: usize) -> Result<(), Error> {
         Ok(())
     }
 

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -4,18 +4,15 @@ use plotters::{
     coord::Shift,
     prelude::{DrawingArea, DrawingAreaErrorKind, DrawingBackend},
 };
-use std::collections::HashSet;
 use std::ops::Range;
+use std::{cmp, collections::HashSet};
 
 use crate::{
-    circuit::layouter::RegionColumn,
     circuit::{layouter::RegionColumn, Value},
-    dev::cost::Layout,
     plonk::{
         Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, DynamicTable,
         DynamicTableInfo, Error, Fixed, FloorPlanner, Instance, Selector,
     },
-    plonk::{Any, Circuit, Column, ConstraintSystem, FloorPlanner},
 };
 
 /// Graphical renderer for circuit layouts.

--- a/halo2_proofs/src/dev/util.rs
+++ b/halo2_proofs/src/dev/util.rs
@@ -143,6 +143,7 @@ pub(super) fn cell_values<'a, F: FieldExt>(
     let cell_values = poly.evaluate(
         &|_| BTreeMap::default(),
         &|_| panic!("virtual selectors are removed during optimization"),
+        &|_| panic!("virtual columns are removed during optimization"),
         &cell_value(virtual_cells, load_fixed),
         &cell_value(virtual_cells, load_advice),
         &cell_value(virtual_cells, load_instance),

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -10,7 +10,8 @@ use super::{
         Advice, Any, Assignment, Circuit, Column, ConstraintSystem, Fixed, FloorPlanner, Instance,
         Selector,
     },
-    permutation, Assigned, Error, LagrangeCoeff, Polynomial, ProvingKey, VerifyingKey,
+    permutation, Assigned, DynamicTable, Error, LagrangeCoeff, Polynomial, ProvingKey,
+    VerifyingKey,
 };
 use crate::{
     arithmetic::CurveAffine,
@@ -50,6 +51,8 @@ struct Assembly<F: Field> {
     fixed: Vec<Polynomial<Assigned<F>, LagrangeCoeff>>,
     permutation: permutation::keygen::Assembly,
     selectors: Vec<Vec<bool>>,
+    /// A map between DynamicTable.index, and rows included.
+    dynamic_tables: Vec<Vec<bool>>,
     // A range of available rows for assignment and copies.
     usable_rows: Range<usize>,
     _marker: std::marker::PhantomData<F>,
@@ -78,6 +81,16 @@ impl<F: Field> Assignment<F> for Assembly<F> {
         }
 
         self.selectors[selector.0][row] = true;
+
+        Ok(())
+    }
+
+    fn add_row_to_table(&mut self, table: &DynamicTable, row: usize) -> Result<(), Error> {
+        if !self.usable_rows.contains(&row) {
+            return Err(Error::not_enough_rows_available(self.k));
+        }
+
+        self.dynamic_tables[table.index.index()][row] = true;
 
         Ok(())
     }
@@ -205,6 +218,7 @@ where
         fixed: vec![domain.empty_lagrange_assigned(); cs.num_fixed_columns],
         permutation: permutation::keygen::Assembly::new(params.n as usize, &cs.permutation),
         selectors: vec![vec![false; params.n as usize]; cs.num_selectors],
+        dynamic_tables: vec![vec![false; params.n as usize]; cs.dynamic_tables.len()],
         usable_rows: 0..params.n as usize - (cs.blinding_factors() + 1),
         _marker: std::marker::PhantomData,
     };
@@ -221,6 +235,13 @@ where
     let (cs, selector_polys) = cs.compress_selectors(assembly.selectors);
     fixed.extend(
         selector_polys
+            .into_iter()
+            .map(|poly| domain.lagrange_from_vec(poly)),
+    );
+
+    let (cs, dynamic_table_polys) = cs.compress_dynamic_table_tags(assembly.dynamic_tables);
+    fixed.extend(
+        dynamic_table_polys
             .into_iter()
             .map(|poly| domain.lagrange_from_vec(poly)),
     );
@@ -266,6 +287,7 @@ where
         fixed: vec![vk.domain.empty_lagrange_assigned(); cs.num_fixed_columns],
         permutation: permutation::keygen::Assembly::new(params.n as usize, &cs.permutation),
         selectors: vec![vec![false; params.n as usize]; cs.num_selectors],
+        dynamic_tables: vec![vec![false; params.n as usize]; cs.dynamic_tables.len()],
         usable_rows: 0..params.n as usize - (cs.blinding_factors() + 1),
         _marker: std::marker::PhantomData,
     };
@@ -282,6 +304,13 @@ where
     let (cs, selector_polys) = cs.compress_selectors(assembly.selectors);
     fixed.extend(
         selector_polys
+            .into_iter()
+            .map(|poly| vk.domain.lagrange_from_vec(poly)),
+    );
+
+    let (cs, dynamic_table_polys) = cs.compress_dynamic_table_tags(assembly.dynamic_tables);
+    fixed.extend(
+        dynamic_table_polys
             .into_iter()
             .map(|poly| vk.domain.lagrange_from_vec(poly)),
     );

--- a/halo2_proofs/src/plonk/keygen.rs
+++ b/halo2_proofs/src/plonk/keygen.rs
@@ -85,12 +85,12 @@ impl<F: Field> Assignment<F> for Assembly<F> {
         Ok(())
     }
 
-    fn add_row_to_table(&mut self, table: &DynamicTable, row: usize) -> Result<(), Error> {
+    fn add_row_to_table(&mut self, table: DynamicTable, row: usize) -> Result<(), Error> {
         if !self.usable_rows.contains(&row) {
             return Err(Error::not_enough_rows_available(self.k));
         }
 
-        self.dynamic_tables[table.index.index()][row] = true;
+        self.dynamic_tables[table.index()][row] = true;
 
         Ok(())
     }
@@ -239,7 +239,7 @@ where
             .map(|poly| domain.lagrange_from_vec(poly)),
     );
 
-    let (cs, dynamic_table_polys) = cs.compress_dynamic_table_tags(assembly.dynamic_tables);
+    let (cs, dynamic_table_polys) = cs.compress_dynamic_table_tags(&assembly.dynamic_tables);
     fixed.extend(
         dynamic_table_polys
             .into_iter()
@@ -308,7 +308,7 @@ where
             .map(|poly| vk.domain.lagrange_from_vec(poly)),
     );
 
-    let (cs, dynamic_table_polys) = cs.compress_dynamic_table_tags(assembly.dynamic_tables);
+    let (cs, dynamic_table_polys) = cs.compress_dynamic_table_tags(&assembly.dynamic_tables);
     fixed.extend(
         dynamic_table_polys
             .into_iter()

--- a/halo2_proofs/src/plonk/lookup/prover.rs
+++ b/halo2_proofs/src/plonk/lookup/prover.rs
@@ -110,6 +110,7 @@ impl<F: FieldExt> Argument<F> {
                     expression.evaluate(
                         &|scalar| poly::Ast::ConstantTerm(scalar),
                         &|_| panic!("virtual selectors are removed during optimization"),
+                        &|_| panic!("virtual columns are removed during optimization"),
                         &|query| {
                             fixed_values[query.column_index]
                                 .with_rotation(query.rotation)
@@ -139,6 +140,7 @@ impl<F: FieldExt> Argument<F> {
                     expression.evaluate(
                         &|scalar| poly::Ast::ConstantTerm(scalar),
                         &|_| panic!("virtual selectors are removed during optimization"),
+                        &|_| panic!("virtual columns are removed during optimization"),
                         &|query| {
                             fixed_cosets[query.column_index]
                                 .with_rotation(query.rotation)

--- a/halo2_proofs/src/plonk/lookup/verifier.rs
+++ b/halo2_proofs/src/plonk/lookup/verifier.rs
@@ -120,6 +120,7 @@ impl<C: CurveAffine> Evaluated<C> {
                         expression.evaluate(
                             &|scalar| scalar,
                             &|_| panic!("virtual selectors are removed during optimization"),
+                            &|_| panic!("virtual columns are removed during optimization"),
                             &|query| fixed_evals[query.index],
                             &|query| advice_evals[query.index],
                             &|query| instance_evals[query.index],

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -15,7 +15,7 @@ use super::{
 use crate::{
     arithmetic::{eval_polynomial, CurveAffine, FieldExt},
     circuit::Value,
-    plonk::Assigned,
+    plonk::{Assigned, DynamicTable},
     poly::{
         self,
         commitment::{Blind, Params},
@@ -167,6 +167,12 @@ pub fn create_proof<
                     A: FnOnce() -> AR,
                     AR: Into<String>,
                 {
+                    // We only care about advice columns here
+
+                    Ok(())
+                }
+
+                fn add_row_to_table(&mut self, _: &DynamicTable, _: usize) -> Result<(), Error> {
                     // We only care about advice columns here
 
                     Ok(())
@@ -556,6 +562,7 @@ pub fn create_proof<
                             expr.evaluate(
                                 &poly::Ast::ConstantTerm,
                                 &|_| panic!("virtual selectors are removed during optimization"),
+                                &|_| panic!("virtual columns are removed during optimization"),
                                 &|query| {
                                     fixed_cosets[query.column_index]
                                         .with_rotation(query.rotation)

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -172,7 +172,7 @@ pub fn create_proof<
                     Ok(())
                 }
 
-                fn add_row_to_table(&mut self, _: &DynamicTable, _: usize) -> Result<(), Error> {
+                fn add_row_to_table(&mut self, _: DynamicTable, _: usize) -> Result<(), Error> {
                     // We only care about advice columns here
 
                     Ok(())

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -231,6 +231,7 @@ pub fn verify_proof<
                             poly.evaluate(
                                 &|scalar| scalar,
                                 &|_| panic!("virtual selectors are removed during optimization"),
+                                &|_| panic!("virtual columns are removed during optimization"),
                                 &|query| fixed_evals[query.index],
                                 &|query| advice_evals[query.index],
                                 &|query| instance_evals[query.index],


### PR DESCRIPTION
● Supports using Advice and Fixed columns as a lookup table.
● Supports interspersed/non-contiguous tables.
● Checks for unassigned cells using the mock prover (like gates do).
● Performs tag combining when tables do not include the same circuit row.

- [x]  ~~I'd still like to remove `DynamicTable.columns`, since the info is also in `ConstraintSystem`.~~
- [ ] And maybe improve `DynamicTableMap` (ideas welcome), but the core of this PR is ready for reviews.