### PR TITLE
`dev::cost`: Handle cost calculation for circuits without permutation

### DIFF
--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -506,3 +506,38 @@ impl<G: PrimeGroup> From<ProofSize<G>> for usize {
             + proof.polycomm.len(point, scalar)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use pasta_curves::{Eq, Fp};
+
+    use crate::circuit::SimpleFloorPlanner;
+
+    use super::*;
+
+    #[test]
+    fn circuit_cost_without_permutation() {
+        const K: u32 = 4;
+
+        struct MyCircuit;
+        impl Circuit<Fp> for MyCircuit {
+            type Config = ();
+            type FloorPlanner = SimpleFloorPlanner;
+
+            fn without_witnesses(&self) -> Self {
+                Self
+            }
+
+            fn configure(_meta: &mut ConstraintSystem<Fp>) -> Self::Config {}
+
+            fn synthesize(
+                &self,
+                _config: Self::Config,
+                _layouter: impl crate::circuit::Layouter<Fp>,
+            ) -> Result<(), Error> {
+                Ok(())
+            }
+        }
+        CircuitCost::<Eq, MyCircuit>::measure(K, &MyCircuit).proof_size(1);
+    }
+}

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -362,8 +362,11 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
 
             // Global permutation argument:
             // - chunks commitments per instance
-            // - 2*chunks + (chunks - 1) evals per instance
-            equality: ProofContribution::new(chunks, 3 * chunks - 1),
+            // - 2 * chunks + (chunks - 1) evals per instance
+            equality: ProofContribution::new(
+                chunks,
+                if chunks == 0 { chunks } else { 3 * chunks - 1 },
+            ),
 
             _marker: PhantomData::default(),
         }


### PR DESCRIPTION
Closes #748 