### PR TITLE
halo2_proofs 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "assert_matches",
  "backtrace",

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.3.4] - 2026-07-22
+### Changed
+- `halo2_proofs::plonk::VerifyingKey::dump_vesta_lean_fixture` (behind the
+  `unstable-verifier-fingerprint` feature flag) now takes the verifier's
+  public `instances` (as in `verify_proof`) in place of the `num_proofs`
+  count. The exporter re-derives each instance commitment from the public
+  inputs and fails fast unless it reproduces the captured commitment, and the
+  exported fixture now emits the public inputs, their derivation, and an
+  `instance_commitments_derived` cross-check theorem. The exported Lean `vk`
+  now mirrors the Rust `VerifyingKey` field-for-field; its synthesized
+  `instanceCommitment` field has been removed.
+
 ## [0.3.3] - 2026-07-20
 ### Added
 - `unstable-verifier-fingerprint` feature flag, gating capture-only tooling

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2_proofs"
-version = "0.3.3"
+version = "0.3.4"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Ying Tong Lai <yingtong@electriccoin.co>",


### PR DESCRIPTION
Release `halo2_proofs 0.3.4`.

Changes since 0.3.3 (all within the `unstable-verifier-fingerprint` feature, which is unstable and exempt from semver; no changes to the stable public API):

### Changed
- `VerifyingKey::dump_vesta_lean_fixture` now takes the verifier's public `instances` (as in `verify_proof`) in place of the `num_proofs` count (#918). The exporter re-derives each instance commitment from the public inputs and fails fast unless it reproduces the captured commitment, and the fixture now emits the public inputs, their derivation, and an `instance_commitments_derived` cross-check theorem. The exported Lean `vk` now mirrors the Rust `VerifyingKey` field-for-field; its synthesized `instanceCommitment` field has been removed.

Verified locally: `cargo test -p halo2_proofs --features unstable-verifier-fingerprint` and `cargo publish --dry-run --locked -p halo2_proofs`.

After merge: tag `halo2_proofs-0.3.4` and publish with `cargo +stable publish --locked -p halo2_proofs` (the pinned 1.60 cargo hangs on "Updating crates.io index").

🤖 Generated with [Claude Code](https://claude.com/claude-code)