### PR TITLE
Reject duplicate lookup table cell assignments

### DIFF
--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `halo2_proofs::circuit`:
+  - Duplicate assignments to the same lookup-table cell now return a table
+    overwrite error before mutating the fixed-column assignment backend.
 
 ## [0.3.2] - 2025-12-04
 ### Added

--- a/halo2_proofs/src/circuit/table_layouter.rs
+++ b/halo2_proofs/src/circuit/table_layouter.rs
@@ -79,6 +79,13 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
         }
 
         let entry = self.default_and_assigned.entry(column).or_default();
+        if entry.1.get(offset).copied().unwrap_or(false) {
+            return Err(Error::TableError(TableError::OverwriteDefault(
+                column,
+                format!("offset {}", offset),
+                format!("{:?}", to()),
+            )));
+        }
 
         let mut value = Value::unknown();
         self.cs.assign_fixed(
@@ -92,19 +99,9 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
             },
         )?;
 
-        match (entry.0.is_none(), offset) {
-            // Use the value at offset 0 as the default value for this table column.
-            (true, 0) => entry.0 = Some(value),
-            // Since there is already an existing default value for this table column,
-            // the caller should not be attempting to assign another value at offset 0.
-            (false, 0) => {
-                return Err(Error::TableError(TableError::OverwriteDefault(
-                    column,
-                    format!("{:?}", entry.0.unwrap()),
-                    format!("{:?}", value),
-                )))
-            }
-            _ => (),
+        // Use the value at offset 0 as the default value for this table column.
+        if entry.0.is_none() && offset == 0 {
+            entry.0 = Some(value);
         }
         if entry.1.len() <= offset {
             entry.1.resize(offset + 1, false);
@@ -280,7 +277,77 @@ mod tests {
         let prover = MockProver::run(K, &FaultyCircuit, vec![]);
         assert_eq!(
             format!("{}", prover.unwrap_err()),
-            "Attempted to overwrite default value Value { inner: Some(Trivial(0x0000000000000000000000000000000000000000000000000000000000000000)) } with Value { inner: Some(Trivial(0x0000000000000000000000000000000000000000000000000000000000000000)) } in TableColumn { inner: Column { index: 0, column_type: Fixed } }"
+            "Attempted to overwrite table value offset 0 with Value { inner: Some(Trivial(0x0000000000000000000000000000000000000000000000000000000000000000)) } in TableColumn { inner: Column { index: 0, column_type: Fixed } }"
+        );
+    }
+
+    #[test]
+    fn table_overwrite_non_default_cell() {
+        const K: u32 = 4;
+
+        #[derive(Clone)]
+        struct FaultyCircuitConfig {
+            table: TableColumn,
+        }
+
+        struct FaultyCircuit;
+
+        impl Circuit<Fp> for FaultyCircuit {
+            type Config = FaultyCircuitConfig;
+
+            type FloorPlanner = SimpleFloorPlanner;
+
+            fn without_witnesses(&self) -> Self {
+                Self
+            }
+
+            fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+                let a = meta.advice_column();
+                let table = meta.lookup_table_column();
+
+                meta.lookup(|cells| {
+                    let a = cells.query_advice(a, Rotation::cur());
+                    vec![(a, table)]
+                });
+
+                Self::Config { table }
+            }
+
+            fn synthesize(
+                &self,
+                config: Self::Config,
+                mut layouter: impl Layouter<Fp>,
+            ) -> Result<(), Error> {
+                layouter.assign_table(
+                    || "duplicate assignment",
+                    |mut table| {
+                        table.assign_cell(
+                            || "default",
+                            config.table,
+                            0,
+                            || Value::known(Fp::zero()),
+                        )?;
+                        table.assign_cell(
+                            || "first assignment",
+                            config.table,
+                            1,
+                            || Value::known(Fp::one()),
+                        )?;
+                        table.assign_cell(
+                            || "duplicate",
+                            config.table,
+                            1,
+                            || Value::known(Fp::from(2)),
+                        )
+                    },
+                )
+            }
+        }
+
+        let prover = MockProver::run(K, &FaultyCircuit, vec![]);
+        assert_eq!(
+            format!("{}", prover.unwrap_err()),
+            "Attempted to overwrite table value offset 1 with Value { inner: Some(Trivial(0x0000000000000000000000000000000000000000000000000000000000000002)) } in TableColumn { inner: Column { index: 0, column_type: Fixed } }"
         );
     }
 

--- a/halo2_proofs/src/plonk/error.rs
+++ b/halo2_proofs/src/plonk/error.rs
@@ -111,7 +111,7 @@ pub enum TableError {
     UnevenColumnLengths((TableColumn, usize), (TableColumn, usize)),
     /// Attempt to assign a used `TableColumn`
     UsedColumn(TableColumn),
-    /// Attempt to overwrite a default value
+    /// Attempt to overwrite a table value
     OverwriteDefault(TableColumn, String, String),
 }
 
@@ -136,7 +136,7 @@ impl fmt::Display for TableError {
             TableError::OverwriteDefault(col, default, val) => {
                 write!(
                     f,
-                    "Attempted to overwrite default value {} with {} in {:?}",
+                    "Attempted to overwrite table value {} with {} in {:?}",
                     default, val, col
                 )
             }


### PR DESCRIPTION
Closes #901

Reject duplicate assignments to the same lookup-table cell before mutating the
fixed-column assignment backend.

`TableLayouter::assign_cell` documents that assigning an already-assigned table
cell returns an error, but only default-row overwrites were rejected. Non-default
duplicate offsets could overwrite the stored fixed value for the same table
cell.

This PR adds the missing duplicate-offset check and regression coverage for both
default-row and non-default-row table overwrites.
