### PR TITLE
Add `no_floating_points` feature flag.

### DIFF
--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -69,6 +69,7 @@ getrandom = { version = "0.2", features = ["js"] }
 
 [features]
 default = ["batch", "multicore"]
+no_floating_points = []
 multicore = ["maybe-rayon/threads"]
 dev-graph = ["plotters", "tabbycat"]
 test-dev-graph = [


### PR DESCRIPTION
We're exploring the usage of halo2 in the context of ACTUS standard implementation and found the usage of floating points prohibitive in our use case. This contribution should make the halo2_proofs code more universal across different operating systems and architectures.

With this flag turned on, the halo2_proofs crate can be compiled into Wasm, and the resulting binary will not use any floating point operations.

The code to generate the table is here https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=cb4b6564b60d0ad65243679f3203fa77 - it's using a binary search to find the lowest argument to the ceil(ln(x)) function in 1..2^64-1 space, that produces the exponent it's looking for. The linked code, and this commit contain relevant tests to ensure the lookup table is correct.