### PR TITLE
halo2_proofs 0.3.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "assert_matches",
  "backtrace",

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-07-20
+### Added
+- `unstable-verifier-fingerprint` feature flag, gating capture-only tooling
+  that exposes the assembled verifier MSM fingerprint and can export it as a
+  Lean fixture. This feature is unstable and exempt from semver; it is off by
+  default and does not affect proof acceptance.
+- `halo2_proofs::plonk::fingerprint` module (behind the
+  `unstable-verifier-fingerprint` feature flag):
+  - `capture_proof_fingerprint`
+  - `ChallengeRecorder`
+  - `TranscriptEvent`
+
+### Changed
+- The `nightly` feature flag now also enables `unstable-verifier-fingerprint`.
+
 ## [0.3.2] - 2025-12-04
 ### Added
 - `halo2_proofs::circuit`:

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2_proofs"
-version = "0.3.2"
+version = "0.3.3"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Ying Tong Lai <yingtong@electriccoin.co>",


### PR DESCRIPTION
Release `halo2_proofs 0.3.3`.

Changes since 0.3.2 (all additive; no breaking changes to the existing public API):

### Added
- `unstable-verifier-fingerprint` feature flag, gating capture-only tooling that exposes the assembled verifier MSM fingerprint and can export it as a Lean fixture (#914). The feature is unstable and exempt from semver; it is off by default and does not affect proof acceptance.
- `halo2_proofs::plonk::fingerprint` module (behind the flag): `capture_proof_fingerprint`, `ChallengeRecorder`, `TranscriptEvent`.

### Changed
- The `nightly` feature flag now also enables `unstable-verifier-fingerprint`.

Also includes internal-only clippy cleanups.

Verified locally: `cargo test -p halo2_proofs` with default features and with `--features unstable-verifier-fingerprint`, plus `cargo publish --dry-run --locked -p halo2_proofs`.

After merge: tag `halo2_proofs-0.3.3` and `cargo publish -p halo2_proofs` (note: run publish with a modern cargo, e.g. `cargo +stable publish` — the pinned 1.60 toolchain uses the pre-sparse git registry index and hangs for a very long time on "Updating crates.io index").

🤖 Generated with [Claude Code](https://claude.com/claude-code)