### PR TITLE
Typo book

### DIFF
--- a/book/src/background/pc-ipa.md
+++ b/book/src/background/pc-ipa.md
@@ -60,9 +60,10 @@ $$
 * the verifier issues a random challenge $u_j$;
 * the prover uses $u_j$ to compress the lower and higher halves of $\mathbf{a}^{(j)}$,
   thus producing a new vector of half the original length 
-  $$\mathbf{a}^{(j-1)} = \mathbf{a_{hi}^{(j)}}\cdot u_j^{-1} + \mathbf{a_{lo}^{(j)}}\cdot u_j.$$
+  <!-- $$\mathbf{a}^{(j-1)} = \mathbf{a_{hi}^{(j)}}\cdot u_j^{-1} + \mathbf{a_{lo}^{(j)}}\cdot u_j.$$ -->
+  $$\mathbf{a}^{(j-1)} = \mathbf{a_{hi}^{(j)}} + \mathbf{a_{lo}^{(j)}}\cdot u_j^{-1}.$$
   The vectors $\mathbf{G}^{(j)}$ and $\mathbf{b}^{(j)}$ are similarly compressed to give
-  $\mathbf{G}^{(j-1)}$ and $\mathbf{b}^{(j-1)}$.
+  $\mathbf{G}^{(j-1)}$ and $\mathbf{b}^{(j-1)}$ (using $u_j$ instead of $u_j^{-1}$).
 * $\mathbf{a}^{(j-1)}$, $\mathbf{G}^{(j-1)}$ and $\mathbf{b}^{(j-1)}$ are input to the
   next round $j - 1.$
 

--- a/book/src/background/pc-ipa.md
+++ b/book/src/background/pc-ipa.md
@@ -60,7 +60,6 @@ $$
 * the verifier issues a random challenge $u_j$;
 * the prover uses $u_j$ to compress the lower and higher halves of $\mathbf{a}^{(j)}$,
   thus producing a new vector of half the original length 
-  <!-- $$\mathbf{a}^{(j-1)} = \mathbf{a_{hi}^{(j)}}\cdot u_j^{-1} + \mathbf{a_{lo}^{(j)}}\cdot u_j.$$ -->
   $$\mathbf{a}^{(j-1)} = \mathbf{a_{hi}^{(j)}} + \mathbf{a_{lo}^{(j)}}\cdot u_j^{-1}.$$
   The vectors $\mathbf{G}^{(j)}$ and $\mathbf{b}^{(j)}$ are similarly compressed to give
   $\mathbf{G}^{(j-1)}$ and $\mathbf{b}^{(j-1)}$ (using $u_j$ instead of $u_j^{-1}$).


### PR DESCRIPTION
The [book](https://github.com/zcash/halo2/blob/main/book/src/background/pc-ipa.md) does not match the [implementation](https://github.com/zcash/halo2/blob/main/halo2_proofs/src/poly/commitment/prover.rs#L128) for the compression of `a`, `b` and `G`.

Following the notation for `high` and `low`, `a` is computed using `a_hi + a_lo * u^{-1}`.