### PR TITLE
Fix links from book

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 ## Usage
 
-This repository contains the [halo2_proofs](halo2_proofs/README.md) and
-[halo2_gadgets](halo2_gadgets/README.md) crates, which should be used directly.
+This repository contains the [halo2_proofs](https://github.com/zcash/halo2/blob/main/halo2_proofs/README.md) and
+[halo2_gadgets](https://github.com/zcash/halo2/blob/main/halo2_gadgets/README.md) crates, which should be used directly.
 
 ## Minimum Supported Rust Version
 


### PR DESCRIPTION
When browsing the [halo2 book](https://zcash.github.io/halo2/) the first 2 links are broken. This is because the text is from the [halo2 readme](https://github.com/zcash/halo2/blob/main/README.md) and the links use relative paths.

This pull request change the links to full url so they should work from the github and from the book.