### PR TITLE
CI: Build book with `mdbook 0.4`

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@adeb05db28a0c0004681db83893d56c0388ea9ea # v1.2.0
         with:
-          mdbook-version: 'latest'
+          mdbook-version: '0.4.52'
 
       - name: Install mdbook-katex and mdbook-pdf
         run: cargo install mdbook-katex mdbook-pdf


### PR DESCRIPTION
`mdbook 0.5` was recently released, but `mdbook-katex` doesn't yet support it.