### PR TITLE
[doc] commitment::verifier: verify_proof does not have [-c]G term

### DIFF
--- a/halo2_proofs/src/poly/commitment/verifier.rs
+++ b/halo2_proofs/src/poly/commitment/verifier.rs
@@ -119,6 +119,9 @@ pub fn verify_proof<'a, C: CurveAffine, E: EncodedChallenge<C>, T: TranscriptRea
     //   P' + \sum([u_j^{-1}] L_j) + \sum([u_j] R_j)
     //   + [-c] G'_0 + [-cbz] U + [-f] W
     //   = 0
+    //
+    // Note that the guard returned from this function does not include
+    // the [-c]G'_0 term.
 
     let c = transcript.read_scalar().map_err(|_| Error::SamplingError)?;
     let neg_c = -c;


### PR DESCRIPTION
Document that `verify_proof` returns a `Guard` containing an `MSM` that does not include the `[-c]G` term.