### PR TITLE
halo2_gadgets: update halo2_proofs version to 0.3.2

### DIFF
--- a/halo2_gadgets/Cargo.toml
+++ b/halo2_gadgets/Cargo.toml
@@ -27,7 +27,7 @@ bitvec = "1"
 ff = "0.13"
 group = "0.13"
 halo2_poseidon = { version = "0.1", path = "../halo2_poseidon", default-features = false }
-halo2_proofs = { version = "0.3", path = "../halo2_proofs", default-features = false }
+halo2_proofs = { version = "0.3.2", path = "../halo2_proofs", default-features = false }
 lazy_static = "1"
 pasta_curves = "0.5"
 proptest = { version = "1.0.0", optional = true }


### PR DESCRIPTION
`halo2_gadgets` uses `IllegalHashFromPrivatePoint` in `chip.rs`, which was only introduced in `halo2_proofs` 0.3.2