### PR TITLE
Bump lockfile to `pathfinder_simd 0.5.5`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0444332826c70dc47be74a7c6a5fc44e23a7905ad6858d4162b658320455ef93"
+checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
 dependencies = [
  "rustc_version",
 ]


### PR DESCRIPTION
Fixes a Rust 1.78+ incompatibility.