### PR TITLE
Book PDF generation

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -12,3 +12,20 @@ title = "The halo2 Book"
 
 [preprocessor.katex]
 macros = "macros.txt"
+renderers = ["html"]
+
+[output.katex]
+
+[output.html]
+
+[output.html.print]
+# Disable page break
+page-break = false
+
+[output.pdf]
+display-header-footer = true
+header-template = "<span></span>"
+footer-template = "<p style='font-size:10px; margin-left: 48%'><span class='pageNumber'></span> / <span class='totalPages'></span></p>"
+
+[output.pdf-outline]
+like-wkhtmltopdf = false


### PR DESCRIPTION
Resolve #692

Install dependencies:
```bash
pip3 install mdbook-pdf-outline
cargo install mdbook-katex mdbook-pdf
# Patched mdbook for fixing broken links in print.html
git clone https://github.com/HollowMan6/mdBook
cd mdBook && cargo install --path . --force
```

Ensure chrome / edge is available in your system, then run `mdbook build`.

Generated PDFs:

[book-without-linebreak.pdf](https://github.com/zcash/halo2/files/10310764/book-without-linebreak.pdf)
[book-with-linebreak.pdf](https://github.com/zcash/halo2/files/10310765/book-with-linebreak.pdf)

Signed-off-by: Hollow Man <hollowman@opensuse.org>