### PR TITLE
halo2_gadgets: depend on `rand` with default-features = false

### DIFF
--- a/halo2_gadgets/CHANGELOG.md
+++ b/halo2_gadgets/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- The dependency on `rand` is now without default features, fixing use of this crate
+  in `no_std` environments.
 
 ## [0.3.1] - 2024-12-16
 - `halo2_gadgets::poseidon::primitives` is now a re-export of the new `halo2_poseidon`

--- a/halo2_gadgets/Cargo.toml
+++ b/halo2_gadgets/Cargo.toml
@@ -31,7 +31,7 @@ halo2_proofs = { version = "0.3", path = "../halo2_proofs", default-features = f
 lazy_static = "1"
 pasta_curves = "0.5"
 proptest = { version = "1.0.0", optional = true }
-rand = "0.8"
+rand = { version = "0.8", default-features = false }
 sinsemilla = "0.1"
 subtle = "2.3"
 uint = "0.9.2" # MSRV 1.56.1


### PR DESCRIPTION
The dependency on `rand` is now without default features, fixing use of `halo2_gadgets`  in `no_std` environments.