### PR TITLE
Reduce verifier instance-commitment overhead

### DIFF
--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to Rust's notion of
 - `halo2_proofs::plonk::verify_proof` now computes instance commitments
   directly from their supplied Lagrange coefficients, without zero-padding to
   the evaluation domain.
+- `halo2_proofs::plonk::verify_proof` now batch-normalizes instance commitments
+  when verifying at least four commitments.
 - `halo2_proofs::arithmetic::best_multiexp` now computes each scalar's
   canonical representation once per MSM instead of once per window.
 

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- `halo2_proofs::plonk::verify_proof` now computes instance commitments
+  directly from their supplied Lagrange coefficients, without zero-padding to
+  the evaluation domain.
+
 ## [0.3.5] - 2026-08-02
 ### Added
 - `halo2_proofs::plonk::VerifyingKey::dump_vesta_lean_fixture_match_only`

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to Rust's notion of
 - `halo2_proofs::plonk::verify_proof` now computes instance commitments
   directly from their supplied Lagrange coefficients, without zero-padding to
   the evaluation domain.
+- `halo2_proofs::arithmetic::best_multiexp` now computes each scalar's
+  canonical representation once per MSM instead of once per window.
 
 ## [0.3.5] - 2026-08-02
 ### Added

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -40,6 +40,10 @@ name = "plonk"
 harness = false
 
 [[bench]]
+name = "plonk_verifier"
+harness = false
+
+[[bench]]
 name = "dev_lookup"
 harness = false
 

--- a/halo2_proofs/benches/plonk_verifier.rs
+++ b/halo2_proofs/benches/plonk_verifier.rs
@@ -1,0 +1,165 @@
+//! Benchmarks batched verification with the instance layout used by Orchard:
+//! a size-$2^{11}$ domain and nine instance values per action. The benchmark
+//! circuit is intentionally minimal, so this is not a full Orchard benchmark.
+
+#[macro_use]
+extern crate criterion;
+
+use criterion::{BenchmarkId, Criterion};
+use halo2_proofs::{
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    pasta::{EqAffine, Fp},
+    plonk::{
+        create_proof, keygen_pk, keygen_vk, verify_proof, Advice, Circuit, Column,
+        ConstraintSystem, Error, Instance, ProvingKey, SingleVerifier,
+    },
+    poly::commitment::Params,
+    transcript::{Blake2bRead, Blake2bWrite, Challenge255},
+};
+use rand_core::OsRng;
+
+const K: u32 = 11;
+const NUM_INSTANCE_VALUES: usize = 9;
+const ACTION_COUNTS: [usize; 4] = [1, 2, 16, 64];
+
+#[derive(Clone, Debug)]
+struct ActionConfig {
+    advice: Column<Advice>,
+    instance: Column<Instance>,
+}
+
+#[derive(Clone)]
+struct ActionCircuit {
+    values: Vec<Value<Fp>>,
+}
+
+impl Circuit<Fp> for ActionCircuit {
+    type Config = ActionConfig;
+    type FloorPlanner = SimpleFloorPlanner;
+
+    fn without_witnesses(&self) -> Self {
+        Self {
+            values: vec![Value::unknown(); self.values.len()],
+        }
+    }
+
+    fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+        let advice = meta.advice_column();
+        let instance = meta.instance_column();
+        meta.enable_equality(advice);
+        meta.enable_equality(instance);
+
+        ActionConfig { advice, instance }
+    }
+
+    fn synthesize(
+        &self,
+        config: Self::Config,
+        mut layouter: impl Layouter<Fp>,
+    ) -> Result<(), Error> {
+        let cells = layouter.assign_region(
+            || "load action instance values",
+            |mut region| {
+                self.values
+                    .iter()
+                    .enumerate()
+                    .map(|(offset, value)| {
+                        region
+                            .assign_advice(
+                                || "action instance value",
+                                config.advice,
+                                offset,
+                                || *value,
+                            )
+                            .map(|cell| cell.cell())
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            },
+        )?;
+
+        for (row, cell) in cells.into_iter().enumerate() {
+            layouter.constrain_instance(cell, config.instance, row)?;
+        }
+
+        Ok(())
+    }
+}
+
+struct VerificationCase {
+    proof: Vec<u8>,
+    public_inputs: Vec<Vec<Fp>>,
+}
+
+fn create_verification_case(
+    params: &Params<EqAffine>,
+    pk: &ProvingKey<EqAffine>,
+    num_actions: usize,
+) -> VerificationCase {
+    let public_inputs = (0..num_actions)
+        .map(|action| {
+            (0..NUM_INSTANCE_VALUES)
+                .map(|value| Fp::from((action * NUM_INSTANCE_VALUES + value) as u64))
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+    let circuits = public_inputs
+        .iter()
+        .map(|values| ActionCircuit {
+            values: values.iter().copied().map(Value::known).collect(),
+        })
+        .collect::<Vec<_>>();
+    let instance_columns = public_inputs
+        .iter()
+        .map(|values| [values.as_slice()])
+        .collect::<Vec<_>>();
+    let instances = instance_columns
+        .iter()
+        .map(|columns| columns.as_slice())
+        .collect::<Vec<_>>();
+
+    let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(Vec::new());
+    create_proof(params, pk, &circuits, &instances, OsRng, &mut transcript)
+        .expect("proof generation should not fail");
+
+    VerificationCase {
+        proof: transcript.finalize(),
+        public_inputs,
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let params = Params::<EqAffine>::new(K);
+    let empty_circuit = ActionCircuit {
+        values: vec![Value::unknown(); NUM_INSTANCE_VALUES],
+    };
+    let vk = keygen_vk(&params, &empty_circuit).expect("keygen_vk should not fail");
+    let pk = keygen_pk(&params, vk, &empty_circuit).expect("keygen_pk should not fail");
+
+    let mut group = c.benchmark_group("plonk-verifier-orchard-shaped");
+    for num_actions in ACTION_COUNTS {
+        let verification_case = create_verification_case(&params, &pk, num_actions);
+        let instance_columns = verification_case
+            .public_inputs
+            .iter()
+            .map(|values| [values.as_slice()])
+            .collect::<Vec<_>>();
+        let instances = instance_columns
+            .iter()
+            .map(|columns| columns.as_slice())
+            .collect::<Vec<_>>();
+
+        group.bench_function(BenchmarkId::new("actions", num_actions), |b| {
+            b.iter(|| {
+                let strategy = SingleVerifier::new(&params);
+                let mut transcript =
+                    Blake2bRead::<_, _, Challenge255<_>>::init(&verification_case.proof[..]);
+                verify_proof(&params, pk.get_vk(), strategy, &instances, &mut transcript)
+                    .expect("proof verification should not fail");
+            });
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/halo2_proofs/src/arithmetic.rs
+++ b/halo2_proofs/src/arithmetic.rs
@@ -71,10 +71,15 @@ impl<C: CurveAffine> Buckets<C> {
         }
     }
 
-    fn sum(&mut self, coeffs: &[C::Scalar], bases: &[C], i: usize) -> C::Curve {
+    fn sum(
+        &mut self,
+        coeffs: &[<C::Scalar as PrimeField>::Repr],
+        bases: &[C],
+        i: usize,
+    ) -> C::Curve {
         // get segmentation and add coeff to buckets content
         for (coeff, base) in coeffs.iter().zip(bases.iter()) {
-            let seg = self.get_at::<C::Scalar>(i, &coeff.to_repr());
+            let seg = self.get_at(i, coeff);
             if seg != 0 {
                 self.coeffs[seg - 1].add_assign(base);
             }
@@ -92,7 +97,7 @@ impl<C: CurveAffine> Buckets<C> {
         acc
     }
 
-    fn get_at<F: PrimeField>(&self, segment: usize, bytes: &F::Repr) -> usize {
+    fn get_at(&self, segment: usize, bytes: &<C::Scalar as PrimeField>::Repr) -> usize {
         let skip_bits = segment * self.c;
         let skip_bytes = skip_bits / 8;
 
@@ -143,6 +148,9 @@ pub fn small_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::C
 pub fn best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
     assert_eq!(coeffs.len(), bases.len());
 
+    // Convert to canonical representations once instead of once per window.
+    let coeffs = coeffs.iter().map(PrimeField::to_repr).collect::<Vec<_>>();
+
     let c = if bases.len() < 4 {
         1
     } else if bases.len() < 32 {
@@ -159,7 +167,7 @@ pub fn best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Cu
             .enumerate()
             .rev()
             .map(|(i, buckets)| {
-                let mut acc = buckets.sum(coeffs, bases, i);
+                let mut acc = buckets.sum(&coeffs, bases, i);
                 (0..c * i).for_each(|_| acc = acc.double());
                 acc
             })
@@ -170,7 +178,7 @@ pub fn best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Cu
             .iter_mut()
             .enumerate()
             .rev()
-            .map(|(i, buckets)| buckets.sum(coeffs, bases, i))
+            .map(|(i, buckets)| buckets.sum(&coeffs, bases, i))
             .fold(C::Curve::identity(), |mut sum, bucket| {
                 // restore original evaluation point
                 (0..c).for_each(|_| sum = sum.double());

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -18,6 +18,9 @@ mod batch;
 #[cfg(feature = "batch")]
 pub use batch::BatchVerifier;
 
+// Batch normalization costs more than individual normalization below this.
+const MIN_BATCH_NORMALIZE: usize = 4;
+
 fn commit_instance<C: CurveAffine>(params: &Params<C>, instance: &[C::Scalar]) -> C::Curve {
     let mut scalars = Vec::with_capacity(instance.len() + 1);
     scalars.extend(instance);
@@ -96,21 +99,55 @@ pub fn verify_proof<
         }
     }
 
-    let instance_commitments = instances
+    let max_instance_len = params.n as usize - (vk.cs.blinding_factors() + 1);
+    if instances
         .iter()
-        .map(|instance| {
-            instance
-                .iter()
-                .map(|instance| {
-                    if instance.len() > params.n as usize - (vk.cs.blinding_factors() + 1) {
-                        return Err(Error::InstanceTooLarge);
-                    }
+        .flat_map(|instance| instance.iter())
+        .any(|instance| instance.len() > max_instance_len)
+    {
+        return Err(Error::InstanceTooLarge);
+    }
 
-                    Ok(commit_instance(params, instance).to_affine())
-                })
-                .collect::<Result<Vec<_>, _>>()
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let batch_normalize = instances
+        .iter()
+        .flat_map(|instance| instance.iter())
+        .take(MIN_BATCH_NORMALIZE)
+        .count()
+        == MIN_BATCH_NORMALIZE;
+    let instance_commitments = if !batch_normalize {
+        instances
+            .iter()
+            .map(|instance| {
+                instance
+                    .iter()
+                    .map(|instance| commit_instance(params, instance).to_affine())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>()
+    } else {
+        let instance_commitments_projective = instances
+            .iter()
+            .flat_map(|instance| instance.iter())
+            .map(|instance| commit_instance(params, instance))
+            .collect::<Vec<_>>();
+        let mut normalized_commitments = vec![C::identity(); instance_commitments_projective.len()];
+        C::Curve::batch_normalize(
+            &instance_commitments_projective,
+            &mut normalized_commitments,
+        );
+        let mut normalized_commitments = normalized_commitments.into_iter();
+        let instance_commitments = instances
+            .iter()
+            .map(|instance| {
+                normalized_commitments
+                    .by_ref()
+                    .take(instance.len())
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>();
+        debug_assert!(normalized_commitments.next().is_none());
+        instance_commitments
+    };
 
     let num_proofs = instance_commitments.len();
 
@@ -348,14 +385,66 @@ pub fn verify_proof<
 
 #[cfg(test)]
 mod tests {
-    use super::commit_instance;
+    use super::{commit_instance, verify_proof, SingleVerifier, MIN_BATCH_NORMALIZE};
     use crate::{
+        circuit::{Layouter, SimpleFloorPlanner, Value},
         pasta::{EqAffine, Fp},
+        plonk::{
+            create_proof, keygen_pk, keygen_vk, Advice, Circuit, Column, ConstraintSystem, Error,
+            Instance,
+        },
         poly::{
             commitment::{Blind, Params},
             EvaluationDomain,
         },
+        transcript::{Blake2bRead, Blake2bWrite, Challenge255},
     };
+    use rand_core::OsRng;
+
+    #[derive(Clone, Debug)]
+    struct TestConfig {
+        advice: Column<Advice>,
+        instance: Column<Instance>,
+    }
+
+    #[derive(Clone)]
+    struct TestCircuit {
+        value: Value<Fp>,
+    }
+
+    impl Circuit<Fp> for TestCircuit {
+        type Config = TestConfig;
+        type FloorPlanner = SimpleFloorPlanner;
+
+        fn without_witnesses(&self) -> Self {
+            Self {
+                value: Value::unknown(),
+            }
+        }
+
+        fn configure(meta: &mut ConstraintSystem<Fp>) -> Self::Config {
+            let advice = meta.advice_column();
+            let instance = meta.instance_column();
+            meta.enable_equality(advice);
+            meta.enable_equality(instance);
+
+            TestConfig { advice, instance }
+        }
+
+        fn synthesize(
+            &self,
+            config: Self::Config,
+            mut layouter: impl Layouter<Fp>,
+        ) -> Result<(), Error> {
+            let cell = layouter.assign_region(
+                || "assign instance value",
+                |mut region| {
+                    region.assign_advice(|| "instance value", config.advice, 0, || self.value)
+                },
+            )?;
+            layouter.constrain_instance(cell.cell(), config.instance, 0)
+        }
+    }
 
     #[test]
     fn instance_commitment_matches_zero_padded_commitment() {
@@ -376,5 +465,44 @@ mod tests {
                 params.commit_lagrange(&padded, Blind::default()),
             );
         }
+    }
+
+    #[test]
+    fn batch_normalized_instance_commitments_verify() {
+        const K: u32 = 4;
+
+        let params = Params::<EqAffine>::new(K);
+        let empty_circuit = TestCircuit {
+            value: Value::unknown(),
+        };
+        let vk = keygen_vk(&params, &empty_circuit).expect("keygen_vk should not fail");
+        let pk = keygen_pk(&params, vk, &empty_circuit).expect("keygen_pk should not fail");
+        let public_inputs = (0..MIN_BATCH_NORMALIZE)
+            .map(|i| vec![Fp::from(i as u64 + 1)])
+            .collect::<Vec<_>>();
+        let circuits = public_inputs
+            .iter()
+            .map(|values| TestCircuit {
+                value: Value::known(values[0]),
+            })
+            .collect::<Vec<_>>();
+        let instance_columns = public_inputs
+            .iter()
+            .map(|values| [values.as_slice()])
+            .collect::<Vec<_>>();
+        let instances = instance_columns
+            .iter()
+            .map(|columns| columns.as_slice())
+            .collect::<Vec<_>>();
+
+        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(Vec::new());
+        create_proof(&params, &pk, &circuits, &instances, OsRng, &mut transcript)
+            .expect("proof generation should not fail");
+        let proof = transcript.finalize();
+
+        let strategy = SingleVerifier::new(&params);
+        let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
+        verify_proof(&params, pk.get_vk(), strategy, &instances, &mut transcript)
+            .expect("proof verification should not fail");
     }
 }

--- a/halo2_proofs/src/plonk/verifier.rs
+++ b/halo2_proofs/src/plonk/verifier.rs
@@ -6,7 +6,7 @@ use super::{
     vanishing, ChallengeBeta, ChallengeGamma, ChallengeTheta, ChallengeX, ChallengeY, Error,
     VerifyingKey,
 };
-use crate::arithmetic::CurveAffine;
+use crate::arithmetic::{best_multiexp, CurveAffine};
 use crate::poly::{
     commitment::{Blind, Guard, Params, MSM},
     multiopen::{self, VerifierQuery},
@@ -17,6 +17,18 @@ use crate::transcript::{read_n_points, read_n_scalars, EncodedChallenge, Transcr
 mod batch;
 #[cfg(feature = "batch")]
 pub use batch::BatchVerifier;
+
+fn commit_instance<C: CurveAffine>(params: &Params<C>, instance: &[C::Scalar]) -> C::Curve {
+    let mut scalars = Vec::with_capacity(instance.len() + 1);
+    scalars.extend(instance);
+    scalars.push(Blind::default().0);
+
+    let mut bases = Vec::with_capacity(instance.len() + 1);
+    bases.extend(&params.g_lagrange[..instance.len()]);
+    bases.push(params.w);
+
+    best_multiexp::<C>(&scalars, &bases)
+}
 
 /// Trait representing a strategy for verifying Halo 2 proofs.
 pub trait VerificationStrategy<'params, C: CurveAffine> {
@@ -93,11 +105,8 @@ pub fn verify_proof<
                     if instance.len() > params.n as usize - (vk.cs.blinding_factors() + 1) {
                         return Err(Error::InstanceTooLarge);
                     }
-                    let mut poly = instance.to_vec();
-                    poly.resize(params.n as usize, C::Scalar::ZERO);
-                    let poly = vk.domain.lagrange_from_vec(poly);
 
-                    Ok(params.commit_lagrange(&poly, Blind::default()).to_affine())
+                    Ok(commit_instance(params, instance).to_affine())
                 })
                 .collect::<Result<Vec<_>, _>>()
         })
@@ -335,4 +344,37 @@ pub fn verify_proof<
     strategy.process(|msm| {
         multiopen::verify_proof(params, transcript, queries, msm).map_err(|_| Error::Opening)
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::commit_instance;
+    use crate::{
+        pasta::{EqAffine, Fp},
+        poly::{
+            commitment::{Blind, Params},
+            EvaluationDomain,
+        },
+    };
+
+    #[test]
+    fn instance_commitment_matches_zero_padded_commitment() {
+        const K: u32 = 5;
+
+        let params = Params::<EqAffine>::new(K);
+        let domain = EvaluationDomain::new(1, K);
+
+        for len in [0, 1, 9, 1 << K] {
+            let instance = (0..len).map(|i| Fp::from(i as u64)).collect::<Vec<_>>();
+            let mut padded = domain.empty_lagrange();
+            for (coefficient, value) in padded.iter_mut().zip(instance.iter()) {
+                *coefficient = *value;
+            }
+
+            assert_eq!(
+                commit_instance(&params, &instance),
+                params.commit_lagrange(&padded, Blind::default()),
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

This contains three independently reviewable commits:

1. Commit directly to the supplied Lagrange-prefix instance values instead of
   allocating and processing a domain-sized zero-padded vector.
2. Convert MSM scalars to canonical representations once per MSM instead of
   once per Pippenger window.
3. Batch-normalize instance commitments when a verification call contains at
   least four commitments; smaller calls retain individual normalization.

It also adds an Orchard-shaped Criterion benchmark at $k = 11$ with nine public
inputs per action and action counts 1, 2, 16, and 64.

## Performance

The following external integration measurements use `zcash/orchard` at
`2b531b9d`, an Apple M4 Max, Rust 1.85.1, and one Rayon thread. Proof creation
is outside the timed region. Each batch is drawn from 64 separately encoded
genuine one-action Orchard proofs with independently randomized proof
commitments. The values are medians of 15 measured `BatchVerifier::finalize`
runs after three warm-up runs:

| Proofs | Upstream main | Three-commit stack | Time reduction |
| ---: | ---: | ---: | ---: |
| 1 | 18.558 ms | 16.907 ms | 8.9% |
| 2 | 22.306 ms | 19.392 ms | 13.1% |
| 16 | 71.653 ms | 53.925 ms | 24.7% |
| 64 | 240.178 ms | 171.766 ms | 28.5% |

Only the first two commits affect this separate-proof workload. Each
`BatchVerifier` entry invokes `verify_proof` for one one-action proof, so it
contains one instance commitment and does not reach the four-commitment batch
normalization threshold.

The committed Criterion benchmark measures 1, 2, 16, and 64 action instances
inside one encoded proof. That workload exercises the third commit, but uses a
minimal Orchard-shaped circuit rather than the full Orchard circuit.

Applications can parallelize independent verification requests at a higher
layer.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p halo2_proofs --lib`
- `cargo test -p halo2_proofs --no-default-features --lib`
- `cargo test -p halo2_proofs --test plonk_api`
- `cargo check -p halo2_proofs --bench plonk_verifier`
- `cargo clippy -p halo2_proofs --all-targets --all-features -- -D warnings`
- Focused tests compare prefix and zero-padded commitments and exercise the
  batch-normalization threshold with a valid proof.

## API and dependencies

- No public or `pub(crate)` Rust API changes.
- No public function-signature or visibility changes.
- No dependency or feature changes.
- Adds the `plonk_verifier` benchmark target and its source file; Criterion was
  already a development dependency.
