### PR TITLE
Don't use `include_bytes!` for `plonk_api` test

### DIFF
--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -459,13 +459,14 @@ fn plonk_api() {
         .expect("proof generation should not fail");
         let proof: Vec<u8> = transcript.finalize();
 
-        std::fs::write("plonk_api_proof.bin", &proof[..])
+        std::fs::write("./tests/plonk_api_proof.bin", &proof[..])
             .expect("should succeed to write new proof");
     }
 
     {
         // Check that a hardcoded proof is satisfied
-        let proof = include_bytes!("plonk_api_proof.bin");
+        let proof = std::fs::read("./tests/plonk_api_proof.bin")
+            .expect("should succeed to read proof");
         let strategy = SingleVerifier::new(&params);
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
         assert!(verify_proof(

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -465,8 +465,8 @@ fn plonk_api() {
 
     {
         // Check that a hardcoded proof is satisfied
-        let proof = std::fs::read("./tests/plonk_api_proof.bin")
-            .expect("should succeed to read proof");
+        let proof =
+            std::fs::read("./tests/plonk_api_proof.bin").expect("should succeed to read proof");
         let strategy = SingleVerifier::new(&params);
         let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
         assert!(verify_proof(


### PR DESCRIPTION
The current working directory for a test always seems to be the root of the crate, hence `./tests/plonk_api_proof.bin` is always the correct path.