### PR TITLE
chore: Speed up random poly generation

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -52,6 +52,7 @@ rand_core = { version = "0.6", default-features = false }
 tracing = "0.1"
 blake2b_simd = "1"
 maybe-rayon = {version = "0.1.0", default-features = false}
+rand_chacha = { version = "0.3", optional = true }
 
 # Developer tooling dependencies
 plotters = { version = "0.3.0", default-features = false, optional = true }
@@ -69,7 +70,7 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [features]
 default = ["batch", "multicore"]
-multicore = ["maybe-rayon/threads"]
+multicore = ["maybe-rayon/threads", "rand_chacha"]
 dev-graph = ["plotters", "tabbycat"]
 test-dev-graph = [
     "dev-graph",

--- a/halo2_proofs/src/poly.rs
+++ b/halo2_proofs/src/poly.rs
@@ -130,6 +130,14 @@ impl<F, B> Polynomial<F, B> {
     pub fn num_coeffs(&self) -> usize {
         self.values.len()
     }
+
+    /// Allows to create a Polynomial from a Vec.
+    pub fn from_evals(vector: Vec<F>) -> Self {
+        Polynomial {
+            values: vector,
+            _marker: PhantomData,
+        }
+    }
 }
 
 pub(crate) fn batch_invert_assigned<F: Field>(

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -19,7 +19,7 @@ use std::marker::PhantomData;
 #[derive(Clone, Debug)]
 pub struct EvaluationDomain<F: Field> {
     n: u64,
-    k: u32,
+    pub(crate) k: u32,
     extended_k: u32,
     omega: F,
     omega_inv: F,


### PR DESCRIPTION
As noted in
https://github.com/privacy-scaling-explorations/halo2/issues/151 the generation of a random poly for degrees bigger than 20 starts to get quite slow.

This PR tries to include some minimal changes in the `commit` fn so that we upstream the improvements achieved in PSE/halo2

Here I forward the benches that I implemented in the PSE PR:
<details>

```
Blinder_poly/serial/18  time:   [28.717 ms 28.779 ms 28.860 ms]                                   
                        change: [+0.0164% +0.2972% +0.5927%] (p = 0.05 < 0.05)
                       
Blinder_poly/parallel/18                                                                             
                        time:   [2.4532 ms 2.4792 ms 2.5064 ms]
                        change: [+0.7593% +2.2239% +3.7108%] (p = 0.00 < 0.05)
                        


Blinder_poly/serial/19  time:   [57.679 ms 57.764 ms 57.866 ms]                                   
                        change: [-1.1429% -0.7681% -0.4110%] (p = 0.00 < 0.05)
                        
Blinder_poly/parallel/19                                                                             
                        time:   [5.4919 ms 5.5360 ms 5.5832 ms]
                        change: [-0.2678% +0.8128% +1.9086%] (p = 0.14 > 0.05)
                        


Blinder_poly/serial/20  time:   [124.00 ms 124.12 ms 124.26 ms]                                   
                        change: [+0.4412% +0.6006% +0.7628%] (p = 0.00 < 0.05)
                        
Blinder_poly/parallel/20                                                                            
                        time:   [19.797 ms 19.868 ms 19.948 ms]
                        change: [-0.8847% -0.3244% +0.2474%] (p = 0.27 > 0.05)
                        


Blinder_poly/serial/21  time:   [243.33 ms 245.28 ms 246.94 ms]                                   
                        change: [-1.4546% -0.6227% +0.0895%] (p = 0.11 > 0.05)
                       
Blinder_poly/parallel/21                                                                            
                        time:   [42.218 ms 44.177 ms 46.453 ms]
                        change: [+4.8431% +9.3787% +14.967%] (p = 0.00 < 0.05)
                        


Blinder_poly/serial/22  time:   [496.53 ms 497.06 ms 497.65 ms]                                   
                        change: [+0.0300% +0.3798% +0.6700%] (p = 0.02 < 0.05)
                       
Blinder_poly/parallel/22                                                                            
                        time:   [79.689 ms 79.914 ms 80.162 ms]
                        change: [-7.9753% -4.9272% -2.8485%] (p = 0.00 < 0.05)
                        
```

</details>

Also leaving CPU info in case is useful:
```
Model name:            Intel(R) Core(TM) i9-10885H CPU @ 2.40GHz
    CPU family:          6
    Model:               165
    Thread(s) per core:  2
    Core(s) per socket:  8
```