### PR TITLE
Fix book deploying CI and add pdf uploading

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -15,16 +15,27 @@ jobs:
           toolchain: nightly
           override: true
 
-      - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@v1
-        with:
-          mdbook-version: 'latest'
+      # - name: Setup mdBook
+      #   uses: peaceiris/actions-mdbook@v1
+      #   with:
+      #     mdbook-version: 'latest'
 
-      - name: Install mdbook-katex
+      # mdBook for mdbook-pdf compatibility by fixing broken links in print.html
+      # Waiting for https://github.com/rust-lang/mdBook/pull/1738 to get merged
+      - name: Clone patched mdbook source code
+        run: cd .. && git clone https://github.com/HollowMan6/mdBook
+
+      - name: Install patched mdbook
+        run: cd ../mdBook && cargo install --path . --force
+
+      - name: Install mdbook-katex and mdbook-pdf
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: mdbook-katex
+          args: mdbook-katex mdbook-pdf
+
+      - name: Install mdbook-pdf-outline
+        run: pip3 install mdbook-pdf-outline
 
       - name: Build halo2 book
         run: mdbook build book/
@@ -47,3 +58,9 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./book/book
+
+      - name: Upload PDF File to Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: The_halo2_Book
+          path: book/book/pdf-outline/*.pdf

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -22,11 +22,11 @@ jobs:
 
       # mdBook for mdbook-pdf compatibility by fixing broken links in print.html
       # Waiting for https://github.com/rust-lang/mdBook/pull/1738 to get merged
-      - name: Clone patched mdbook source code
-        run: cd .. && git clone https://github.com/HollowMan6/mdBook
-
       - name: Install patched mdbook
-        run: cd ../mdBook && cargo install --path . --force
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: mdbook --git https://github.com/HollowMan6/mdBook.git --rev 62e01b34c23b957579c04ee1b24b57814ed8a4d5
 
       - name: Install mdbook-katex and mdbook-pdf
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
Continuation of #713 

Hi! Sorry I didn't notice that there's a CI for book deploying.

This PR should fix book deploying CI. I've also added the pdf uploading functionality, so that readers now can download the pdf books directly from the GitHub Actions Artifacts.

Signed-off-by: Hollow Man <hollowman@opensuse.org>