### PR TITLE
Clarify zero-window handling in decompose_word

### DIFF
--- a/halo2_gadgets/CHANGELOG.md
+++ b/halo2_gadgets/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Fixed
+- `halo2_gadgets::utilities::decompose_word` now rejects zero-bit windows with
+  an explicit panic message.
+
 ## [0.5.0] - 2026-06-02
 
 ### Added

--- a/halo2_gadgets/src/utilities.rs
+++ b/halo2_gadgets/src/utilities.rs
@@ -179,13 +179,13 @@ pub fn range_check<F: PrimeField>(word: Expression<F>, range: usize) -> Expressi
 ///
 /// # Panics
 ///
-/// We are returning a `Vec<u8>` which means the window size is limited to
-/// <= 8 bits.
+/// We are returning a `Vec<u8>` which means the window size must be in `1..=8`.
 pub fn decompose_word<F: PrimeFieldBits>(
     word: &F,
     word_num_bits: usize,
     window_num_bits: usize,
 ) -> Vec<u8> {
+    assert!(window_num_bits > 0, "window_num_bits must be non-zero");
     assert!(window_num_bits <= 8);
 
     // Pad bits to multiple of window_num_bits
@@ -449,6 +449,12 @@ mod tests {
             // Check that original scalar is recovered from decomposition
             assert_eq!(scalar, pallas::Scalar::from_repr(bytes.try_into().unwrap()).unwrap());
         }
+    }
+
+    #[test]
+    #[should_panic(expected = "window_num_bits must be non-zero")]
+    fn test_decompose_word_rejects_zero_window() {
+        decompose_word(&pallas::Scalar::ONE, pallas::Scalar::NUM_BITS as usize, 0);
     }
 
     #[test]


### PR DESCRIPTION
This PR clarifies the panic behavior of `halo2_gadgets::utilities::decompose_word` when called with a zero-bit window.

Previously, `window_num_bits = 0` reached the padding calculation and panicked due to division/remainder by zero. This change adds an explicit assertion before that calculation and updates the panic documentation to state that the window size must be in `1..=8`.

A regression test covers the zero-window case, and the `halo2_gadgets` changelog has been updated.
