### PR TITLE
halo2_proofs 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -884,7 +884,7 @@ dependencies = [
 
 [[package]]
 name = "halo2_proofs"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "assert_matches",
  "backtrace",

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.3.5] - 2026-08-02
+### Added
+- `halo2_proofs::plonk::VerifyingKey::dump_vesta_lean_fixture_match_only`
+  (behind the `unstable-verifier-fingerprint` feature flag), the sibling of
+  `dump_vesta_lean_fixture` for captured *non-accepting* verifier runs (such
+  as random proof strings). In place of the honest exporter's eval theorems,
+  the exported fixture proves exact coefficient/term agreement of the
+  Lean-assembled MSM with the capture (`fingerprint_matches`) and that the
+  capture is non-accepting (`capturedMsm_evalNat_ne_zero`). The export fails
+  fast if the captured MSM *is* the group identity; accepting captures must
+  use `dump_vesta_lean_fixture`. Everything else (coordinate ordering,
+  on-curve validation, URS emission, instance-commitment re-derivation, and
+  the slot-reconstruction and term-count guards) is identical to the honest
+  exporter, so regeneration stays bit-reproducible across both modes.
+
 ## [0.3.4] - 2026-07-22
 ### Changed
 - `halo2_proofs::plonk::VerifyingKey::dump_vesta_lean_fixture` (behind the

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "halo2_proofs"
-version = "0.3.4"
+version = "0.3.5"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Ying Tong Lai <yingtong@electriccoin.co>",


### PR DESCRIPTION
Release `halo2_proofs 0.3.5`.

Changes since 0.3.4 (all within the `unstable-verifier-fingerprint` feature, which is unstable and exempt from semver; no changes to the stable public API):

### Added
- `VerifyingKey::dump_vesta_lean_fixture_match_only` (#924), the sibling of `dump_vesta_lean_fixture` for captured *non-accepting* verifier runs (such as random proof strings). In place of the honest exporter's eval theorems, the exported fixture proves exact coefficient/term agreement of the Lean-assembled MSM with the capture (`fingerprint_matches`) and that the capture is non-accepting (`capturedMsm_evalNat_ne_zero`). The export fails fast if the captured MSM *is* the group identity; accepting captures must use `dump_vesta_lean_fixture`. Everything else is identical to the honest exporter, so regeneration stays bit-reproducible across both modes.

Verified locally: `cargo +stable test -p halo2_proofs --features unstable-verifier-fingerprint` and `cargo +stable publish --dry-run --locked -p halo2_proofs`.

After merge: tag `halo2_proofs-0.3.5` and publish with `cargo +stable publish --locked -p halo2_proofs` (the pinned 1.60 cargo hangs on "Updating crates.io index").

🤖 Generated with [Claude Code](https://claude.com/claude-code)