### PR TITLE
Fix crash in constant allocation edge case

### DIFF
--- a/halo2_proofs/src/circuit/floor_planner/v1.rs
+++ b/halo2_proofs/src/circuit/floor_planner/v1.rs
@@ -103,7 +103,11 @@ impl FloorPlanner for V1 {
             fixed_allocations.iter().flat_map(|(c, a)| {
                 let c = *c;
                 a.free_intervals(0, Some(first_unassigned_row))
-                    .flat_map(move |e| e.range().unwrap().map(move |i| (c, i)))
+                .flat_map(move |e| {
+                    e.range()
+                        .into_iter()
+                        .flat_map(move |r| r.map(move |l| (c, l)))
+                })                
             })
         };
 


### PR DESCRIPTION
Replace unwrap on free interval range with safe iteration so the floor planner returns a planning error instead of panicking.
