### PR TITLE
Split `ConstraintSystem` into a builder type and a verifying key type

### DIFF
--- a/halo2_gadgets/benches/poseidon.rs
+++ b/halo2_gadgets/benches/poseidon.rs
@@ -4,7 +4,7 @@ use halo2_proofs::{
     pasta::Fp,
     plonk::{
         create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Circuit, Column,
-        ConstraintSystem, Error, Instance, SingleVerifier,
+        ConstraintSystemBuilder, Error, Instance, SingleVerifier,
     },
     poly::commitment::Params,
     transcript::{Blake2bRead, Blake2bWrite, Challenge255},
@@ -52,7 +52,7 @@ where
         }
     }
 
-    fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystemBuilder<Fp>) -> Self::Config {
         let state = (0..WIDTH).map(|_| meta.advice_column()).collect::<Vec<_>>();
         let expected = meta.instance_column();
         meta.enable_equality(expected);

--- a/halo2_gadgets/benches/sha256.rs
+++ b/halo2_gadgets/benches/sha256.rs
@@ -2,7 +2,7 @@ use halo2_proofs::{
     circuit::{Layouter, SimpleFloorPlanner, Value},
     pasta::{pallas, EqAffine},
     plonk::{
-        create_proof, keygen_pk, keygen_vk, verify_proof, Circuit, ConstraintSystem, Error,
+        create_proof, keygen_pk, keygen_vk, verify_proof, Circuit, ConstraintSystemBuilder, Error,
         SingleVerifier,
     },
     poly::commitment::Params,
@@ -32,7 +32,7 @@ fn bench(name: &str, k: u32, c: &mut Criterion) {
             Self::default()
         }
 
-        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+        fn configure(meta: &mut ConstraintSystemBuilder<pallas::Base>) -> Self::Config {
             Table16Chip::configure(meta)
         }
 

--- a/halo2_gadgets/src/ecc.rs
+++ b/halo2_gadgets/src/ecc.rs
@@ -583,7 +583,7 @@ pub(crate) mod tests {
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
-        plonk::{Circuit, ConstraintSystem, Error},
+        plonk::{Circuit, ConstraintSystemBuilder, Error},
     };
     use lazy_static::lazy_static;
     use pasta_curves::pallas;
@@ -736,7 +736,7 @@ pub(crate) mod tests {
             MyCircuit { test_errors: false }
         }
 
-        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+        fn configure(meta: &mut ConstraintSystemBuilder<pallas::Base>) -> Self::Config {
             let advices = [
                 meta.advice_column(),
                 meta.advice_column(),

--- a/halo2_gadgets/src/ecc/chip.rs
+++ b/halo2_gadgets/src/ecc/chip.rs
@@ -11,7 +11,7 @@ use ff::PrimeField;
 use group::prime::PrimeCurveAffine;
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter, Value},
-    plonk::{Advice, Assigned, Column, ConstraintSystem, Error, Fixed},
+    plonk::{Advice, Assigned, Column, ConstraintSystemBuilder, Error, Fixed},
 };
 use pasta_curves::{arithmetic::CurveAffine, pallas};
 
@@ -261,7 +261,7 @@ impl<FixedPoints: super::FixedPoints<pallas::Affine>> EccChip<FixedPoints> {
     /// All columns in `advices` will be equality-enabled.
     #[allow(non_snake_case)]
     pub fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         advices: [Column<Advice>; 10],
         lagrange_coeffs: [Column<Fixed>; 8],
         range_check: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,

--- a/halo2_gadgets/src/ecc/chip/add.rs
+++ b/halo2_gadgets/src/ecc/chip/add.rs
@@ -3,7 +3,9 @@ use super::EccPoint;
 use group::ff::PrimeField;
 use halo2_proofs::{
     circuit::Region,
-    plonk::{Advice, Assigned, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
+    plonk::{
+        Advice, Assigned, Column, ConstraintSystemBuilder, Constraints, Error, Expression, Selector,
+    },
     poly::Rotation,
 };
 use pasta_curves::pallas;
@@ -36,7 +38,7 @@ pub struct Config {
 impl Config {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         x_p: Column<Advice>,
         y_p: Column<Advice>,
         x_qr: Column<Advice>,
@@ -74,7 +76,7 @@ impl Config {
         [self.x_qr, self.y_qr].into_iter().collect()
     }
 
-    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         // https://p.z.cash/halo2-0.1:ecc-complete-addition
         meta.create_gate("complete addition", |meta| {
             let q_add = meta.query_selector(self.q_add);

--- a/halo2_gadgets/src/ecc/chip/add_incomplete.rs
+++ b/halo2_gadgets/src/ecc/chip/add_incomplete.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use super::NonIdentityEccPoint;
 use halo2_proofs::{
     circuit::Region,
-    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystemBuilder, Constraints, Error, Selector},
     poly::Rotation,
 };
 use pasta_curves::pallas;
@@ -23,7 +23,7 @@ pub struct Config {
 
 impl Config {
     pub(super) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         x_p: Column<Advice>,
         y_p: Column<Advice>,
         x_qr: Column<Advice>,
@@ -53,7 +53,7 @@ impl Config {
             .collect()
     }
 
-    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         // https://p.z.cash/halo2-0.1:ecc-incomplete-addition
         meta.create_gate("incomplete addition", |meta| {
             let q_add_incomplete = meta.query_selector(self.q_add_incomplete);

--- a/halo2_gadgets/src/ecc/chip/mul.rs
+++ b/halo2_gadgets/src/ecc/chip/mul.rs
@@ -11,7 +11,7 @@ use std::{
 use ff::{Field, PrimeField};
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Region, Value},
-    plonk::{Advice, Assigned, Column, ConstraintSystem, Constraints, Error, Selector},
+    plonk::{Advice, Assigned, Column, ConstraintSystemBuilder, Constraints, Error, Selector},
     poly::Rotation,
 };
 use uint::construct_uint;
@@ -63,7 +63,7 @@ pub struct Config {
 
 impl Config {
     pub(super) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         add_config: add::Config,
         lookup_config: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
         advices: [Column<Advice>; 10],
@@ -126,7 +126,7 @@ impl Config {
         config
     }
 
-    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         // If `lsb` is 0, (x, y) = (x_p, -y_p). If `lsb` is 1, (x, y) = (0,0).
         // https://p.z.cash/halo2-0.1:ecc-var-mul-lsb-gate?partial
         meta.create_gate("LSB check", |meta| {

--- a/halo2_gadgets/src/ecc/chip/mul/complete.rs
+++ b/halo2_gadgets/src/ecc/chip/mul/complete.rs
@@ -4,7 +4,7 @@ use crate::utilities::{bool_check, ternary};
 
 use halo2_proofs::{
     circuit::{Region, Value},
-    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
+    plonk::{Advice, Column, ConstraintSystemBuilder, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
 
@@ -22,7 +22,7 @@ pub struct Config {
 
 impl Config {
     pub(super) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         z_complete: Column<Advice>,
         add_config: add::Config,
     ) -> Self {
@@ -43,7 +43,7 @@ impl Config {
     /// This is used to check the bits used in complete addition, since the incomplete
     /// addition gate (controlled by `q_mul`) already checks scalar decomposition for
     /// the other bits.
-    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         // | y_p | z_complete |
         // --------------------
         // | y_p | z_{i + 1}  |

--- a/halo2_gadgets/src/ecc/chip/mul/incomplete.rs
+++ b/halo2_gadgets/src/ecc/chip/mul/incomplete.rs
@@ -6,7 +6,8 @@ use group::ff::PrimeField;
 use halo2_proofs::{
     circuit::{Region, Value},
     plonk::{
-        Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector, VirtualCells,
+        Advice, Column, ConstraintSystemBuilder, Constraints, Error, Expression, Selector,
+        VirtualCells,
     },
     poly::Rotation,
 };
@@ -73,7 +74,7 @@ pub(crate) struct Config<const NUM_BITS: usize> {
 
 impl<const NUM_BITS: usize> Config<NUM_BITS> {
     pub(super) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         z: Column<Advice>,
         x_a: Column<Advice>,
         x_p: Column<Advice>,
@@ -104,7 +105,7 @@ impl<const NUM_BITS: usize> Config<NUM_BITS> {
     }
 
     // Gate for incomplete addition part of variable-base scalar multiplication.
-    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         // Closure to compute x_{R,i} = λ_{1,i}^2 - x_{A,i} - x_{P,i}
         let x_r = |meta: &mut VirtualCells<pallas::Base>, rotation: Rotation| {
             self.double_and_add.x_r(meta, rotation)

--- a/halo2_gadgets/src/ecc/chip/mul/overflow.rs
+++ b/halo2_gadgets/src/ecc/chip/mul/overflow.rs
@@ -7,7 +7,9 @@ use group::ff::PrimeField;
 use halo2_proofs::circuit::AssignedCell;
 use halo2_proofs::{
     circuit::Layouter,
-    plonk::{Advice, Assigned, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
+    plonk::{
+        Advice, Assigned, Column, ConstraintSystemBuilder, Constraints, Error, Expression, Selector,
+    },
     poly::Rotation,
 };
 use pasta_curves::pallas;
@@ -26,7 +28,7 @@ pub struct Config {
 
 impl Config {
     pub(super) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         lookup_config: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
         advices: [Column<Advice>; 3],
     ) -> Self {
@@ -45,7 +47,7 @@ impl Config {
         config
     }
 
-    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         // https://p.z.cash/halo2-0.1:ecc-var-mul-overflow
         meta.create_gate("overflow checks", |meta| {
             let q_mul_overflow = meta.query_selector(self.q_mul_overflow);

--- a/halo2_gadgets/src/ecc/chip/mul_fixed.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed.rs
@@ -13,7 +13,7 @@ use group::{
 use halo2_proofs::{
     circuit::{AssignedCell, Region, Value},
     plonk::{
-        Advice, Column, ConstraintSystem, Constraints, Error, Expression, Fixed, Selector,
+        Advice, Column, ConstraintSystemBuilder, Constraints, Error, Expression, Fixed, Selector,
         VirtualCells,
     },
     poly::Rotation,
@@ -54,7 +54,7 @@ pub struct Config<FixedPoints: super::FixedPoints<pallas::Affine>> {
 impl<FixedPoints: super::FixedPoints<pallas::Affine>> Config<FixedPoints> {
     #[allow(clippy::too_many_arguments)]
     pub(super) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         lagrange_coeffs: [Column<Fixed>; H],
         window: Column<Advice>,
         u: Column<Advice>,
@@ -112,7 +112,7 @@ impl<FixedPoints: super::FixedPoints<pallas::Affine>> Config<FixedPoints> {
     /// This gate is not used in the mul_fixed::full_width helper, since the full-width
     /// scalar is witnessed directly as three-bit windows instead of being decomposed
     /// via a running sum.
-    fn running_sum_coords_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn running_sum_coords_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         meta.create_gate("Running sum coordinates check", |meta| {
             let q_mul_fixed_running_sum =
                 meta.query_selector(self.running_sum_config.q_range_check());

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/base_field_elem.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/base_field_elem.rs
@@ -10,7 +10,7 @@ use crate::{
 use group::ff::PrimeField;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter},
-    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Expression, Selector},
+    plonk::{Advice, Column, ConstraintSystemBuilder, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
 use pasta_curves::pallas;
@@ -27,7 +27,7 @@ pub struct Config<Fixed: FixedPoints<pallas::Affine>> {
 
 impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
     pub(crate) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         canon_advices: [Column<Advice>; 3],
         lookup_config: LookupRangeCheckConfig<pallas::Base, { sinsemilla::K }>,
         super_config: super::Config<Fixed>,
@@ -56,7 +56,7 @@ impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
         config
     }
 
-    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         // Check that the base field element is canonical.
         // https://p.z.cash/halo2-0.1:ecc-fixed-mul-base-canonicity
         meta.create_gate("Canonicity checks", |meta| {

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/full_width.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/full_width.rs
@@ -5,7 +5,7 @@ use arrayvec::ArrayVec;
 use ff::PrimeField;
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Region, Value},
-    plonk::{ConstraintSystem, Constraints, Error, Selector},
+    plonk::{ConstraintSystemBuilder, Constraints, Error, Selector},
     poly::Rotation,
 };
 use pasta_curves::pallas;
@@ -18,7 +18,7 @@ pub struct Config<Fixed: FixedPoints<pallas::Affine>> {
 
 impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
     pub(crate) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         super_config: super::Config<Fixed>,
     ) -> Self {
         let config = Self {
@@ -31,7 +31,7 @@ impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
         config
     }
 
-    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         // Check that each window `k` is within 3 bits
         // https://p.z.cash/halo2-0.1:ecc-fixed-mul-full-word
         meta.create_gate("Full-width fixed-base scalar mul", |meta| {

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -5,7 +5,7 @@ use crate::{ecc::chip::MagnitudeSign, utilities::bool_check};
 
 use halo2_proofs::{
     circuit::{Layouter, Region},
-    plonk::{ConstraintSystem, Constraints, Error, Expression, Selector},
+    plonk::{ConstraintSystemBuilder, Constraints, Error, Expression, Selector},
     poly::Rotation,
 };
 use pasta_curves::pallas;
@@ -19,7 +19,7 @@ pub struct Config<Fixed: FixedPoints<pallas::Affine>> {
 
 impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
     pub(crate) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         super_config: super::Config<Fixed>,
     ) -> Self {
         let config = Self {
@@ -32,7 +32,7 @@ impl<Fixed: FixedPoints<pallas::Affine>> Config<Fixed> {
         config
     }
 
-    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         // Gate contains the following constraints:
         // - https://p.z.cash/halo2-0.1:ecc-fixed-mul-short-msb
         // - https://p.z.cash/halo2-0.1:ecc-fixed-mul-short-conditional-neg
@@ -409,7 +409,7 @@ pub mod tests {
         use halo2_proofs::{
             circuit::{Layouter, SimpleFloorPlanner},
             dev::{FailureLocation, MockProver, VerifyFailure},
-            plonk::{Circuit, ConstraintSystem, Error},
+            plonk::{Circuit, ConstraintSystemBuilder, Error},
         };
 
         #[derive(Default)]
@@ -432,7 +432,7 @@ pub mod tests {
                 Self::default()
             }
 
-            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<pallas::Base>) -> Self::Config {
                 let advices = [
                     meta.advice_column(),
                     meta.advice_column(),

--- a/halo2_gadgets/src/ecc/chip/witness_point.rs
+++ b/halo2_gadgets/src/ecc/chip/witness_point.rs
@@ -5,8 +5,8 @@ use group::prime::PrimeCurveAffine;
 use halo2_proofs::{
     circuit::{AssignedCell, Region, Value},
     plonk::{
-        Advice, Assigned, Column, ConstraintSystem, Constraints, Error, Expression, Selector,
-        VirtualCells,
+        Advice, Assigned, Column, ConstraintSystemBuilder, Constraints, Error, Expression,
+        Selector, VirtualCells,
     },
     poly::Rotation,
 };
@@ -29,7 +29,7 @@ pub struct Config {
 
 impl Config {
     pub(super) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         x: Column<Advice>,
         y: Column<Advice>,
     ) -> Self {
@@ -45,7 +45,7 @@ impl Config {
         config
     }
 
-    fn create_gate(&self, meta: &mut ConstraintSystem<pallas::Base>) {
+    fn create_gate(&self, meta: &mut ConstraintSystemBuilder<pallas::Base>) {
         let curve_eqn = |meta: &mut VirtualCells<pallas::Base>| {
             let x = meta.query_advice(self.x, Rotation::cur());
             let y = meta.query_advice(self.y, Rotation::cur());

--- a/halo2_gadgets/src/poseidon/pow5.rs
+++ b/halo2_gadgets/src/poseidon/pow5.rs
@@ -5,7 +5,8 @@ use group::ff::Field;
 use halo2_proofs::{
     circuit::{AssignedCell, Cell, Chip, Layouter, Region, Value},
     plonk::{
-        Advice, Any, Column, ConstraintSystem, Constraints, Error, Expression, Fixed, Selector,
+        Advice, Any, Column, ConstraintSystemBuilder, Constraints, Error, Expression, Fixed,
+        Selector,
     },
     poly::Rotation,
 };
@@ -54,7 +55,7 @@ impl<F: Field, const WIDTH: usize, const RATE: usize> Pow5Chip<F, WIDTH, RATE> {
     // needs to be known wherever we implement the hashing gadget, but it isn't strictly
     // necessary for the permutation.
     pub fn configure<S: Spec<F, WIDTH, RATE>>(
-        meta: &mut ConstraintSystem<F>,
+        meta: &mut ConstraintSystemBuilder<F>,
         state: [Column<Advice>; WIDTH],
         partial_sbox: Column<Advice>,
         rc_a: [Column<Fixed>; WIDTH],
@@ -597,7 +598,7 @@ mod tests {
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
         pasta::Fp,
-        plonk::{Circuit, ConstraintSystem, Error},
+        plonk::{Circuit, ConstraintSystemBuilder, Error},
     };
     use pasta_curves::pallas;
     use rand::rngs::OsRng;
@@ -624,7 +625,7 @@ mod tests {
             PermuteCircuit::<S, WIDTH, RATE>(PhantomData)
         }
 
-        fn configure(meta: &mut ConstraintSystem<Fp>) -> Pow5Config<Fp, WIDTH, RATE> {
+        fn configure(meta: &mut ConstraintSystemBuilder<Fp>) -> Pow5Config<Fp, WIDTH, RATE> {
             let state = (0..WIDTH).map(|_| meta.advice_column()).collect::<Vec<_>>();
             let partial_sbox = meta.advice_column();
 
@@ -743,7 +744,7 @@ mod tests {
             }
         }
 
-        fn configure(meta: &mut ConstraintSystem<Fp>) -> Pow5Config<Fp, WIDTH, RATE> {
+        fn configure(meta: &mut ConstraintSystemBuilder<Fp>) -> Pow5Config<Fp, WIDTH, RATE> {
             let state = (0..WIDTH).map(|_| meta.advice_column()).collect::<Vec<_>>();
             let partial_sbox = meta.advice_column();
 

--- a/halo2_gadgets/src/sha256/table16.rs
+++ b/halo2_gadgets/src/sha256/table16.rs
@@ -5,7 +5,7 @@ use super::Sha256Instructions;
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter, Region, Value},
     pasta::pallas,
-    plonk::{Advice, Any, Assigned, Column, ConstraintSystem, Error},
+    plonk::{Advice, Any, Assigned, Column, ConstraintSystemBuilder, Error},
 };
 
 mod compression;
@@ -266,7 +266,7 @@ impl Table16Chip {
 
     /// Configures a circuit to include this chip.
     pub fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
     ) -> <Self as Chip<pallas::Base>>::Config {
         // Columns required by this chip:
         let message_schedule = meta.advice_column();
@@ -457,7 +457,7 @@ mod tests {
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner},
         pasta::pallas,
-        plonk::{Circuit, ConstraintSystem, Error},
+        plonk::{Circuit, ConstraintSystemBuilder, Error},
     };
 
     #[test]
@@ -473,7 +473,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<pallas::Base>) -> Self::Config {
                 Table16Chip::configure(meta)
             }
 

--- a/halo2_gadgets/src/sha256/table16/compression.rs
+++ b/halo2_gadgets/src/sha256/table16/compression.rs
@@ -6,7 +6,7 @@ use super::{
 use halo2_proofs::{
     circuit::{Layouter, Value},
     pasta::pallas,
-    plonk::{Advice, Column, ConstraintSystem, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystemBuilder, Error, Selector},
     poly::Rotation,
 };
 use std::convert::TryInto;
@@ -457,7 +457,7 @@ impl Table16Assignment for CompressionConfig {}
 
 impl CompressionConfig {
     pub(super) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         lookup: SpreadInputs,
         message_schedule: Column<Advice>,
         extras: [Column<Advice>; 6],
@@ -944,7 +944,7 @@ mod tests {
         circuit::{Layouter, SimpleFloorPlanner},
         dev::MockProver,
         pasta::pallas,
-        plonk::{Circuit, ConstraintSystem, Error},
+        plonk::{Circuit, ConstraintSystemBuilder, Error},
     };
 
     #[test]
@@ -959,7 +959,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<pallas::Base>) -> Self::Config {
                 Table16Chip::configure(meta)
             }
 

--- a/halo2_gadgets/src/sha256/table16/message_schedule.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule.rs
@@ -4,7 +4,7 @@ use super::{super::BLOCK_SIZE, AssignedBits, BlockWord, SpreadInputs, Table16Ass
 use halo2_proofs::{
     circuit::Layouter,
     pasta::pallas,
-    plonk::{Advice, Column, ConstraintSystem, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystemBuilder, Error, Selector},
     poly::Rotation,
 };
 
@@ -71,7 +71,7 @@ impl MessageScheduleConfig {
     /// itself.
     #[allow(clippy::many_single_char_names)]
     pub(super) fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         lookup: SpreadInputs,
         message_schedule: Column<Advice>,
         extras: [Column<Advice>; 6],
@@ -401,7 +401,7 @@ mod tests {
         circuit::{Layouter, SimpleFloorPlanner},
         dev::MockProver,
         pasta::pallas,
-        plonk::{Circuit, ConstraintSystem, Error},
+        plonk::{Circuit, ConstraintSystemBuilder, Error},
     };
 
     #[test]
@@ -416,7 +416,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<pallas::Base>) -> Self::Config {
                 Table16Chip::configure(meta)
             }
 

--- a/halo2_gadgets/src/sha256/table16/spread_table.rs
+++ b/halo2_gadgets/src/sha256/table16/spread_table.rs
@@ -4,7 +4,7 @@ use group::ff::{Field, PrimeField};
 use halo2_proofs::{
     circuit::{Chip, Layouter, Region, Value},
     pasta::pallas,
-    plonk::{Advice, Column, ConstraintSystem, Error, TableColumn},
+    plonk::{Advice, Column, ConstraintSystemBuilder, Error, TableColumn},
     poly::Rotation,
 };
 use std::convert::TryInto;
@@ -182,7 +182,7 @@ impl<F: Field> Chip<F> for SpreadTableChip<F> {
 
 impl<F: PrimeField> SpreadTableChip<F> {
     pub fn configure(
-        meta: &mut ConstraintSystem<F>,
+        meta: &mut ConstraintSystemBuilder<F>,
         input_tag: Column<Advice>,
         input_dense: Column<Advice>,
         input_spread: Column<Advice>,
@@ -298,7 +298,7 @@ mod tests {
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
         pasta::Fp,
-        plonk::{Advice, Circuit, Column, ConstraintSystem, Error},
+        plonk::{Advice, Circuit, Column, ConstraintSystemBuilder, Error},
     };
 
     #[test]
@@ -317,7 +317,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<F>) -> Self::Config {
                 let input_tag = meta.advice_column();
                 let input_dense = meta.advice_column();
                 let input_spread = meta.advice_column();

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -456,7 +456,7 @@ pub(crate) mod tests {
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
-        plonk::{Circuit, ConstraintSystem, Error},
+        plonk::{Circuit, ConstraintSystemBuilder, Error},
     };
     use rand::rngs::OsRng;
 
@@ -532,7 +532,7 @@ pub(crate) mod tests {
         }
 
         #[allow(non_snake_case)]
-        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+        fn configure(meta: &mut ConstraintSystemBuilder<pallas::Base>) -> Self::Config {
             let advices = [
                 meta.advice_column(),
                 meta.advice_column(),

--- a/halo2_gadgets/src/sinsemilla/chip.rs
+++ b/halo2_gadgets/src/sinsemilla/chip.rs
@@ -16,7 +16,7 @@ use std::marker::PhantomData;
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter, Value},
     plonk::{
-        Advice, Column, ConstraintSystem, Constraints, Error, Expression, Fixed, Selector,
+        Advice, Column, ConstraintSystemBuilder, Constraints, Error, Expression, Fixed, Selector,
         TableColumn, VirtualCells,
     },
     poly::Rotation,
@@ -149,7 +149,7 @@ where
     #[allow(clippy::too_many_arguments)]
     #[allow(non_snake_case)]
     pub fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         advices: [Column<Advice>; 5],
         witness_pieces: Column<Advice>,
         fixed_y_q: Column<Fixed>,

--- a/halo2_gadgets/src/sinsemilla/chip/generator_table.rs
+++ b/halo2_gadgets/src/sinsemilla/chip/generator_table.rs
@@ -1,7 +1,7 @@
 use group::ff::PrimeField;
 use halo2_proofs::{
     circuit::{Layouter, Value},
-    plonk::{ConstraintSystem, Error, Expression, TableColumn},
+    plonk::{ConstraintSystemBuilder, Error, Expression, TableColumn},
     poly::Rotation,
 };
 
@@ -24,7 +24,7 @@ impl GeneratorTableConfig {
     /// this specific configuration sets up Sinsemilla-specific constraints
     /// controlled by `q_sinsemilla`, and would likely not apply to other chips.
     pub fn configure<Hash, Commit, F>(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         config: super::SinsemillaConfig<Hash, Commit, F>,
     ) where
         Hash: HashDomains<pallas::Affine>,

--- a/halo2_gadgets/src/sinsemilla/merkle.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle.rs
@@ -192,7 +192,7 @@ pub mod tests {
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
         pasta::pallas,
-        plonk::{Circuit, ConstraintSystem, Error},
+        plonk::{Circuit, ConstraintSystemBuilder, Error},
     };
 
     use rand::{rngs::OsRng, RngCore};
@@ -218,7 +218,7 @@ pub mod tests {
             Self::default()
         }
 
-        fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+        fn configure(meta: &mut ConstraintSystemBuilder<pallas::Base>) -> Self::Config {
             let advices = [
                 meta.advice_column(),
                 meta.advice_column(),

--- a/halo2_gadgets/src/sinsemilla/merkle/chip.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle/chip.rs
@@ -2,7 +2,7 @@
 
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter, Value},
-    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystemBuilder, Constraints, Error, Selector},
     poly::Rotation,
 };
 use pasta_curves::pallas;
@@ -86,7 +86,7 @@ where
 {
     /// Configures the [`MerkleChip`].
     pub fn configure(
-        meta: &mut ConstraintSystem<pallas::Base>,
+        meta: &mut ConstraintSystemBuilder<pallas::Base>,
         sinsemilla_config: SinsemillaConfig<Hash, Commit, F>,
     ) -> MerkleConfig<Hash, Commit, F> {
         // All five advice columns are equality-enabled by SinsemillaConfig.

--- a/halo2_gadgets/src/utilities.rs
+++ b/halo2_gadgets/src/utilities.rs
@@ -244,7 +244,7 @@ mod tests {
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner},
         dev::{FailureLocation, MockProver, VerifyFailure},
-        plonk::{Any, Circuit, ConstraintSystem, Constraints, Error, Selector},
+        plonk::{Any, Circuit, ConstraintSystemBuilder, Constraints, Error, Selector},
         poly::Rotation,
     };
     use pasta_curves::pallas;
@@ -276,7 +276,7 @@ mod tests {
                 MyCircuit(self.0)
             }
 
-            fn configure(meta: &mut ConstraintSystem<pallas::Base>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<pallas::Base>) -> Self::Config {
                 let selector = meta.selector();
                 let advice = meta.advice_column();
 

--- a/halo2_gadgets/src/utilities/cond_swap.rs
+++ b/halo2_gadgets/src/utilities/cond_swap.rs
@@ -5,7 +5,7 @@ use super::{bool_check, ternary, UtilitiesInstructions};
 use group::ff::{Field, PrimeField};
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter, Value},
-    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystemBuilder, Constraints, Error, Selector},
     poly::Rotation,
 };
 use std::marker::PhantomData;
@@ -130,7 +130,7 @@ impl<F: PrimeField> CondSwapChip<F> {
     ///
     /// `advices[0]` will be equality-enabled.
     pub fn configure(
-        meta: &mut ConstraintSystem<F>,
+        meta: &mut ConstraintSystemBuilder<F>,
         advices: [Column<Advice>; 5],
     ) -> CondSwapConfig {
         let a = advices[0];
@@ -200,7 +200,7 @@ mod tests {
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::MockProver,
-        plonk::{Circuit, ConstraintSystem, Error},
+        plonk::{Circuit, ConstraintSystemBuilder, Error},
     };
     use pasta_curves::pallas::Base;
     use rand::rngs::OsRng;
@@ -222,7 +222,7 @@ mod tests {
                 Self::default()
             }
 
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<F>) -> Self::Config {
                 let advices = [
                     meta.advice_column(),
                     meta.advice_column(),

--- a/halo2_gadgets/src/utilities/decompose_running_sum.rs
+++ b/halo2_gadgets/src/utilities/decompose_running_sum.rs
@@ -25,7 +25,7 @@
 use ff::PrimeFieldBits;
 use halo2_proofs::{
     circuit::{AssignedCell, Region, Value},
-    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector},
+    plonk::{Advice, Column, ConstraintSystemBuilder, Constraints, Error, Selector},
     poly::Rotation,
 };
 
@@ -68,7 +68,7 @@ impl<F: PrimeFieldBits, const WINDOW_NUM_BITS: usize> RunningSumConfig<F, WINDOW
     ///
     /// `z` will be equality-enabled.
     pub fn configure(
-        meta: &mut ConstraintSystem<F>,
+        meta: &mut ConstraintSystemBuilder<F>,
         q_range_check: Selector,
         z: Column<Advice>,
     ) -> Self {
@@ -212,7 +212,7 @@ mod tests {
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner},
         dev::{FailureLocation, MockProver, VerifyFailure},
-        plonk::{Any, Circuit, ConstraintSystem, Error},
+        plonk::{Any, Circuit, ConstraintSystemBuilder, Error},
     };
     use pasta_curves::pallas;
     use rand::rngs::OsRng;
@@ -252,7 +252,7 @@ mod tests {
                 }
             }
 
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<F>) -> Self::Config {
                 let z = meta.advice_column();
                 let q_range_check = meta.selector();
                 let constants = meta.fixed_column();

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -3,7 +3,7 @@
 
 use halo2_proofs::{
     circuit::{AssignedCell, Layouter, Region},
-    plonk::{Advice, Column, ConstraintSystem, Constraints, Error, Selector, TableColumn},
+    plonk::{Advice, Column, ConstraintSystemBuilder, Constraints, Error, Selector, TableColumn},
     poly::Rotation,
 };
 use std::{convert::TryInto, marker::PhantomData};
@@ -78,7 +78,7 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheckConfig<F, K> {
     ///
     /// Both the `running_sum` and `constants` columns will be equality-enabled.
     pub fn configure(
-        meta: &mut ConstraintSystem<F>,
+        meta: &mut ConstraintSystemBuilder<F>,
         running_sum: Column<Advice>,
         table_idx: TableColumn,
     ) -> Self {
@@ -176,7 +176,7 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheckConfig<F, K> {
     /// Range check on an existing cell that is copied into this helper.
     ///
     /// Returns an error if `element` is not in a column that was passed to
-    /// [`ConstraintSystem::enable_equality`] during circuit configuration.
+    /// [`ConstraintSystemBuilder::enable_equality`] during circuit configuration.
     pub fn copy_check(
         &self,
         mut layouter: impl Layouter<F>,
@@ -393,7 +393,7 @@ mod tests {
     use halo2_proofs::{
         circuit::{Layouter, SimpleFloorPlanner, Value},
         dev::{FailureLocation, MockProver, VerifyFailure},
-        plonk::{Circuit, ConstraintSystem, Error},
+        plonk::{Circuit, ConstraintSystemBuilder, Error},
     };
     use pasta_curves::pallas;
 
@@ -415,7 +415,7 @@ mod tests {
                 *self
             }
 
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<F>) -> Self::Config {
                 let running_sum = meta.advice_column();
                 let table_idx = meta.lookup_table_column();
                 let constants = meta.fixed_column();
@@ -514,7 +514,7 @@ mod tests {
                 }
             }
 
-            fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<F>) -> Self::Config {
                 let running_sum = meta.advice_column();
                 let table_idx = meta.lookup_table_column();
                 let constants = meta.fixed_column();

--- a/halo2_proofs/benches/dev_lookup.rs
+++ b/halo2_proofs/benches/dev_lookup.rs
@@ -33,7 +33,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             Self::default()
         }
 
-        fn configure(meta: &mut ConstraintSystem<F>) -> MyConfig {
+        fn configure(meta: &mut ConstraintSystemBuilder<F>) -> MyConfig {
             let config = MyConfig {
                 selector: meta.complex_selector(),
                 table: meta.lookup_table_column(),

--- a/halo2_proofs/benches/plonk.rs
+++ b/halo2_proofs/benches/plonk.rs
@@ -179,7 +179,7 @@ fn criterion_benchmark(c: &mut Criterion) {
             }
         }
 
-        fn configure(meta: &mut ConstraintSystem<F>) -> PlonkConfig {
+        fn configure(meta: &mut ConstraintSystemBuilder<F>) -> PlonkConfig {
             meta.set_minimum_degree(5);
 
             let a = meta.advice_column();

--- a/halo2_proofs/examples/circuit-layout.rs
+++ b/halo2_proofs/examples/circuit-layout.rs
@@ -2,7 +2,9 @@ use ff::Field;
 use halo2_proofs::{
     circuit::{Cell, Layouter, Region, SimpleFloorPlanner, Value},
     pasta::Fp,
-    plonk::{Advice, Assigned, Circuit, Column, ConstraintSystem, Error, Fixed, TableColumn},
+    plonk::{
+        Advice, Assigned, Circuit, Column, ConstraintSystemBuilder, Error, Fixed, TableColumn,
+    },
     poly::Rotation,
 };
 use rand_core::OsRng;
@@ -170,7 +172,7 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
     }
 
     #[allow(clippy::many_single_char_names)]
-    fn configure(meta: &mut ConstraintSystem<F>) -> PlonkConfig {
+    fn configure(meta: &mut ConstraintSystemBuilder<F>) -> PlonkConfig {
         let e = meta.advice_column();
         let a = meta.advice_column();
         let b = meta.advice_column();

--- a/halo2_proofs/examples/simple-example.rs
+++ b/halo2_proofs/examples/simple-example.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use group::ff::Field;
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter, Region, SimpleFloorPlanner, Value},
-    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Fixed, Instance, Selector},
+    plonk::{Advice, Circuit, Column, ConstraintSystemBuilder, Error, Fixed, Instance, Selector},
     poly::Rotation,
 };
 
@@ -74,7 +74,7 @@ impl<F: Field> FieldChip<F> {
     }
 
     fn configure(
-        meta: &mut ConstraintSystem<F>,
+        meta: &mut ConstraintSystemBuilder<F>,
         advice: [Column<Advice>; 2],
         instance: Column<Instance>,
         constant: Column<Fixed>,
@@ -253,7 +253,7 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
         Self::default()
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystemBuilder<F>) -> Self::Config {
         // We create the two advice columns that FieldChip uses for I/O.
         let advice = [meta.advice_column(), meta.advice_column()];
 

--- a/halo2_proofs/examples/two-chip.rs
+++ b/halo2_proofs/examples/two-chip.rs
@@ -3,7 +3,7 @@ use std::marker::PhantomData;
 use group::ff::Field;
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter, Region, SimpleFloorPlanner, Value},
-    plonk::{Advice, Circuit, Column, ConstraintSystem, Error, Instance, Selector},
+    plonk::{Advice, Circuit, Column, ConstraintSystemBuilder, Error, Instance, Selector},
     poly::Rotation,
 };
 
@@ -153,7 +153,7 @@ impl<F: Field> AddChip<F> {
     }
 
     fn configure(
-        meta: &mut ConstraintSystem<F>,
+        meta: &mut ConstraintSystemBuilder<F>,
         advice: [Column<Advice>; 2],
     ) -> <Self as Chip<F>>::Config {
         let s_add = meta.selector();
@@ -255,7 +255,7 @@ impl<F: Field> MulChip<F> {
     }
 
     fn configure(
-        meta: &mut ConstraintSystem<F>,
+        meta: &mut ConstraintSystemBuilder<F>,
         advice: [Column<Advice>; 2],
     ) -> <Self as Chip<F>>::Config {
         for column in &advice {
@@ -376,7 +376,7 @@ impl<F: Field> FieldChip<F> {
     }
 
     fn configure(
-        meta: &mut ConstraintSystem<F>,
+        meta: &mut ConstraintSystemBuilder<F>,
         advice: [Column<Advice>; 2],
         instance: Column<Instance>,
     ) -> <Self as Chip<F>>::Config {
@@ -463,7 +463,7 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
         Self::default()
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystemBuilder<F>) -> Self::Config {
         // We create the two advice columns that FieldChip uses for I/O.
         let advice = [meta.advice_column(), meta.advice_column()];
 

--- a/halo2_proofs/src/circuit/floor_planner/single_pass.rs
+++ b/halo2_proofs/src/circuit/floor_planner/single_pass.rs
@@ -384,7 +384,9 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut crate::plonk::ConstraintSystem<vesta::Scalar>) -> Self::Config {
+            fn configure(
+                meta: &mut crate::plonk::ConstraintSystemBuilder<vesta::Scalar>,
+            ) -> Self::Config {
                 meta.advice_column()
             }
 

--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -498,7 +498,7 @@ mod tests {
                 MyCircuit {}
             }
 
-            fn configure(meta: &mut crate::plonk::ConstraintSystem<vesta::Scalar>) -> Self::Config {
+            fn configure(meta: &mut crate::plonk::ConstraintSystemBuilder<vesta::Scalar>) -> Self::Config {
                 meta.advice_column()
             }
 

--- a/halo2_proofs/src/circuit/table_layouter.rs
+++ b/halo2_proofs/src/circuit/table_layouter.rs
@@ -156,7 +156,7 @@ mod tests {
     use crate::{
         circuit::{Layouter, SimpleFloorPlanner},
         dev::MockProver,
-        plonk::{Circuit, ConstraintSystem},
+        plonk::{Circuit, ConstraintSystemBuilder},
         poly::Rotation,
     };
 
@@ -182,7 +182,7 @@ mod tests {
                 Self
             }
 
-            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<Fp>) -> Self::Config {
                 let a = meta.advice_column();
                 let table = meta.lookup_table_column();
 
@@ -240,7 +240,7 @@ mod tests {
                 Self
             }
 
-            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<Fp>) -> Self::Config {
                 let a = meta.advice_column();
                 let table = meta.lookup_table_column();
 
@@ -304,7 +304,7 @@ mod tests {
                 Self
             }
 
-            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<Fp>) -> Self::Config {
                 let a = meta.advice_column();
                 let table = meta.lookup_table_column();
 
@@ -369,7 +369,7 @@ mod tests {
                 Self
             }
 
-            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+            fn configure(meta: &mut ConstraintSystemBuilder<Fp>) -> Self::Config {
                 let a = meta.advice_column();
                 let table = (meta.lookup_table_column(), meta.lookup_table_column());
                 meta.lookup(|cells| {

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -400,7 +400,7 @@ fn render_lookup<F: Field>(
 ) {
     let n = prover.n as i32;
     let cs = &prover.cs;
-    let lookup = &cs.lookups[lookup_index];
+    let lookup = &cs.cs.lookups[lookup_index];
 
     // Get the absolute row on which the lookup's inputs are being queried, so we can
     // fetch the input values.
@@ -469,15 +469,15 @@ fn render_lookup<F: Field>(
             &|_| panic!("virtual selectors are removed during optimization"),
             &cell_value(
                 Any::Fixed,
-                &util::load(n, row, &cs.fixed_queries, &prover.fixed),
+                &util::load(n, row, &cs.cs.fixed_queries, &prover.fixed),
             ),
             &cell_value(
                 Any::Advice,
-                &util::load(n, row, &cs.advice_queries, &prover.advice),
+                &util::load(n, row, &cs.cs.advice_queries, &prover.advice),
             ),
             &cell_value(
                 Any::Instance,
-                &util::load_instance(n, row, &cs.instance_queries, &prover.instance),
+                &util::load_instance(n, row, &cs.cs.instance_queries, &prover.instance),
             ),
             &|a| a,
             &|mut a, mut b| {
@@ -541,7 +541,7 @@ impl VerifyFailure {
                 column,
                 offset,
             } => render_cell_not_assigned(
-                &prover.cs.gates,
+                &prover.cs.cs.gates,
                 gate,
                 region,
                 *gate_offset,
@@ -552,9 +552,12 @@ impl VerifyFailure {
                 constraint,
                 location,
                 cell_values,
-            } => {
-                render_constraint_not_satisfied(&prover.cs.gates, constraint, location, cell_values)
-            }
+            } => render_constraint_not_satisfied(
+                &prover.cs.cs.gates,
+                constraint,
+                location,
+                cell_values,
+            ),
             Self::Lookup {
                 lookup_index,
                 location,

--- a/halo2_proofs/src/dev/gates.rs
+++ b/halo2_proofs/src/dev/gates.rs
@@ -7,7 +7,7 @@ use ff::PrimeField;
 
 use crate::{
     dev::util,
-    plonk::{Circuit, ConstraintSystem},
+    plonk::{Circuit, ConstraintSystemBuilder},
 };
 
 #[derive(Debug)]
@@ -51,7 +51,7 @@ struct Gate {
 ///         Self::default()
 ///     }
 ///
-///     fn configure(meta: &mut ConstraintSystem<F>) -> MyConfig {
+///     fn configure(meta: &mut ConstraintSystemBuilder<F>) -> MyConfig {
 ///         let a = meta.advice_column();
 ///         let b = meta.advice_column();
 ///         let c = meta.advice_column();
@@ -102,10 +102,11 @@ impl CircuitGates {
     /// Collects the gates from within the circuit.
     pub fn collect<F: PrimeField, C: Circuit<F>>() -> Self {
         // Collect the graph details.
-        let mut cs = ConstraintSystem::default();
+        let mut cs = ConstraintSystemBuilder::default();
         let _ = C::configure(&mut cs);
 
         let gates = cs
+            .cs
             .gates
             .iter()
             .map(|gate| Gate {
@@ -185,6 +186,7 @@ impl CircuitGates {
             .collect();
 
         let (total_negations, total_additions, total_multiplications) = cs
+            .cs
             .gates
             .iter()
             .flat_map(|gate| {

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -4,7 +4,7 @@ use tabbycat::{AttrList, Edge, GraphBuilder, GraphType, Identity, StmtList};
 use crate::{
     circuit::Value,
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
+        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystemBuilder, Error, Fixed,
         FloorPlanner, Instance, Selector,
     },
 };
@@ -21,10 +21,10 @@ pub fn circuit_dot_graph<F: Field, ConcreteCircuit: Circuit<F>>(
     circuit: &ConcreteCircuit,
 ) -> String {
     // Collect the graph details.
-    let mut cs = ConstraintSystem::default();
+    let mut cs = ConstraintSystemBuilder::default();
     let config = ConcreteCircuit::configure(&mut cs);
     let mut graph = Graph::default();
-    ConcreteCircuit::FloorPlanner::synthesize(&mut graph, circuit, config, cs.constants).unwrap();
+    ConcreteCircuit::FloorPlanner::synthesize(&mut graph, circuit, config, cs.cs.constants).unwrap();
 
     // Construct the node labels. We need to store these, because tabbycat operates on
     // string references, and we need those references to live long enough.

--- a/halo2_proofs/src/dev/tfp.rs
+++ b/halo2_proofs/src/dev/tfp.rs
@@ -6,7 +6,7 @@ use tracing::{debug, debug_span, span::EnteredSpan};
 use crate::{
     circuit::{layouter::RegionLayouter, AssignedCell, Cell, Layouter, Region, Table, Value},
     plonk::{
-        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystem, Error, Fixed,
+        Advice, Any, Assigned, Assignment, Circuit, Column, ConstraintSystemBuilder, Error, Fixed,
         FloorPlanner, Instance, Selector,
     },
 };
@@ -50,7 +50,7 @@ use crate::{
 ///         Self { some_witness: Value::unknown() }
 ///     }
 ///
-///     fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+///     fn configure(meta: &mut ConstraintSystemBuilder<F>) -> Self::Config {
 ///         // ..
 /// #       todo!()
 ///     }
@@ -126,7 +126,7 @@ impl<'c, F: Field, C: Circuit<F>> Circuit<F> for TracingCircuit<'c, F, C> {
         Self::owned(self.inner_ref().without_witnesses())
     }
 
-    fn configure(meta: &mut ConstraintSystem<F>) -> Self::Config {
+    fn configure(meta: &mut ConstraintSystemBuilder<F>) -> Self::Config {
         let _span = debug_span!("configure").entered();
         C::configure(meta)
     }

--- a/halo2_proofs/src/plonk.rs
+++ b/halo2_proofs/src/plonk.rs
@@ -45,6 +45,8 @@ pub struct VerifyingKey<C: CurveAffine> {
     cs: ConstraintSystem<C::Scalar>,
     /// Cached maximum degree of `cs` (which doesn't change after construction).
     cs_degree: usize,
+    /// Cached number of blinding factors (which doesn't change after construction).
+    num_blinding_factors: usize,
     /// The representative of this `VerifyingKey` in transcripts.
     transcript_repr: C::Scalar,
 }
@@ -57,17 +59,19 @@ where
         domain: EvaluationDomain<C::Scalar>,
         fixed_commitments: Vec<C>,
         permutation: permutation::VerifyingKey<C>,
-        cs: ConstraintSystem<C::Scalar>,
+        cs: ConstraintSystemBuilder<C::Scalar>,
     ) -> Self {
         // Compute cached values.
         let cs_degree = cs.degree();
+        let num_blinding_factors = cs.blinding_factors();
 
         let mut vk = Self {
             domain,
             fixed_commitments,
             permutation,
-            cs,
+            cs: cs.cs,
             cs_degree,
+            num_blinding_factors,
             // Temporary, this is not pinned.
             transcript_repr: C::Scalar::ZERO,
         };

--- a/halo2_proofs/src/plonk/error.rs
+++ b/halo2_proofs/src/plonk/error.rs
@@ -31,9 +31,9 @@ pub enum Error {
     /// Instance provided exceeds number of available rows
     InstanceTooLarge,
     /// Circuit synthesis requires global constants, but circuit configuration did not
-    /// call [`ConstraintSystem::enable_constant`] on fixed columns with sufficient space.
+    /// call [`ConstraintSystemBuilder::enable_constant`] on fixed columns with sufficient space.
     ///
-    /// [`ConstraintSystem::enable_constant`]: crate::plonk::ConstraintSystem::enable_constant
+    /// [`ConstraintSystemBuilder::enable_constant`]: crate::plonk::ConstraintSystemBuilder::enable_constant
     NotEnoughColumnsForConstants,
     /// The instance sets up a copy constraint involving a column that has not been
     /// included in the permutation.

--- a/halo2_proofs/src/plonk/lookup/prover.rs
+++ b/halo2_proofs/src/plonk/lookup/prover.rs
@@ -264,7 +264,7 @@ impl<C: CurveAffine, Ev: Copy + Send + Sync> Permuted<C, Ev> {
         mut rng: R,
         transcript: &mut T,
     ) -> Result<Committed<C, Ev>, Error> {
-        let blinding_factors = pk.vk.cs.blinding_factors();
+        let blinding_factors = pk.vk.num_blinding_factors;
         // Goal is to compute the products of fractions
         //
         // Numerator: (\theta^{m-1} a_0(\omega^i) + \theta^{m-2} a_1(\omega^i) + ... + \theta a_{m-2}(\omega^i) + a_{m-1}(\omega^i) + \beta)
@@ -568,7 +568,7 @@ fn permute_expression_pair<C: CurveAffine, R: RngCore>(
     input_expression: &Polynomial<C::Scalar, LagrangeCoeff>,
     table_expression: &Polynomial<C::Scalar, LagrangeCoeff>,
 ) -> Result<ExpressionPair<C::Scalar>, Error> {
-    let blinding_factors = pk.vk.cs.blinding_factors();
+    let blinding_factors = pk.vk.num_blinding_factors;
     let usable_rows = params.n as usize - (blinding_factors + 1);
 
     let mut permuted_input_expression: Vec<C::Scalar> = input_expression.to_vec();

--- a/halo2_proofs/src/plonk/permutation/prover.rs
+++ b/halo2_proofs/src/plonk/permutation/prover.rs
@@ -72,7 +72,7 @@ impl Argument {
         // 3 circuit for the permutation argument.
         assert!(pk.vk.cs_degree >= 3);
         let chunk_len = pk.vk.cs_degree - 2;
-        let blinding_factors = pk.vk.cs.blinding_factors();
+        let blinding_factors = pk.vk.num_blinding_factors;
 
         // Each column gets its own delta power.
         let mut deltaomega = C::Scalar::ONE;
@@ -214,7 +214,7 @@ impl<C: CurveAffine, Ev: Copy + Send + Sync> Committed<C, Ev> {
         impl Iterator<Item = poly::Ast<Ev, C::Scalar, ExtendedLagrangeCoeff>> + 'a,
     ) {
         let chunk_len = pk.vk.cs_degree - 2;
-        let blinding_factors = pk.vk.cs.blinding_factors();
+        let blinding_factors = pk.vk.num_blinding_factors;
         let last_rotation = Rotation(-((blinding_factors + 1) as i32));
 
         let constructed = Constructed {
@@ -346,7 +346,7 @@ impl<C: CurveAffine> Constructed<C> {
         transcript: &mut T,
     ) -> Result<Evaluated<C>, Error> {
         let domain = &pk.vk.domain;
-        let blinding_factors = pk.vk.cs.blinding_factors();
+        let blinding_factors = pk.vk.num_blinding_factors;
 
         {
             let mut sets = self.sets.iter();
@@ -391,7 +391,7 @@ impl<C: CurveAffine> Evaluated<C> {
         pk: &'a plonk::ProvingKey<C>,
         x: ChallengeX<C>,
     ) -> impl Iterator<Item = ProverQuery<'a, C>> + Clone {
-        let blinding_factors = pk.vk.cs.blinding_factors();
+        let blinding_factors = pk.vk.num_blinding_factors;
         let x_next = pk.vk.domain.rotate_omega(*x, Rotation::next());
         let x_last = pk
             .vk

--- a/halo2_proofs/src/plonk/permutation/verifier.rs
+++ b/halo2_proofs/src/plonk/permutation/verifier.rs
@@ -193,7 +193,7 @@ impl<C: CurveAffine> Evaluated<C> {
         vk: &'r plonk::VerifyingKey<C>,
         x: ChallengeX<C>,
     ) -> impl Iterator<Item = VerifierQuery<'r, 'params, C>> + Clone {
-        let blinding_factors = vk.cs.blinding_factors();
+        let blinding_factors = vk.num_blinding_factors;
         let x_next = vk.domain.rotate_omega(*x, Rotation::next());
         let x_last = vk
             .domain

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -90,7 +90,7 @@ pub fn verify_proof<
             instance
                 .iter()
                 .map(|instance| {
-                    if instance.len() > params.n as usize - (vk.cs.blinding_factors() + 1) {
+                    if instance.len() > params.n as usize - (vk.num_blinding_factors + 1) {
                         return Err(Error::InstanceTooLarge);
                     }
                     let mut poly = instance.to_vec();
@@ -205,7 +205,7 @@ pub fn verify_proof<
         // x^n
         let xn = x.pow(&[params.n, 0, 0, 0]);
 
-        let blinding_factors = vk.cs.blinding_factors();
+        let blinding_factors = vk.num_blinding_factors;
         let l_evals = vk
             .domain
             .l_i_range(*x, xn, (-((blinding_factors + 1) as i32))..=0);

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -9,7 +9,8 @@ use halo2_proofs::dev::MockProver;
 use halo2_proofs::pasta::{Eq, EqAffine, Fp};
 use halo2_proofs::plonk::{
     create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Assigned, BatchVerifier, Circuit,
-    Column, ConstraintSystem, Error, Fixed, SingleVerifier, TableColumn, VerificationStrategy,
+    Column, ConstraintSystemBuilder, Error, Fixed, SingleVerifier, TableColumn,
+    VerificationStrategy,
 };
 use halo2_proofs::poly::commitment::{Guard, MSM};
 use halo2_proofs::poly::{commitment::Params, Rotation};
@@ -272,7 +273,7 @@ fn plonk_api() {
             }
         }
 
-        fn configure(meta: &mut ConstraintSystem<F>) -> PlonkConfig {
+        fn configure(meta: &mut ConstraintSystemBuilder<F>) -> PlonkConfig {
             let e = meta.advice_column();
             let a = meta.advice_column();
             let b = meta.advice_column();


### PR DESCRIPTION
This is an initial refactor performed during Halo 2 Office Hours, to explore the effects of this split on the wider codebase.

At the end, we discussed the result, and noted that the verifying key type still contains data in sub-types that is irrelevant to the actual verifying key. The verifying key type is also never exposed in the public API of the verifying key; `ConstraintSystem` was only public for its use in `Circuit::configure`.

The likely next steps are:
- Rework `PinnedConstraintSystem` to be the verifying key type, only storing the data needed for the transcript, but being an owned type that exposes immutable references via methods instead of its fields being `pub(crate)`.
- Undo the `ConstraintSystemBuilder` rename, so we are just removing parts of the `ConstraintSystem` API.
- Rework `ConstraintSystem::pinned` and `VerifyingKey::from_parts` to instead become the builder method for the verifying key type along with the data that is cached alongside it inside `VerifyingKey`.
- Refactor the very few methods that we identified as only relevant to the verifying key type, as they are only used redundantly.