### PR TITLE
Avoid zero-padding prover instance commitments

### DIFF
--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+### Changed
+- `halo2_proofs::plonk::create_proof` now commits directly to the supplied
+  instance values instead of zero-padding them to the evaluation domain first.
+
 ## [0.3.5] - 2026-08-02
 ### Added
 - `halo2_proofs::plonk::VerifyingKey::dump_vesta_lean_fixture_match_only`

--- a/halo2_proofs/src/plonk/prover.rs
+++ b/halo2_proofs/src/plonk/prover.rs
@@ -13,7 +13,7 @@ use super::{
     ChallengeY, Error, ProvingKey,
 };
 use crate::{
-    arithmetic::{eval_polynomial, CurveAffine},
+    arithmetic::{best_multiexp, eval_polynomial, CurveAffine},
     circuit::Value,
     plonk::Assigned,
     poly::{
@@ -27,6 +27,18 @@ use crate::{
     poly::batch_invert_assigned,
     transcript::{EncodedChallenge, TranscriptWrite},
 };
+
+fn commit_instance<C: CurveAffine>(params: &Params<C>, instance: &[C::Scalar]) -> C::Curve {
+    let mut scalars = Vec::with_capacity(instance.len() + 1);
+    scalars.extend(instance);
+    scalars.push(Blind::default().0);
+
+    let mut bases = Vec::with_capacity(instance.len() + 1);
+    bases.extend(&params.g_lagrange[..instance.len()]);
+    bases.push(params.w);
+
+    best_multiexp::<C>(&scalars, &bases)
+}
 
 /// This creates a proof for the provided `circuit` when given the public
 /// parameters `params` and the proving key [`ProvingKey`] that was
@@ -90,9 +102,9 @@ pub fn create_proof<
                     Ok(poly)
                 })
                 .collect::<Result<Vec<_>, _>>()?;
-            let instance_commitments_projective: Vec<_> = instance_values
+            let instance_commitments_projective: Vec<_> = instance
                 .iter()
-                .map(|poly| params.commit_lagrange(poly, Blind::default()))
+                .map(|values| commit_instance(params, values))
                 .collect();
             let mut instance_commitments =
                 vec![C::identity(); instance_commitments_projective.len()];
@@ -722,6 +734,27 @@ pub fn create_proof<
         .chain(vanishing.open(x));
 
     multiopen::create_proof(params, rng, transcript, instances).map_err(|_| Error::Opening)
+}
+
+#[test]
+fn test_commit_instance() {
+    use pasta_curves::{EqAffine, Fp};
+
+    let params: Params<EqAffine> = Params::new(3);
+    let domain = crate::poly::EvaluationDomain::new(1, 3);
+    let instance = [Fp::from(3), Fp::ZERO, Fp::from(5)];
+
+    for instance in [&[][..], &instance[..]] {
+        let mut poly = domain.empty_lagrange();
+        for (coefficient, value) in poly.iter_mut().zip(instance.iter()) {
+            *coefficient = *value;
+        }
+
+        assert_eq!(
+            commit_instance(&params, instance),
+            params.commit_lagrange(&poly, Blind::default())
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Public instance columns are prefix-populated and zero-padded to the evaluation
domain. The prover previously passed the entire padded polynomial to the
instance commitment MSM. This instead commits to the supplied prefix plus the
blinding generator; the omitted trailing coefficients are all zero.

The prover still constructs the same zero-padded polynomial for interpolation,
coset evaluation, and opening, so this changes only the amount of work used to
compute the commitment.

## Performance

On the single-threaded genuine one-action Orchard proving benchmark this saved
roughly 8 ms, or about 0.5%, on the then-current optimization stack.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p halo2_proofs --lib`
- `cargo test -p halo2_proofs --no-default-features --lib`
- `cargo clippy -p halo2_proofs --all-targets --all-features -- -D warnings`
- A focused equivalence test compares prefix commitments with the original
  zero-padded commitment for both an empty column and a column containing an
  internal zero.

## API and dependencies

- No public or `pub(crate)` API changes.
- No function-signature or visibility changes.
- No feature or dependency changes.

## Integration note

The [verifier optimization PR](https://github.com/zcash/halo2/pull/929) has the
same module-private helper. The second of these PRs to land should move that
helper to their common private parent module during rebase, avoiding permanent
duplication without making either PR depend on the other today.
