### PR TITLE
Fix article usage in "curves.md"

### DIFF
--- a/book/src/background/curves.md
+++ b/book/src/background/curves.md
@@ -284,7 +284,7 @@ This is described in detail in the [Internet draft on Hashing to Elliptic Curves
 Several algorithms can be used depending on efficiency and security requirements. The
 framework used in the Internet Draft makes use of several functions:
 
-* ``hash_to_field``: takes a byte sequence input and maps it to a element in the base
+* ``hash_to_field``: takes a byte sequence input and maps it to an element in the base
   field $\mathbb{F}_p$
 * ``map_to_curve``: takes an $\mathbb{F}_p$ element and maps it to $E_p$.
 


### PR DESCRIPTION
This pull request addresses a minor grammatical issue in the `curves.md` file. The article "a" was incorrectly used before the word "element," which begins with a vowel sound. It has been corrected to "an" for proper usage in English grammar. The change improves readability and ensures consistency with the rules of article usage.

### Changes:
- Replaced "a element" with "an element" in the `book/src/background/curves.md` file.
