### PR TITLE
chore: drop unnecessary F: Debug bound and unused Debug import

### DIFF
--- a/halo2_proofs/src/circuit/table_layouter.rs
+++ b/halo2_proofs/src/circuit/table_layouter.rs
@@ -2,7 +2,7 @@
 
 use std::{
     collections::HashMap,
-    fmt::{self, Debug},
+    fmt::{self},
 };
 
 use ff::Field;
@@ -115,7 +115,7 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
     }
 }
 
-pub(crate) fn compute_table_lengths<F: Debug>(
+pub(crate) fn compute_table_lengths<F>(
     default_and_assigned: &HashMap<TableColumn, (DefaultTableValue<F>, Vec<bool>)>,
 ) -> Result<usize, Error> {
     let column_lengths: Result<Vec<_>, Error> = default_and_assigned


### PR DESCRIPTION
 Removed an unused Debug import and eliminated the redundant F: Debug bound from compute_table_lengths. The function does not use F or require formatting, and callers only need F: Field