### PR TITLE
`plonk::Error::TableError`: Better lookup errors

### DIFF
--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -13,7 +13,7 @@ pub mod floor_planner;
 pub use floor_planner::single_pass::SimpleFloorPlanner;
 
 pub mod layouter;
-pub mod table_layouter;
+mod table_layouter;
 
 pub use table_layouter::TableLayouter;
 

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -13,6 +13,9 @@ pub mod floor_planner;
 pub use floor_planner::single_pass::SimpleFloorPlanner;
 
 pub mod layouter;
+pub mod table_layouter;
+
+pub use table_layouter::TableLayouter;
 
 /// A chip implements a set of instructions that can be used by gadgets.
 ///
@@ -365,11 +368,11 @@ impl<'r, F: Field> Region<'r, F> {
 /// A lookup table in the circuit.
 #[derive(Debug)]
 pub struct Table<'r, F: Field> {
-    table: &'r mut dyn layouter::TableLayouter<F>,
+    table: &'r mut dyn TableLayouter<F>,
 }
 
-impl<'r, F: Field> From<&'r mut dyn layouter::TableLayouter<F>> for Table<'r, F> {
-    fn from(table: &'r mut dyn layouter::TableLayouter<F>) -> Self {
+impl<'r, F: Field> From<&'r mut dyn TableLayouter<F>> for Table<'r, F> {
+    fn from(table: &'r mut dyn TableLayouter<F>) -> Self {
         Table { table }
     }
 }

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -7,8 +7,9 @@ use ff::Field;
 
 use crate::{
     circuit::{
-        layouter::{RegionColumn, RegionLayouter, RegionShape, TableLayouter},
-        Cell, Layouter, Region, RegionIndex, RegionStart, Table, Value,
+        layouter::{RegionColumn, RegionLayouter, RegionShape},
+        table_layouter::SimpleTableLayouter,
+        Cell, Layouter, Region, RegionIndex, RegionStart, Table, TableLayouter, Value,
     },
     plonk::{
         Advice, Any, Assigned, Assignment, Circuit, Column, Error, Fixed, FloorPlanner, Instance,
@@ -373,86 +374,6 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> RegionLayouter<F>
             right.column,
             *self.layouter.regions[*right.region_index] + right.row_offset,
         )?;
-
-        Ok(())
-    }
-}
-
-/// The default value to fill a table column with.
-///
-/// - The outer `Option` tracks whether the value in row 0 of the table column has been
-///   assigned yet. This will always be `Some` once a valid table has been completely
-///   assigned.
-/// - The inner `Value` tracks whether the underlying `Assignment` is evaluating
-///   witnesses or not.
-type DefaultTableValue<F> = Option<Value<Assigned<F>>>;
-
-pub(crate) struct SimpleTableLayouter<'r, 'a, F: Field, CS: Assignment<F> + 'a> {
-    cs: &'a mut CS,
-    used_columns: &'r [TableColumn],
-    // maps from a fixed column to a pair (default value, vector saying which rows are assigned)
-    pub(crate) default_and_assigned: HashMap<TableColumn, (DefaultTableValue<F>, Vec<bool>)>,
-}
-
-impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> fmt::Debug for SimpleTableLayouter<'r, 'a, F, CS> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("SimpleTableLayouter")
-            .field("used_columns", &self.used_columns)
-            .field("default_and_assigned", &self.default_and_assigned)
-            .finish()
-    }
-}
-
-impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> SimpleTableLayouter<'r, 'a, F, CS> {
-    pub(crate) fn new(cs: &'a mut CS, used_columns: &'r [TableColumn]) -> Self {
-        SimpleTableLayouter {
-            cs,
-            used_columns,
-            default_and_assigned: HashMap::default(),
-        }
-    }
-}
-
-impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
-    for SimpleTableLayouter<'r, 'a, F, CS>
-{
-    fn assign_cell<'v>(
-        &'v mut self,
-        annotation: &'v (dyn Fn() -> String + 'v),
-        column: TableColumn,
-        offset: usize,
-        to: &'v mut (dyn FnMut() -> Value<Assigned<F>> + 'v),
-    ) -> Result<(), Error> {
-        if self.used_columns.contains(&column) {
-            return Err(Error::Synthesis); // TODO better error
-        }
-
-        let entry = self.default_and_assigned.entry(column).or_default();
-
-        let mut value = Value::unknown();
-        self.cs.assign_fixed(
-            annotation,
-            column.inner(),
-            offset, // tables are always assigned starting at row 0
-            || {
-                let res = to();
-                value = res;
-                res
-            },
-        )?;
-
-        match (entry.0.is_none(), offset) {
-            // Use the value at offset 0 as the default value for this table column.
-            (true, 0) => entry.0 = Some(value),
-            // Since there is already an existing default value for this table column,
-            // the caller should not be attempting to assign another value at offset 0.
-            (false, 0) => return Err(Error::Synthesis), // TODO better error
-            _ => (),
-        }
-        if entry.1.len() <= offset {
-            entry.1.resize(offset + 1, false);
-        }
-        entry.1[offset] = true;
 
         Ok(())
     }

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -8,7 +8,7 @@ use ff::Field;
 use crate::{
     circuit::{
         layouter::{RegionColumn, RegionLayouter, RegionShape},
-        table_layouter::SimpleTableLayouter,
+        table_layouter::{compute_table_lengths, SimpleTableLayouter},
         Cell, Layouter, Region, RegionIndex, RegionStart, Table, TableLayouter, Value,
     },
     plonk::{
@@ -166,24 +166,7 @@ impl<'a, F: Field, CS: Assignment<F> + 'a> Layouter<F> for SingleChipLayouter<'a
 
         // Check that all table columns have the same length `first_unused`,
         // and all cells up to that length are assigned.
-        let first_unused = {
-            match default_and_assigned
-                .values()
-                .map(|(_, assigned)| {
-                    if assigned.iter().all(|b| *b) {
-                        Some(assigned.len())
-                    } else {
-                        None
-                    }
-                })
-                .reduce(|acc, item| match (acc, item) {
-                    (Some(a), Some(b)) if a == b => Some(a),
-                    _ => None,
-                }) {
-                Some(Some(len)) => len,
-                _ => return Err(Error::Synthesis), // TODO better error
-            }
-        };
+        let first_unused = compute_table_lengths(&default_and_assigned)?;
 
         // Record these columns so that we can prevent them from being used again.
         for column in default_and_assigned.keys() {

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -4,9 +4,9 @@ use ff::Field;
 
 use crate::{
     circuit::{
-        floor_planner::single_pass::SimpleTableLayouter,
-        layouter::{RegionColumn, RegionLayouter, RegionShape, TableLayouter},
-        Cell, Layouter, Region, RegionIndex, RegionStart, Table, Value,
+        layouter::{RegionColumn, RegionLayouter, RegionShape},
+        table_layouter::SimpleTableLayouter,
+        Cell, Layouter, Region, RegionIndex, RegionStart, Table, TableLayouter, Value,
     },
     plonk::{
         Advice, Any, Assigned, Assignment, Circuit, Column, Error, Fixed, FloorPlanner, Instance,

--- a/halo2_proofs/src/circuit/layouter.rs
+++ b/halo2_proofs/src/circuit/layouter.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use ff::Field;
 
 use super::{Cell, RegionIndex, Value};
-use crate::plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector, TableColumn};
+use crate::plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector};
 
 /// Helper trait for implementing a custom [`Layouter`].
 ///
@@ -107,24 +107,6 @@ pub trait RegionLayouter<F: Field>: fmt::Debug {
     ///
     /// Returns an error if either of the cells is not within the given permutation.
     fn constrain_equal(&mut self, left: Cell, right: Cell) -> Result<(), Error>;
-}
-
-/// Helper trait for implementing a custom [`Layouter`].
-///
-/// This trait is used for implementing table assignments.
-///
-/// [`Layouter`]: super::Layouter
-pub trait TableLayouter<F: Field>: fmt::Debug {
-    /// Assigns a fixed value to a table cell.
-    ///
-    /// Returns an error if the table cell has already been assigned to.
-    fn assign_cell<'v>(
-        &'v mut self,
-        annotation: &'v (dyn Fn() -> String + 'v),
-        column: TableColumn,
-        offset: usize,
-        to: &'v mut (dyn FnMut() -> Value<Assigned<F>> + 'v),
-    ) -> Result<(), Error>;
 }
 
 /// The shape of a region. For a region at a certain index, we track

--- a/halo2_proofs/src/circuit/layouter.rs
+++ b/halo2_proofs/src/circuit/layouter.rs
@@ -6,6 +6,7 @@ use std::fmt;
 
 use ff::Field;
 
+pub use super::table_layouter::TableLayouter;
 use super::{Cell, RegionIndex, Value};
 use crate::plonk::{Advice, Any, Assigned, Column, Error, Fixed, Instance, Selector};
 

--- a/halo2_proofs/src/circuit/table_layouter.rs
+++ b/halo2_proofs/src/circuit/table_layouter.rs
@@ -1,0 +1,107 @@
+//! Implementations of common table layouters.
+
+use std::{collections::HashMap, fmt};
+
+use ff::Field;
+
+use crate::plonk::{Assigned, Assignment, Error, TableColumn};
+
+use super::Value;
+
+/// Helper trait for implementing a custom [`Layouter`].
+///
+/// This trait is used for implementing table assignments.
+///
+/// [`Layouter`]: super::Layouter
+pub trait TableLayouter<F: Field>: std::fmt::Debug {
+    /// Assigns a fixed value to a table cell.
+    ///
+    /// Returns an error if the table cell has already been assigned to.
+    fn assign_cell<'v>(
+        &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
+        column: TableColumn,
+        offset: usize,
+        to: &'v mut (dyn FnMut() -> Value<Assigned<F>> + 'v),
+    ) -> Result<(), Error>;
+}
+
+/// The default value to fill a table column with.
+///
+/// - The outer `Option` tracks whether the value in row 0 of the table column has been
+///   assigned yet. This will always be `Some` once a valid table has been completely
+///   assigned.
+/// - The inner `Value` tracks whether the underlying `Assignment` is evaluating
+///   witnesses or not.
+type DefaultTableValue<F> = Option<Value<Assigned<F>>>;
+
+pub(crate) struct SimpleTableLayouter<'r, 'a, F: Field, CS: Assignment<F> + 'a> {
+    cs: &'a mut CS,
+    used_columns: &'r [TableColumn],
+    // maps from a fixed column to a pair (default value, vector saying which rows are assigned)
+    pub(crate) default_and_assigned: HashMap<TableColumn, (DefaultTableValue<F>, Vec<bool>)>,
+}
+
+impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> fmt::Debug for SimpleTableLayouter<'r, 'a, F, CS> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SimpleTableLayouter")
+            .field("used_columns", &self.used_columns)
+            .field("default_and_assigned", &self.default_and_assigned)
+            .finish()
+    }
+}
+
+impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> SimpleTableLayouter<'r, 'a, F, CS> {
+    pub(crate) fn new(cs: &'a mut CS, used_columns: &'r [TableColumn]) -> Self {
+        SimpleTableLayouter {
+            cs,
+            used_columns,
+            default_and_assigned: HashMap::default(),
+        }
+    }
+}
+
+impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
+    for SimpleTableLayouter<'r, 'a, F, CS>
+{
+    fn assign_cell<'v>(
+        &'v mut self,
+        annotation: &'v (dyn Fn() -> String + 'v),
+        column: TableColumn,
+        offset: usize,
+        to: &'v mut (dyn FnMut() -> Value<Assigned<F>> + 'v),
+    ) -> Result<(), Error> {
+        if self.used_columns.contains(&column) {
+            return Err(Error::Synthesis); // TODO better error
+        }
+
+        let entry = self.default_and_assigned.entry(column).or_default();
+
+        let mut value = Value::unknown();
+        self.cs.assign_fixed(
+            annotation,
+            column.inner(),
+            offset, // tables are always assigned starting at row 0
+            || {
+                let res = to();
+                value = res;
+                res
+            },
+        )?;
+
+        match (entry.0.is_none(), offset) {
+            // Use the value at offset 0 as the default value for this table column.
+            (true, 0) => entry.0 = Some(value),
+            // Since there is already an existing default value for this table column,
+            // the caller should not be attempting to assign another value at offset 0.
+            (false, 0) => return Err(Error::Synthesis), // TODO better error
+            _ => (),
+        }
+        if entry.1.len() <= offset {
+            entry.1.resize(offset + 1, false);
+        }
+        entry.1[offset] = true;
+
+        Ok(())
+    }
+}

--- a/halo2_proofs/src/circuit/table_layouter.rs
+++ b/halo2_proofs/src/circuit/table_layouter.rs
@@ -105,3 +105,24 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
         Ok(())
     }
 }
+
+pub(crate) fn compute_table_lengths<F>(
+    default_and_assigned: &HashMap<TableColumn, (DefaultTableValue<F>, Vec<bool>)>,
+) -> Result<usize, Error> {
+    match default_and_assigned
+        .values()
+        .map(|(_, assigned)| {
+            if assigned.iter().all(|b| *b) {
+                Some(assigned.len())
+            } else {
+                None
+            }
+        })
+        .reduce(|acc, item| match (acc, item) {
+            (Some(a), Some(b)) if a == b => Some(a),
+            _ => None,
+        }) {
+        Some(Some(len)) => Ok(len),
+        _ => return Err(Error::Synthesis), // TODO better error
+    }
+}

--- a/halo2_proofs/src/plonk/circuit.rs
+++ b/halo2_proofs/src/plonk/circuit.rs
@@ -311,7 +311,7 @@ pub struct InstanceQuery {
 /// they cannot simultaneously be used as general fixed columns.
 ///
 /// [`Layouter::assign_table`]: crate::circuit::Layouter::assign_table
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Ord, PartialOrd)]
 pub struct TableColumn {
     /// The fixed column that this table column is stored in.
     ///

--- a/halo2_proofs/src/plonk/error.rs
+++ b/halo2_proofs/src/plonk/error.rs
@@ -2,6 +2,7 @@ use std::error;
 use std::fmt;
 use std::io;
 
+use super::TableColumn;
 use super::{Any, Column};
 
 /// This is an error that could occur during proving or circuit synthesis.
@@ -37,6 +38,8 @@ pub enum Error {
     /// The instance sets up a copy constraint involving a column that has not been
     /// included in the permutation.
     ColumnNotInPermutation(Column<Any>),
+    /// An error relating to a lookup table.
+    TableError(TableError),
 }
 
 impl From<io::Error> for Error {
@@ -79,6 +82,7 @@ impl fmt::Display for Error {
                 "Column {:?} must be included in the permutation. Help: try applying `meta.enable_equalty` on the column",
                 column
             ),
+            Error::TableError(error) => write!(f, "{}", error)
         }
     }
 }
@@ -88,6 +92,48 @@ impl error::Error for Error {
         match self {
             Error::Transcript(e) => Some(e),
             _ => None,
+        }
+    }
+}
+
+/// This is an error that could occur during table synthesis.
+#[derive(Debug)]
+pub enum TableError {
+    /// A `TableColumn` has not been assigned.
+    ColumnNotAssigned(TableColumn),
+    /// A Table has columns of uneven lengths.
+    UnevenColumnLengths((TableColumn, usize), (TableColumn, usize)),
+    /// Attempt to assign a used `TableColumn`
+    UsedColumn(TableColumn),
+    /// Attempt to overwrite a default value
+    OverwriteDefault(TableColumn, String, String),
+}
+
+impl fmt::Display for TableError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TableError::ColumnNotAssigned(col) => {
+                write!(
+                    f,
+                    "{:?} not fully assigned. Help: assign a value at offset 0.",
+                    col
+                )
+            }
+            TableError::UnevenColumnLengths((col, col_len), (table, table_len)) => write!(
+                f,
+                "{:?} has length {} while {:?} has length {}",
+                col, col_len, table, table_len
+            ),
+            TableError::UsedColumn(col) => {
+                write!(f, "{:?} has already been used", col)
+            }
+            TableError::OverwriteDefault(col, default, val) => {
+                write!(
+                    f,
+                    "Attempted to overwrite default value {} with {} in {:?}",
+                    default, val, col
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
"All good lookups are alike, but every bad lookup is bad in its own way" - @nalinbhardwaj

Supersedes #750, inspired by https://github.com/zcash/halo2/pull/750#discussion_r1141000039. 