### PR TITLE
Add method to retrieve circuit size parameter k

### DIFF
--- a/halo2_proofs/src/poly/commitment.rs
+++ b/halo2_proofs/src/poly/commitment.rs
@@ -160,6 +160,11 @@ impl<C: CurveAffine> Params<C> {
         self.g.clone()
     }
 
+    /// Get the circuit size parameter k
+    pub fn k(&self) -> u32 {
+        self.k
+    }
+
     /// Writes params to a buffer.
     pub fn write<W: io::Write>(&self, writer: &mut W) -> io::Result<()> {
         writer.write_all(&self.k.to_le_bytes())?;


### PR DESCRIPTION
expose circuit size k for use in mapping params out for caching opportunities. 