### PR TITLE
chore: instance columns for poseidon bench

### DIFF
--- a/halo2_gadgets/benches/poseidon.rs
+++ b/halo2_gadgets/benches/poseidon.rs
@@ -172,11 +172,9 @@ fn bench_poseidon<S, const WIDTH: usize, const RATE: usize, const L: usize>(
         _spec: PhantomData,
     };
 
-    // Create a proof
-    let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-
     c.bench_function(&prover_name, |b| {
         b.iter(|| {
+            let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
             create_proof(
                 &params,
                 &pk,
@@ -189,6 +187,17 @@ fn bench_poseidon<S, const WIDTH: usize, const RATE: usize, const L: usize>(
         })
     });
 
+    // Create a proof
+    let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
+    create_proof(
+        &params,
+        &pk,
+        &[circuit],
+        &[&[&[output]]],
+        &mut rng,
+        &mut transcript,
+    )
+    .expect("proof generation should not fail");
     let proof = transcript.finalize();
 
     c.bench_function(&verifier_name, |b| {


### PR DESCRIPTION
Noticed a small lingering todo in `halo2_gadgets/benches/poseidon.rs` to move the outputs from a `Value` to an instance column. This PR does just that ! 

- [x] replaces `HashCircuit.output`, which is of type `Value<Fp>`, with  `MyConfig.expected` of type `Column<Instance>`. 
- [x] tested full suite of benchmarks 
- [x] ran `clippy`  

Resolves #711