### PR TITLE
Fix MD book generation

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: '1.76.0'
           override: true
 
       # - name: Setup mdBook
@@ -26,7 +26,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: install
-          args: mdbook --git https://github.com/HollowMan6/mdBook.git --rev 62e01b34c23b957579c04ee1b24b57814ed8a4d5
+          args: mdbook --git https://github.com/HollowMan6/mdBook.git --rev 5830c9555a4dc051675d17f1fcb04dd0920543e8
 
       - name: Install mdbook-katex and mdbook-pdf
         uses: actions-rs/cargo@v1
@@ -39,6 +39,11 @@ jobs:
 
       - name: Build halo2 book
         run: mdbook build book/
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2023-10-05 
+          override: true
 
       - name: Build latest rustdocs
         uses: actions-rs/cargo@v1

--- a/book/book.toml
+++ b/book/book.toml
@@ -14,8 +14,6 @@ title = "The halo2 Book"
 macros = "macros.txt"
 renderers = ["html"]
 
-[output.katex]
-
 [output.html]
 
 [output.html.print]


### PR DESCRIPTION
It seems that the last nightly does not work very well to compile mdbook (patched rev 5830c9555a4dc051675d17f1fcb04dd0920543e8) nor to compile halo2 (that is fixed to 1.60).

This PR fixes the toolchain to properly compile the tools for generating the documentation, because seems that `cargo install` uses the `rust-toolchain.toml` file by default. Also, having a fixed toolchain is not a bad idea to ensure proper generation of documentation IMO.

BTW, I had to remove `[output.katex]` since it was failing [here](https://github.com/rust-lang/mdBook/blob/5830c9555a4dc051675d17f1fcb04dd0920543e8/src/preprocess/cmd.rs#L46) because the received JSON was not an array of two elements. Anyway seems that html is properly generated. cc/ @HollowMan6 