### PR TITLE
Speed up IPA generator collapse with batched GLV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,12 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
-name = "bit_field"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,22 +585,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "exr"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1e481eb11a482815d3e9d618db8c42a93207134662873809335a92327440c18"
-dependencies = [
- "bit_field",
- "flume",
- "half 2.2.1",
- "lebe",
- "miniz_oxide",
- "rayon-core",
- "smallvec",
- "zune-inflate",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,19 +640,6 @@ name = "float-ord"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bad48618fdb549078c333a7a8528acb57af271d0433bdecd523eb620628364e"
-
-[[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
- "spin 0.9.8",
-]
 
 [[package]]
 name = "fnv"
@@ -750,18 +715,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures-core"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36d3378ee38c2a36ad710c5d30c2911d752cb941c00c72dbabfb786a7970817"
-
-[[package]]
 name = "getrandom"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -772,16 +725,6 @@ dependencies = [
  "libc",
  "wasi",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "gif"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06"
-dependencies = [
- "color_quant",
- "weezl",
 ]
 
 [[package]]
@@ -826,15 +769,6 @@ name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
-
-[[package]]
-name = "half"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
-dependencies = [
- "crunchy",
-]
 
 [[package]]
 name = "halo2"
@@ -896,7 +830,6 @@ dependencies = [
  "group",
  "gumdrop",
  "halo2_legacy_pdqsort",
- "image",
  "indexmap",
  "maybe-rayon",
  "pasta_curves",
@@ -904,7 +837,6 @@ dependencies = [
  "proptest",
  "rand_core",
  "tabbycat",
- "tempfile",
  "tracing",
 ]
 
@@ -956,14 +888,10 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
- "exr",
- "gif",
  "jpeg-decoder",
  "num-rational",
  "num-traits",
  "png",
- "scoped_threadpool",
- "tiff",
 ]
 
 [[package]]
@@ -1040,9 +968,6 @@ name = "jpeg-decoder"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9478aa10f73e7528198d75109c8be5cd7d15fb530238040148d5f9a22d4c5b3b"
-dependencies = [
- "rayon",
-]
 
 [[package]]
 name = "js-sys"
@@ -1059,14 +984,8 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
-
-[[package]]
-name = "lebe"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
@@ -1174,15 +1093,6 @@ checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
  "simd-adler32",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -1301,9 +1211,8 @@ dependencies = [
 
 [[package]]
 name = "pasta_curves"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e57598f73cc7e1b2ac63c79c517b31a0877cd7c402cdcaa311b5208de7a095"
+version = "0.5.2"
+source = "git+https://github.com/valargroup/pasta_curves?rev=21898a77810260ae8f2ed4f27058315729e683bc#21898a77810260ae8f2ed4f27058315729e683bc"
 dependencies = [
  "blake2b_simd",
  "ff",
@@ -1331,26 +1240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
 dependencies = [
  "rustc_version",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
 ]
 
 [[package]]
@@ -1723,12 +1612,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped_threadpool"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,7 +1638,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half 1.8.2",
+ "half",
  "serde",
 ]
 
@@ -1809,15 +1692,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1973,17 +1847,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.39",
-]
-
-[[package]]
-name = "tiff"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f71e422515e83e3ab8a03d4781d05ebf864fc61f4546e6ecffa58cbd34181a0"
-dependencies = [
- "flate2",
- "jpeg-decoder",
- "weezl",
 ]
 
 [[package]]
@@ -2165,12 +2028,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "weezl"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2295,13 +2152,4 @@ dependencies = [
  "dlib",
  "once_cell",
  "pkg-config",
-]
-
-[[package]]
-name = "zune-inflate"
-version = "0.2.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
-dependencies = [
- "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
     "halo2_poseidon",
     "halo2_proofs",
 ]
+
+[patch.crates-io]
+pasta_curves = { git = "https://github.com/valargroup/pasta_curves", rev = "21898a77810260ae8f2ed4f27058315729e683bc" }

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the [halo2_proofs](https://github.com/zcash/halo2/blob/
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.60** or higher.
+Requires Rust **1.63** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be done with a
 minor version bump.

--- a/halo2/CHANGELOG.md
+++ b/halo2/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The minimum supported Rust version is now 1.63.
+
 ## [0.1.0-beta.2] - 2022-02-14
 ### Removed
 - Everything (moved to `halo2_proofs` crate).

--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Jack Grigg <jack@electriccoin.co>",
 ]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 description = "[BETA] Fast zero-knowledge proof-carrying data implementation with no trusted setup"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zcash/halo2"

--- a/halo2_gadgets/CHANGELOG.md
+++ b/halo2_gadgets/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The minimum supported Rust version is now 1.63.
+
 ## [0.5.0] - 2026-06-02
 
 ### Added

--- a/halo2_gadgets/Cargo.toml
+++ b/halo2_gadgets/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Kris Nuttycombe <kris@electriccoin.co>",
 ]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 description = "Reusable gadgets and chip implementations for Halo 2"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zcash/halo2"

--- a/halo2_gadgets/README.md
+++ b/halo2_gadgets/README.md
@@ -1,6 +1,6 @@
 # halo2_gadgets [![Crates.io](https://img.shields.io/crates/v/halo2_gadgets.svg)](https://crates.io/crates/halo2_gadgets) #
 
-Requires Rust 1.60+.
+Requires Rust 1.63+.
 
 ## Documentation
 

--- a/halo2_poseidon/CHANGELOG.md
+++ b/halo2_poseidon/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The minimum supported Rust version is now 1.63.
+
 ## [0.1.0] - 2024-12-16
 Initial release, extracted from `halo2_gadgets 0.3.0`. Includes minor changes
 for `no-std` support.

--- a/halo2_poseidon/Cargo.toml
+++ b/halo2_poseidon/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Ying Tong Lai",
 ]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 description = "The Poseidon algebraic hash function for Halo 2"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zcash/halo2"

--- a/halo2_poseidon/README.md
+++ b/halo2_poseidon/README.md
@@ -1,6 +1,6 @@
 # halo2_poseidon [![Crates.io](https://img.shields.io/crates/v/halo2_poseidon.svg)](https://crates.io/crates/halo2_poseidon) #
 
-Requires Rust 1.60+.
+Requires Rust 1.63+.
 
 ## Documentation
 

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The IPA prover now batches the scalar multiplications used to collapse its
+  generator vector, using GLV for Pasta curves because the Fiat-Shamir
+  challenges are public.
+- The minimum supported Rust version is now 1.63.
+
 ## [0.3.5] - 2026-08-02
 ### Added
 - `halo2_proofs::plonk::VerifyingKey::dump_vesta_lean_fixture_match_only`

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
     "Jack Grigg <jack@electriccoin.co>",
 ]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 description = """
 Fast PLONK-based zero-knowledge proving system with no trusted setup
 """
@@ -52,7 +52,7 @@ backtrace = { version = "0.3", optional = true }
 ff = "0.13"
 group = "0.13"
 indexmap = "1"
-pasta_curves = "0.5"
+pasta_curves = { version = "0.5.2", features = ["glv"] }
 rand_core = { version = "0.6", default-features = false }
 tracing = "0.1"
 blake2b_simd = "1"
@@ -72,10 +72,8 @@ gumdrop = "0.8"
 proptest = "1"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 
-# Indirect dev-dependencies that we pin to preserve MSRV in CI checks.
+# Indirect dev-dependency that we pin to preserve MSRV in CI checks.
 dashmap = ">=5, <5.5.0" # dashmap 5.5.0 has MSRV 1.64
-image = ">=0.24, <0.24.5" # image 0.24.5 has MSRV 1.61
-tempfile = ">=3, <3.7.0" # tempfile 3.7.0 has MSRV 1.63
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 getrandom = { version = "0.2", features = ["js"] }

--- a/halo2_proofs/README.md
+++ b/halo2_proofs/README.md
@@ -4,7 +4,7 @@
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.60** or higher.
+Requires Rust **1.63** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be done with a
 minor version bump.

--- a/halo2_proofs/src/poly/commitment/prover.rs
+++ b/halo2_proofs/src/poly/commitment/prover.rs
@@ -4,11 +4,11 @@ use rand_core::RngCore;
 use super::super::{Coeff, Polynomial};
 use super::{Blind, Params};
 use crate::arithmetic::{
-    best_multiexp, compute_inner_product, eval_polynomial, parallelize, CurveAffine,
+    best_multiexp, compute_inner_product, eval_polynomial, parallelize, CurveAffine, CurveExt,
 };
 use crate::transcript::{EncodedChallenge, TranscriptWrite};
 
-use group::Curve;
+use group::{Curve, Group};
 use std::io;
 
 /// Create a polynomial commitment opening proof for the polynomial defined
@@ -156,11 +156,73 @@ fn parallel_generator_collapse<C: CurveAffine>(g: &mut [C], challenge: C::Scalar
     let (g_lo, g_hi) = g.split_at_mut(len);
 
     parallelize(g_lo, |g_lo, start| {
-        let g_hi = &g_hi[start..];
-        let mut tmp = Vec::with_capacity(g_lo.len());
-        for (g_lo, g_hi) in g_lo.iter().zip(g_hi.iter()) {
-            tmp.push(g_lo.to_curve() + &(*g_hi * challenge));
+        let g_hi = &g_hi[start..start + g_lo.len()];
+        let mut scaled = vec![C::Curve::identity(); g_hi.len()];
+        // The Fiat-Shamir challenge is public, so variable-time scalar
+        // multiplication is appropriate here.
+        <C::Curve as CurveExt>::batch_mul_same_scalar_vartime(g_hi, &challenge, &mut scaled);
+        for (scaled, g_lo) in scaled.iter_mut().zip(g_lo.iter()) {
+            *scaled += *g_lo;
         }
-        C::Curve::batch_normalize(&tmp, g_lo);
+        C::Curve::batch_normalize(&scaled, g_lo);
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parallel_generator_collapse;
+    use crate::arithmetic::CurveAffine;
+    use ff::Field;
+    use group::{Curve, Group};
+    use pasta_curves::{pallas, vesta};
+
+    fn generator_collapse_matches_native<C>()
+    where
+        C: CurveAffine + core::fmt::Debug,
+    {
+        let points: Vec<C> = (0..16)
+            .map(|i| {
+                if i == 3 || i == 12 {
+                    C::identity()
+                } else {
+                    C::from(C::Curve::generator() * C::Scalar::from(i as u64 + 1))
+                }
+            })
+            .collect();
+        let full_width = (C::Scalar::from(0x9E37_79B9_7F4A_7C15u64).square()
+            + C::Scalar::from(0x0123_4567_89AB_CDEFu64))
+        .square();
+        let challenges = [
+            C::Scalar::ZERO,
+            C::Scalar::ONE,
+            -C::Scalar::ONE,
+            C::Scalar::from(2),
+            full_width,
+        ];
+
+        for challenge in challenges {
+            let half = points.len() / 2;
+            let expected_projective: Vec<C::Curve> = points[..half]
+                .iter()
+                .zip(points[half..].iter())
+                .map(|(g_lo, g_hi)| g_lo.to_curve() + (*g_hi * challenge))
+                .collect();
+            let mut expected = vec![C::identity(); half];
+            C::Curve::batch_normalize(&expected_projective, &mut expected);
+
+            let mut actual = points.clone();
+            parallel_generator_collapse(&mut actual, challenge);
+            assert_eq!(&actual[..half], expected);
+        }
+    }
+
+    #[test]
+    fn generator_collapse_matches_native_pallas() {
+        generator_collapse_matches_native::<pallas::Affine>();
+    }
+
+    #[test]
+    fn generator_collapse_matches_native_vesta() {
+        generator_collapse_matches_native::<vesta::Affine>();
+    }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.63.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

Speeds up the IPA prover's generator-collapse step by batching the
multiplications that share one scalar.

Each IPA round computes the equivalent of

```text
g_lo[i] = g_lo[i] + challenge * g_hi[i]
```

for one challenge shared by the entire half-vector. The prover now delegates
that shared work to
`CurveExt::batch_mul_same_scalar_vartime`, adds the low-half points, and keeps
the existing final batch normalization. Pallas and Vesta use the batched GLV
implementation added by zcash/pasta_curves#97.

This also raises the workspace MSRV from Rust 1.60 to 1.63, as previously
agreed for this dependency update.

Depends on: https://github.com/zcash/pasta_curves/pull/97

## Security and correctness

The optimized multiplication is variable-time in the scalar. This call site
is appropriate because the scalar is a public Fiat-Shamir challenge and the
generator vector is public. No witness, blinding factor, spending key, or
other secret scalar enters this path.

The computation, transcript, proof encoding, and verifier are unchanged.
Focused Pallas and Vesta tests compare the optimized collapse with the prior
formula across identity points and scalar edge cases. Every benchmark backend
also creates and verifies a proof before measurement.

## Single-thread performance

These per-proof benchmarks deliberately use one worker so deployments can
parallelize independent proofs at a higher level. Results are means from an
ABBA run order on an otherwise idle arm64 machine.

| Workload | Native | Batched GLV | Latency reduction | Throughput |
| --- | ---: | ---: | ---: | ---: |
| Orchard proof, one action, protocol k = 11 | 3.925 s | 3.779 s | 3.73% | 1.039x |
| Synthetic Halo proof, k = 13 | 2.554 s | 1.804 s | 29.36% | 1.416x |
| k = 13 generator collapse only | 1.144 s | 395.4 ms | 65.44% | 2.893x |

The Orchard and synthetic rows are different circuits, so their absolute
times are not directly comparable. In the k = 13 run, generator collapse
accounts for 748.6 ms of the 749.7 ms end-to-end saving.

One k = 11 GLV run contained a severe high outlier outside generator collapse.
The ABBA median aggregate is 3.925 s to 3.769 s (3.98%, 1.042x), while the
directly affected collapse phase is stable at 240.7 ms to 83.9 ms (65.15%).

## Verifier impact

There is no direct verifier speedup in this PR. The new call is confined to
the IPA prover. Verification uses heterogeneous-scalar MSMs rather than a
vector multiplied by one shared scalar, so this particular batching hook does
not apply to either single or batch verification.

## API-surface audit

- No public Rust item, signature, or visibility changes are made in this
  repository.
- The `rust-version` of `halo2`, `halo2_proofs`, `halo2_gadgets`, and
  `halo2_poseidon` changes from 1.60 to 1.63.
- `halo2_proofs` enables the `pasta_curves/glv` dependency feature. Because
  `pasta_curves` is already publicly re-exported as `halo2_proofs::pasta`, this
  also makes `halo2_proofs::pasta::glv` reachable downstream.
- The minimum `pasta_curves` requirement changes from `0.5` to `0.5.2` in the
  draft. It must be updated to the release containing zcash/pasta_curves#97
  before merge.
- No `pub(crate)` item, Cargo feature, enum variant, type alias, constant, or
  constructor is added or changed.

## Validation

- Rust 1.63 workspace all-features check
- Rust 1.63 formatting check
- `halo2_proofs` all-features release tests and doctests
- focused Pallas and Vesta generator-collapse equivalence tests
- default-feature Clippy with warnings denied
- proof-generation preflights verified for the k = 11 and k = 13 benchmark
  workloads

## Stacked dependency note

This draft temporarily pins commit
`21898a77810260ae8f2ed4f27058315729e683bc` from the `valargroup/pasta_curves`
branch through `[patch.crates-io]`, so CI and reviewers can exercise the stack
before the prerequisite is published. This override must be removed and the
normal crates.io dependency updated after zcash/pasta_curves#97 is released;
the crate must not be released with the git patch.
