### PR TITLE
Update reference to Friedman's number theory notes with a working link

### DIFF
--- a/book/src/background/fields.md
+++ b/book/src/background/fields.md
@@ -304,4 +304,4 @@ Important notes:
   of unity). There is a two-to-one mapping between the elements and their squares.
 
 ## References
-[^chinese-remainder]: [Friedman, R. (n.d.) "Cyclic Groups and Elementary Number Theory II" (p. 5).](http://www.math.columbia.edu/~rf/numbertheory2.pdf)
+[^chinese-remainder]: [Friedman, R. (n.d.) "Cyclic Groups and Elementary Number Theory II" (p. 5).](https://www.math.columbia.edu/~thaddeus/iv/friedman1.pdf)


### PR DESCRIPTION
Replaced the outdated and broken link to Robert Friedman's "Cyclic Groups and Elementary Number Theory II" with a currently available version hosted at math.columbia.edu. This ensures the reference in the fields background chapter is accessible to readers.