### PR TITLE
Update rust-toolchain to 1.61.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.61.0"


### PR DESCRIPTION
This is needed for the package `image v0.24.6`.