### PR TITLE
ensure extended_k <= S

### DIFF
--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -52,6 +52,9 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
             extended_k += 1;
         }
 
+        // ensure extended_k <= S
+        assert!(extended_k <= F::S);
+
         let mut extended_omega = F::ROOT_OF_UNITY;
 
         // Get extended_omega, the 2^{extended_k}'th root of unity


### PR DESCRIPTION
If `extended_k > S`, the for loop will do nothing:

```
        for _ in extended_k..F::S {
            extended_omega = extended_omega.square();
        }
```

and `extended_omega` will be left as `F::ROOT_OF_UNITY`, which is incorrect.