### PR TITLE
feat: update rust toolchain to 1.66.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.66.0"


### PR DESCRIPTION
update toolchain to resolve
```
error: package `rayon-core v1.12.0` cannot be built because it requires rustc 1.63 or newer, while the currently active rustc version is 1.60.0


error: package `constant_time_eq v0.3.0` cannot be built because it requires rustc 1.66.0 or newer, while the currently active rustc version is 1.63.0
```