### PR TITLE
pow_vartime([n, 0, 0, 0] => pow_vartime([n]

### DIFF
--- a/halo2_proofs/src/plonk/permutation/prover.rs
+++ b/halo2_proofs/src/plonk/permutation/prover.rs
@@ -128,7 +128,7 @@ impl Argument {
                     Any::Instance => instance,
                 };
                 parallelize(&mut modified_values, |modified_values, start| {
-                    let mut deltaomega = deltaomega * &omega.pow_vartime([start as u64, 0, 0, 0]);
+                    let mut deltaomega = deltaomega * &omega.pow_vartime([start as u64]);
                     for (modified_values, value) in modified_values
                         .iter_mut()
                         .zip(values[column.index()][start..].iter())

--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -80,7 +80,7 @@ impl<C: CurveAffine> Params<C> {
         }
         let mut g_lagrange_projective = g_projective;
         best_fft(&mut g_lagrange_projective, alpha_inv, k);
-        let minv = C::Scalar::TWO_INV.pow_vartime([k as u64, 0, 0, 0]);
+        let minv = C::Scalar::TWO_INV.pow_vartime([k as u64]);
         parallelize(&mut g_lagrange_projective, |g, _| {
             for g in g.iter_mut() {
                 *g *= minv;

--- a/halo2_proofs/src/poly/domain.rs
+++ b/halo2_proofs/src/poly/domain.rs
@@ -86,8 +86,8 @@ impl<F: WithSmallOrderMulGroup<3>> EvaluationDomain<F> {
         {
             // Compute the evaluations of t(X) = X^n - 1 in the coset evaluation domain.
             // We don't have to compute all of them, because it will repeat.
-            let orig = F::ZETA.pow_vartime([n, 0, 0, 0]);
-            let step = extended_omega.pow_vartime([n, 0, 0, 0]);
+            let orig = F::ZETA.pow_vartime([n]);
+            let step = extended_omega.pow_vartime([n]);
             let mut cur = orig;
             loop {
                 t_evaluations.push(cur);


### PR DESCRIPTION
`pow_vartime([n, 0, 0, 0] => pow_vartime([n]` always holds, so it seems there's no point in wasting resource computing `pow_vartime([n, 0, 0, 0] ` instead of `pow_vartime([n]`.