### PR TITLE
fix: doc for plonk::verify_proof to reflect Result<V::Output, Error>

### DIFF
--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -63,7 +63,9 @@ impl<'params, C: CurveAffine> VerificationStrategy<'params, C> for SingleVerifie
     }
 }
 
-/// Returns a boolean indicating whether or not the proof is valid
+/// Verifies a proof using the provided strategy.
+///
+/// On success returns the strategy-defined output (`V::Output`), or an `Error` on failure.
 pub fn verify_proof<
     'params,
     C: CurveAffine,


### PR DESCRIPTION
Update comment: it no longer claims a boolean return.
Clarify semantics: returns strategy-defined V::Output on success, Error on failure.