### PR TITLE
Optimize small constants and subtraction in the polynomial evaluator

### DIFF
--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- The internal polynomial evaluator now avoids field multiplication for scales
+  by $1$ and $-1$, and evaluates subtraction without materializing a negated
+  polynomial.
+
 ## [0.3.5] - 2026-08-02
 ### Added
 - `halo2_proofs::plonk::VerifyingKey::dump_vesta_lean_fixture_match_only`

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -8,9 +8,9 @@ and this project adheres to Rust's notion of
 ## [Unreleased]
 
 ### Changed
-- The internal polynomial evaluator now avoids field multiplication for scales
-  by $1$ and $-1$, and evaluates subtraction without materializing a negated
-  polynomial.
+- The internal polynomial evaluator now uses field identity, negation, or
+  doubling for multiplications by $1$, $-1$, or $2$, and evaluates subtraction
+  without materializing a negated polynomial.
 
 ## [0.3.5] - 2026-08-02
 ### Added

--- a/halo2_proofs/src/poly/evaluator.rs
+++ b/halo2_proofs/src/poly/evaluator.rs
@@ -162,6 +162,16 @@ impl<E, F: Field, B: Basis> Evaluator<E, F, B> {
                 ),
                 Ast::Add(a, b) => {
                     let mut lhs = recurse(a, ctx);
+                    if let Ast::Scale(rhs, scalar) = b.as_ref() {
+                        if *scalar == -F::ONE {
+                            let rhs = recurse(rhs, ctx);
+                            for (lhs, rhs) in lhs.iter_mut().zip(rhs.iter()) {
+                                *lhs -= *rhs;
+                            }
+                            return lhs;
+                        }
+                    }
+
                     let rhs = recurse(b, ctx);
                     for (lhs, rhs) in lhs.iter_mut().zip(rhs.iter()) {
                         *lhs += *rhs;
@@ -678,5 +688,18 @@ mod tests {
             let result = evaluator.evaluate(&(Ast::ConstantTerm(value) * scalar), &domain);
             assert!(result.iter().all(|result| *result == expected));
         }
+    }
+
+    #[test]
+    fn subtract_polynomials() {
+        let domain = EvaluationDomain::new(1, 4);
+        let mut evaluator = new_evaluator::<_, _, ExtendedLagrangeCoeff>(|| {});
+        evaluator.register_poly(ExtendedLagrangeCoeff::empty_poly(&domain));
+
+        let lhs = pallas::Base::from(42);
+        let rhs = pallas::Base::from(17);
+        let result =
+            evaluator.evaluate(&(Ast::ConstantTerm(lhs) - Ast::ConstantTerm(rhs)), &domain);
+        assert!(result.iter().all(|result| *result == lhs - rhs));
     }
 }

--- a/halo2_proofs/src/poly/evaluator.rs
+++ b/halo2_proofs/src/poly/evaluator.rs
@@ -178,8 +178,14 @@ impl<E, F: Field, B: Basis> Evaluator<E, F, B> {
                 }
                 Ast::Scale(a, scalar) => {
                     let mut lhs = recurse(a, ctx);
-                    for lhs in lhs.iter_mut() {
-                        *lhs *= scalar;
+                    if *scalar == -F::ONE {
+                        for lhs in lhs.iter_mut() {
+                            *lhs = -*lhs;
+                        }
+                    } else if *scalar != F::ONE {
+                        for lhs in lhs.iter_mut() {
+                            *lhs *= scalar;
+                        }
                     }
                     lhs
                 }
@@ -659,5 +665,18 @@ mod tests {
         test_case(k, new_evaluator::<_, _, Coeff>(|| {}));
         test_case(k, new_evaluator::<_, _, LagrangeCoeff>(|| {}));
         test_case(k, new_evaluator::<_, _, ExtendedLagrangeCoeff>(|| {}));
+    }
+
+    #[test]
+    fn scale_by_identity_values() {
+        let domain = EvaluationDomain::new(1, 4);
+        let mut evaluator = new_evaluator::<_, _, ExtendedLagrangeCoeff>(|| {});
+        evaluator.register_poly(ExtendedLagrangeCoeff::empty_poly(&domain));
+
+        let value = pallas::Base::from(42);
+        for (scalar, expected) in [(pallas::Base::ONE, value), (-pallas::Base::ONE, -value)] {
+            let result = evaluator.evaluate(&(Ast::ConstantTerm(value) * scalar), &domain);
+            assert!(result.iter().all(|result| *result == expected));
+        }
     }
 }

--- a/halo2_proofs/src/poly/evaluator.rs
+++ b/halo2_proofs/src/poly/evaluator.rs
@@ -146,6 +146,8 @@ impl<E, F: Field, B: Basis> Evaluator<E, F, B> {
             chunk_size: usize,
             chunk_index: usize,
             polys: &'a [Polynomial<F, B>],
+            minus_one: F,
+            two: F,
         }
 
         fn recurse<E, F: WithSmallOrderMulGroup<3>, B: BasisOps>(
@@ -163,7 +165,7 @@ impl<E, F: Field, B: Basis> Evaluator<E, F, B> {
                 Ast::Add(a, b) => {
                     let mut lhs = recurse(a, ctx);
                     if let Ast::Scale(rhs, scalar) = b.as_ref() {
-                        if *scalar == -F::ONE {
+                        if *scalar == ctx.minus_one {
                             let rhs = recurse(rhs, ctx);
                             for (lhs, rhs) in lhs.iter_mut().zip(rhs.iter()) {
                                 *lhs -= *rhs;
@@ -179,6 +181,19 @@ impl<E, F: Field, B: Basis> Evaluator<E, F, B> {
                     lhs
                 }
                 Ast::Mul(AstMul(a, b)) => {
+                    // Preserve the multiplication shape while avoiding a constant
+                    // vector for scalars with cheap field operations.
+                    if let Ast::ConstantTerm(scalar) = a.as_ref() {
+                        if let Some(rhs) = recurse_small_scale(b, *scalar, ctx) {
+                            return rhs;
+                        }
+                    }
+                    if let Ast::ConstantTerm(scalar) = b.as_ref() {
+                        if let Some(lhs) = recurse_small_scale(a, *scalar, ctx) {
+                            return lhs;
+                        }
+                    }
+
                     let mut lhs = recurse(a, ctx);
                     let rhs = recurse(b, ctx);
                     for (lhs, rhs) in lhs.iter_mut().zip(rhs.iter()) {
@@ -186,19 +201,16 @@ impl<E, F: Field, B: Basis> Evaluator<E, F, B> {
                     }
                     lhs
                 }
-                Ast::Scale(a, scalar) => {
-                    let mut lhs = recurse(a, ctx);
-                    if *scalar == -F::ONE {
-                        for lhs in lhs.iter_mut() {
-                            *lhs = -*lhs;
-                        }
-                    } else if *scalar != F::ONE {
+                Ast::Scale(a, scalar) => match recurse_small_scale(a, *scalar, ctx) {
+                    Some(lhs) => lhs,
+                    None => {
+                        let mut lhs = recurse(a, ctx);
                         for lhs in lhs.iter_mut() {
                             *lhs *= scalar;
                         }
+                        lhs
                     }
-                    lhs
-                }
+                },
                 Ast::DistributePowers(terms, base) => terms.iter().fold(
                     B::constant_term(ctx.poly_len, ctx.chunk_size, ctx.chunk_index, F::ZERO),
                     |mut acc, term| {
@@ -223,8 +235,34 @@ impl<E, F: Field, B: Basis> Evaluator<E, F, B> {
             }
         }
 
+        fn recurse_small_scale<E, F: WithSmallOrderMulGroup<3>, B: BasisOps>(
+            ast: &Ast<E, F, B>,
+            scalar: F,
+            ctx: &AstContext<'_, F, B>,
+        ) -> Option<Vec<F>> {
+            if scalar == ctx.minus_one {
+                let mut values = recurse(ast, ctx);
+                for value in values.iter_mut() {
+                    *value = -*value;
+                }
+                Some(values)
+            } else if scalar == F::ONE {
+                Some(recurse(ast, ctx))
+            } else if scalar == ctx.two {
+                let mut values = recurse(ast, ctx);
+                for value in values.iter_mut() {
+                    *value = value.double();
+                }
+                Some(values)
+            } else {
+                None
+            }
+        }
+
         // Apply `ast` to each chunk in parallel, writing the result into an output
         // polynomial.
+        let minus_one = -F::ONE;
+        let two = F::ONE.double();
         let mut result = B::empty_poly(domain);
         multicore::scope(|scope| {
             for (chunk_index, out) in result.chunks_mut(chunk_size).enumerate() {
@@ -235,6 +273,8 @@ impl<E, F: Field, B: Basis> Evaluator<E, F, B> {
                         chunk_size,
                         chunk_index,
                         polys: &self.polys,
+                        minus_one,
+                        two,
                     };
                     out.copy_from_slice(&recurse(ast, &ctx));
                 });
@@ -678,16 +718,66 @@ mod tests {
     }
 
     #[test]
-    fn scale_by_identity_values() {
+    fn scale_by_small_values() {
         let domain = EvaluationDomain::new(1, 4);
         let mut evaluator = new_evaluator::<_, _, ExtendedLagrangeCoeff>(|| {});
         evaluator.register_poly(ExtendedLagrangeCoeff::empty_poly(&domain));
 
         let value = pallas::Base::from(42);
-        for (scalar, expected) in [(pallas::Base::ONE, value), (-pallas::Base::ONE, -value)] {
+        for (scalar, expected) in [
+            (pallas::Base::ONE, value),
+            (-pallas::Base::ONE, -value),
+            (pallas::Base::ONE.double(), value.double()),
+        ] {
             let result = evaluator.evaluate(&(Ast::ConstantTerm(value) * scalar), &domain);
             assert!(result.iter().all(|result| *result == expected));
         }
+    }
+
+    #[test]
+    fn multiply_by_constant_terms() {
+        fn check<B: BasisOps>()
+        where
+            Ast<fn(), pallas::Base, B>: std::ops::Mul<Output = Ast<fn(), pallas::Base, B>>,
+        {
+            fn context() {}
+
+            let domain = EvaluationDomain::new(1, 4);
+            let mut poly = B::empty_poly(&domain);
+            for (index, value) in poly.iter_mut().enumerate() {
+                *value = pallas::Base::from(index as u64 + 7);
+            }
+            let expected = poly.clone();
+
+            let mut evaluator = new_evaluator::<fn(), _, B>(context);
+            let leaf = evaluator.register_poly(poly);
+            let two = pallas::Base::ONE.double();
+
+            for scalar in [
+                -pallas::Base::ONE,
+                pallas::Base::ONE,
+                two,
+                pallas::Base::from(7),
+            ] {
+                let constant = Ast::ConstantTerm(scalar);
+                let expression = Ast::from(leaf);
+                let constant_lhs = constant.clone() * expression.clone();
+                let constant_rhs = expression * constant;
+
+                for ast in [constant_lhs, constant_rhs] {
+                    assert!(matches!(&ast, Ast::Mul(_)));
+
+                    let result = evaluator.evaluate(&ast, &domain);
+                    assert!(result
+                        .iter()
+                        .zip(expected.iter())
+                        .all(|(result, value)| *result == *value * scalar));
+                }
+            }
+        }
+
+        check::<LagrangeCoeff>();
+        check::<ExtendedLagrangeCoeff>();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This removes avoidable field work in the internal polynomial evaluator:

- Scales and direct constant products by `1`, `-1`, and `2` now use identity,
  negation, and doubling respectively instead of general field
  multiplication. Direct products are recognized with the constant on either
  side.
- `Ast::Add(lhs, Ast::Scale(rhs, -1))`, the representation produced by the
  subtraction operators, now subtracts `rhs` directly instead of first
  materializing and negating a complete intermediate vector.

The three changes are separate commits. They preserve the existing AST shapes
and evaluation interfaces; in particular, direct constant products are not
rewritten during AST construction. Values `3` and above retain the generic
multiplication path.

## Performance

In the single-threaded genuine one-action Orchard proving benchmark, avoiding
identity-scale multiplications reduced proving time by about 15.6%. Direct
subtraction removed a further 3.0% on the then-current stacked branch. The
combined effect is approximately 18% less proving time for this benchmark.

Against the two-commit PR head, the small-constant change reduced a stable
single-threaded bracket from 1,082.5 ms to 1,077.1 ms, or 0.50%. At Orchard's
16,384-point extended domain it avoids or replaces 901,120 general field
multiplications per proof: 262,144 identity products are eliminated and
638,976 multiplications by two become field doublings.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p halo2_proofs --lib`
- `cargo test -p halo2_proofs --no-default-features --lib`
- `cargo clippy -p halo2_proofs --lib -- -D warnings`
- Focused tests exercise both polynomial bases, constants on either product
  side, the `-1`/`1`/`2` paths, an arbitrary generic constant, and the
  subtraction AST path.

## API and dependencies

- No public or `pub(crate)` API changes.
- No function-signature or visibility changes.
- No feature or dependency changes.
