### PR TITLE
Constrain `inferno` transitive dependency to our MSRV

### DIFF
--- a/halo2_gadgets/Cargo.toml
+++ b/halo2_gadgets/Cargo.toml
@@ -42,6 +42,7 @@ criterion = "0.3"
 proptest = "1.0.0"
 
 [target.'cfg(unix)'.dev-dependencies]
+inferno = ">=0.11, <0.11.5" # MSRV 1.59
 pprof = { version = "0.8", features = ["criterion", "flamegraph"] } # MSRV 1.56
 
 [lib]


### PR DESCRIPTION
`inferno 0.11.5` raised its MSRV to 1.64.0. Adding this range constraint is fine because it's only a dev-dependency.