### PR TITLE
`lookup::prover`: Compress expressions and cosets in `commit_permuted`

### DIFF
--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -490,7 +490,6 @@ pub fn create_proof<
                     lookup.commit_product(
                         pk,
                         params,
-                        theta,
                         beta,
                         gamma,
                         &mut coset_evaluator,
@@ -536,7 +535,7 @@ pub fn create_proof<
             // Evaluate the h(X) polynomial's constraint system expressions for the lookup constraints, if any.
             lookups
                 .into_iter()
-                .map(|p| p.construct(theta, beta, gamma, l0, l_blind, l_last))
+                .map(|p| p.construct(beta, gamma, l0, l_blind, l_last))
                 .unzip()
         })
         .unzip();


### PR DESCRIPTION
The `theta` challenge is used in the lookup argument to compress the input and table expressions. This compression can be done fully in the `commit_permuted` step, after which the original uncompressed expressions are no longer needed.