### PR TITLE
Make `Error` a non_exhaustive type.

### DIFF
--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -57,6 +57,7 @@ and this project adheres to Rust's notion of
       `Column<Fixed>` variant.
     - `query_fixed` now no longer takes a `Rotation` argument,
       and can only be used to query the current rotation.
+  - `Error` is now a [`non_exhaustive`](https://doc.rust-lang.org/reference/attributes/type_system.html) type.
 
 ## [0.2.0] - 2022-06-23
 ### Added

--- a/halo2_proofs/src/plonk/error.rs
+++ b/halo2_proofs/src/plonk/error.rs
@@ -6,6 +6,7 @@ use super::{Any, Column};
 
 /// This is an error that could occur during proving or circuit synthesis.
 // TODO: these errors need to be cleaned up
+#[non_exhaustive]
 #[derive(Debug)]
 pub enum Error {
     /// This is an error that can occur during synthesis of the circuit, for


### PR DESCRIPTION
This allows us to add new variants in point releases.