### PR TITLE
Signed Booth recoding for multiexp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       matrix:
         target:
           - wasm32-unknown-unknown
-          - wasm32-wasi
+          - wasm32-wasip1
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the [halo2_proofs](https://github.com/zcash/halo2/blob/
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.60** or higher.
+Requires Rust **1.88** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be done with a
 minor version bump.

--- a/halo2/CHANGELOG.md
+++ b/halo2/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The minimum supported Rust version is now 1.88.
 
 ## [0.1.0-beta.2] - 2022-02-14
 ### Removed

--- a/halo2/Cargo.toml
+++ b/halo2/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
     "Jack Grigg <jack@electriccoin.co>",
 ]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.88"
 description = "[BETA] Fast zero-knowledge proof-carrying data implementation with no trusted setup"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zcash/halo2"

--- a/halo2_gadgets/CHANGELOG.md
+++ b/halo2_gadgets/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The minimum supported Rust version is now 1.88.
 
 ## [0.5.0] - 2026-06-02
 

--- a/halo2_gadgets/Cargo.toml
+++ b/halo2_gadgets/Cargo.toml
@@ -9,7 +9,7 @@ authors = [
     "Kris Nuttycombe <kris@electriccoin.co>",
 ]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.88"
 description = "Reusable gadgets and chip implementations for Halo 2"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zcash/halo2"

--- a/halo2_gadgets/README.md
+++ b/halo2_gadgets/README.md
@@ -1,6 +1,6 @@
 # halo2_gadgets [![Crates.io](https://img.shields.io/crates/v/halo2_gadgets.svg)](https://crates.io/crates/halo2_gadgets) #
 
-Requires Rust 1.60+.
+Requires Rust 1.88+.
 
 ## Documentation
 

--- a/halo2_gadgets/benches/poseidon.rs
+++ b/halo2_gadgets/benches/poseidon.rs
@@ -89,7 +89,7 @@ where
                 let message_word = |i: usize| {
                     let value = self.message.map(|message_vals| message_vals[i]);
                     region.assign_advice(
-                        || format!("load message_{}", i),
+                        || format!("load message_{i}"),
                         config.input[i],
                         0,
                         || value,

--- a/halo2_gadgets/src/ecc/chip.rs
+++ b/halo2_gadgets/src/ecc/chip.rs
@@ -638,7 +638,7 @@ where
     ) -> Result<(Self::Point, Self::ScalarFixed), Error> {
         let config = self.config().mul_fixed_full.clone();
         config.assign(
-            layouter.namespace(|| format!("fixed-base mul of {:?}", base)),
+            layouter.namespace(|| format!("fixed-base mul of {base:?}")),
             scalar,
             base,
         )
@@ -652,7 +652,7 @@ where
     ) -> Result<(Self::Point, Self::ScalarFixedShort), Error> {
         let config = self.config().mul_fixed_short.clone();
         config.assign(
-            layouter.namespace(|| format!("short fixed-base mul of {:?}", base)),
+            layouter.namespace(|| format!("short fixed-base mul of {base:?}")),
             scalar,
             base,
         )
@@ -666,7 +666,7 @@ where
     ) -> Result<Self::Point, Error> {
         let config = self.config().mul_fixed_base_field.clone();
         config.assign(
-            layouter.namespace(|| format!("base-field elem fixed-base mul of {:?}", base)),
+            layouter.namespace(|| format!("base-field elem fixed-base mul of {base:?}")),
             base_field_elem,
             base,
         )

--- a/halo2_gadgets/src/ecc/chip/constants.rs
+++ b/halo2_gadgets/src/ecc/chip/constants.rs
@@ -16,11 +16,11 @@ pub const H: usize = 1 << FIXED_BASE_WINDOW_SIZE;
 
 /// Number of windows for a full-width scalar
 pub const NUM_WINDOWS: usize =
-    (pallas::Scalar::NUM_BITS as usize + FIXED_BASE_WINDOW_SIZE - 1) / FIXED_BASE_WINDOW_SIZE;
+    (pallas::Scalar::NUM_BITS as usize).div_ceil(FIXED_BASE_WINDOW_SIZE);
 
 /// Number of windows for a short signed scalar
 pub const NUM_WINDOWS_SHORT: usize =
-    (L_SCALAR_SHORT + FIXED_BASE_WINDOW_SIZE - 1) / FIXED_BASE_WINDOW_SIZE;
+    L_SCALAR_SHORT.div_ceil(FIXED_BASE_WINDOW_SIZE);
 
 /// $\ell_\mathsf{value}$
 /// Number of bits in an unsigned short scalar.

--- a/halo2_gadgets/src/ecc/chip/constants.rs
+++ b/halo2_gadgets/src/ecc/chip/constants.rs
@@ -15,12 +15,10 @@ pub const FIXED_BASE_WINDOW_SIZE: usize = 3;
 pub const H: usize = 1 << FIXED_BASE_WINDOW_SIZE;
 
 /// Number of windows for a full-width scalar
-pub const NUM_WINDOWS: usize =
-    (pallas::Scalar::NUM_BITS as usize).div_ceil(FIXED_BASE_WINDOW_SIZE);
+pub const NUM_WINDOWS: usize = (pallas::Scalar::NUM_BITS as usize).div_ceil(FIXED_BASE_WINDOW_SIZE);
 
 /// Number of windows for a short signed scalar
-pub const NUM_WINDOWS_SHORT: usize =
-    L_SCALAR_SHORT.div_ceil(FIXED_BASE_WINDOW_SIZE);
+pub const NUM_WINDOWS_SHORT: usize = L_SCALAR_SHORT.div_ceil(FIXED_BASE_WINDOW_SIZE);
 
 /// $\ell_\mathsf{value}$
 /// Number of bits in an unsigned short scalar.

--- a/halo2_gadgets/src/ecc/chip/mul.rs
+++ b/halo2_gadgets/src/ecc/chip/mul.rs
@@ -421,6 +421,7 @@ impl<F: Field> Deref for Z<F> {
 // https://p.z.cash/halo2-0.1:ecc-var-mul-witness-scalar?partial
 #[allow(clippy::assign_op_pattern)]
 #[allow(clippy::ptr_offset_with_cast)]
+#[allow(clippy::manual_div_ceil)]
 fn decompose_for_scalar_mul(scalar: Value<&pallas::Base>) -> Vec<Value<bool>> {
     construct_uint! {
         struct U256(4);

--- a/halo2_gadgets/src/ecc/chip/mul_fixed.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed.rs
@@ -218,11 +218,7 @@ impl<FixedPoints: super::FixedPoints<pallas::Affine>> Config<FixedPoints> {
             // Assign x-coordinate Lagrange interpolation coefficients
             for k in 0..H {
                 region.assign_fixed(
-                    || {
-                        format!(
-                            "Lagrange interpolation coeff for window: {window:?}, k: {k:?}"
-                        )
-                    },
+                    || format!("Lagrange interpolation coeff for window: {window:?}, k: {k:?}"),
                     self.lagrange_coeffs[k],
                     window + offset,
                     || {

--- a/halo2_gadgets/src/ecc/chip/mul_fixed.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed.rs
@@ -220,8 +220,7 @@ impl<FixedPoints: super::FixedPoints<pallas::Affine>> Config<FixedPoints> {
                 region.assign_fixed(
                     || {
                         format!(
-                            "Lagrange interpolation coeff for window: {:?}, k: {:?}",
-                            window, k
+                            "Lagrange interpolation coeff for window: {window:?}, k: {k:?}"
                         )
                     },
                     self.lagrange_coeffs[k],
@@ -238,7 +237,7 @@ impl<FixedPoints: super::FixedPoints<pallas::Affine>> Config<FixedPoints> {
 
             // Assign z-values for each window
             region.assign_fixed(
-                || format!("z-value for window: {:?}", window),
+                || format!("z-value for window: {window:?}"),
                 self.fixed_z,
                 window + offset,
                 || {
@@ -276,7 +275,7 @@ impl<FixedPoints: super::FixedPoints<pallas::Affine>> Config<FixedPoints> {
                 x.into()
             });
             let x = region.assign_advice(
-                || format!("mul_b_x, window {}", w),
+                || format!("mul_b_x, window {w}"),
                 self.add_config.x_p,
                 offset + w,
                 || x,
@@ -288,7 +287,7 @@ impl<FixedPoints: super::FixedPoints<pallas::Affine>> Config<FixedPoints> {
                 y.into()
             });
             let y = region.assign_advice(
-                || format!("mul_b_y, window {}", w),
+                || format!("mul_b_y, window {w}"),
                 self.add_config.y_p,
                 offset + w,
                 || y,

--- a/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
+++ b/halo2_gadgets/src/ecc/chip/mul_fixed/short.rs
@@ -576,11 +576,11 @@ pub mod tests {
             "-1".into()
         } else {
             // Format value as hex.
-            let s = format!("{:?}", v);
+            let s = format!("{v:?}");
             // Remove leading zeroes.
             let s = s.strip_prefix("0x").unwrap();
             let s = s.trim_start_matches('0');
-            format!("0x{}", s)
+            format!("0x{s}")
         }
     }
 

--- a/halo2_gadgets/src/poseidon.rs
+++ b/halo2_gadgets/src/poseidon.rs
@@ -277,7 +277,7 @@ impl<
             .enumerate()
         {
             self.sponge
-                .absorb(layouter.namespace(|| format!("absorb_{}", i)), value)?;
+                .absorb(layouter.namespace(|| format!("absorb_{i}")), value)?;
         }
         self.sponge
             .finish_absorbing(layouter.namespace(|| "finish absorbing"))?

--- a/halo2_gadgets/src/poseidon/pow5.rs
+++ b/halo2_gadgets/src/poseidon/pow5.rs
@@ -380,12 +380,7 @@ impl<
                             // The capacity element is never altered by the input.
                             .unwrap_or_else(|| Value::known(F::ZERO));
                     region
-                        .assign_advice(
-                            || format!("load output_{i}"),
-                            config.state[i],
-                            2,
-                            || value,
-                        )
+                        .assign_advice(|| format!("load output_{i}"), config.state[i], 2, || value)
                         .map(StateWord)
                 };
 

--- a/halo2_gadgets/src/poseidon/pow5.rs
+++ b/halo2_gadgets/src/poseidon/pow5.rs
@@ -285,7 +285,7 @@ impl<
                 let mut state = Vec::with_capacity(WIDTH);
                 let mut load_state_word = |i: usize, value: F| -> Result<_, Error> {
                     let var = region.assign_advice_from_constant(
-                        || format!("state_{}", i),
+                        || format!("state_{i}"),
                         config.state[i],
                         0,
                         value,
@@ -324,7 +324,7 @@ impl<
                     initial_state[i]
                         .0
                         .copy_advice(
-                            || format!("load state_{}", i),
+                            || format!("load state_{i}"),
                             &mut region,
                             config.state[i],
                             0,
@@ -343,7 +343,7 @@ impl<
                             let value = Value::known(*padding_value);
                             let cell = region
                                 .assign_fixed(
-                                    || format!("load pad_{}", i),
+                                    || format!("load pad_{i}"),
                                     config.rc_b[i],
                                     1,
                                     || value,
@@ -354,7 +354,7 @@ impl<
                         _ => panic!("Input is not padded"),
                     };
                     let var = region.assign_advice(
-                        || format!("load input_{}", i),
+                        || format!("load input_{i}"),
                         config.state[i],
                         1,
                         || value,
@@ -381,7 +381,7 @@ impl<
                             .unwrap_or_else(|| Value::known(F::ZERO));
                     region
                         .assign_advice(
-                            || format!("load output_{}", i),
+                            || format!("load output_{i}"),
                             config.state[i],
                             2,
                             || value,
@@ -479,7 +479,7 @@ impl<F: Field, const WIDTH: usize> Pow5State<F, WIDTH> {
             });
 
             region.assign_advice(
-                || format!("round_{} partial_sbox", round),
+                || format!("round_{round} partial_sbox"),
                 config.partial_sbox,
                 offset,
                 || r.as_ref().map(|r| r[0]),
@@ -541,7 +541,7 @@ impl<F: Field, const WIDTH: usize> Pow5State<F, WIDTH> {
         let load_state_word = |i: usize| {
             initial_state[i]
                 .0
-                .copy_advice(|| format!("load state_{}", i), region, config.state[i], 0)
+                .copy_advice(|| format!("load state_{i}"), region, config.state[i], 0)
                 .map(StateWord)
         };
 
@@ -563,7 +563,7 @@ impl<F: Field, const WIDTH: usize> Pow5State<F, WIDTH> {
         // Load the round constants.
         let mut load_round_constant = |i: usize| {
             region.assign_fixed(
-                || format!("round_{} rc_{}", round, i),
+                || format!("round_{round} rc_{i}"),
                 config.rc_a[i],
                 offset,
                 || Value::known(config.round_constants[round][i]),
@@ -579,7 +579,7 @@ impl<F: Field, const WIDTH: usize> Pow5State<F, WIDTH> {
         let next_state_word = |i: usize| {
             let value = next_state[i];
             let var = region.assign_advice(
-                || format!("round_{} state_{}", next_round, i),
+                || format!("round_{next_round} state_{i}"),
                 config.state[i],
                 offset + 1,
                 || value,
@@ -655,7 +655,7 @@ mod tests {
                     let state_word = |i: usize| {
                         let value = Value::known(Fp::from(i as u64));
                         let var = region.assign_advice(
-                            || format!("load state_{}", i),
+                            || format!("load state_{i}"),
                             config.state[i],
                             0,
                             || value,
@@ -694,7 +694,7 @@ mod tests {
                 |mut region| {
                     let mut final_state_word = |i: usize| {
                         let var = region.assign_advice(
-                            || format!("load final_state_{}", i),
+                            || format!("load final_state_{i}"),
                             config.state[i],
                             0,
                             || Value::known(expected_final_state[i]),
@@ -778,7 +778,7 @@ mod tests {
                     let message_word = |i: usize| {
                         let value = self.message.map(|message_vals| message_vals[i]);
                         region.assign_advice(
-                            || format!("load message_{}", i),
+                            || format!("load message_{i}"),
                             config.state[i],
                             0,
                             || value,

--- a/halo2_gadgets/src/sha256/table16/compression.rs
+++ b/halo2_gadgets/src/sha256/table16/compression.rs
@@ -998,7 +998,7 @@ mod tests {
 
         let prover = match MockProver::<pallas::Base>::run(17, &circuit, vec![]) {
             Ok(prover) => prover,
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!("{e:?}"),
         };
         assert_eq!(prover.verify(), Ok(()));
     }

--- a/halo2_gadgets/src/sha256/table16/message_schedule.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule.rs
@@ -448,7 +448,7 @@ mod tests {
 
         let prover = match MockProver::<pallas::Base>::run(17, &circuit, vec![]) {
             Ok(prover) => prover,
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!("{e:?}"),
         };
         assert_eq!(prover.verify(), Ok(()));
     }

--- a/halo2_gadgets/src/sha256/table16/message_schedule/schedule_util.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule/schedule_util.rs
@@ -161,16 +161,16 @@ impl MessageScheduleConfig {
 
         let w_lo = {
             let w_lo_val = word.map(|word| word as u16);
-            AssignedBits::<16>::assign(region, || format!("W_{}_lo", word_idx), a_3, row, w_lo_val)?
+            AssignedBits::<16>::assign(region, || format!("W_{word_idx}_lo"), a_3, row, w_lo_val)?
         };
         let w_hi = {
             let w_hi_val = word.map(|word| (word >> 16) as u16);
-            AssignedBits::<16>::assign(region, || format!("W_{}_hi", word_idx), a_4, row, w_hi_val)?
+            AssignedBits::<16>::assign(region, || format!("W_{word_idx}_hi"), a_4, row, w_hi_val)?
         };
 
         let word = AssignedBits::<32>::assign(
             region,
-            || format!("W_{}", word_idx),
+            || format!("W_{word_idx}"),
             self.message_schedule,
             row,
             word,

--- a/halo2_gadgets/src/sha256/table16/message_schedule/subregion1.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule/subregion1.rs
@@ -47,7 +47,7 @@ impl Subregion1Word {
                     .iter()
                     .chain(c.iter())
                     .chain(d.iter())
-                    .chain(std::iter::repeat(&false).take(6))
+                    .chain(std::iter::repeat_n(&false, 6))
                     .copied()
                     .collect::<Vec<_>>();
                 let xor_1 = c

--- a/halo2_gadgets/src/sha256/table16/message_schedule/subregion2.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule/subregion2.rs
@@ -68,7 +68,7 @@ impl Subregion2Word {
                     .chain(e.iter())
                     .chain(f.iter())
                     .chain(g.iter())
-                    .chain(std::iter::repeat(&false).take(6))
+                    .chain(std::iter::repeat_n(&false, 6))
                     .copied()
                     .collect::<Vec<_>>();
 
@@ -116,7 +116,7 @@ impl Subregion2Word {
                     .chain(e.iter())
                     .chain(f.iter())
                     .chain(g.iter())
-                    .chain(std::iter::repeat(&false).take(20))
+                    .chain(std::iter::repeat_n(&false, 20))
                     .copied()
                     .collect::<Vec<_>>();
 
@@ -252,13 +252,13 @@ impl MessageScheduleConfig {
 
             // Assign W_i, carry_i
             region.assign_advice(
-                || format!("W_{}", new_word_idx),
+                || format!("W_{new_word_idx}"),
                 a_5,
                 get_word_row(new_word_idx - 16) + 1,
                 || word.map(|word| pallas::Base::from(word as u64)),
             )?;
             region.assign_advice(
-                || format!("carry_{}", new_word_idx),
+                || format!("carry_{new_word_idx}"),
                 a_9,
                 get_word_row(new_word_idx - 16) + 1,
                 || carry.map(pallas::Base::from),

--- a/halo2_gadgets/src/sha256/table16/message_schedule/subregion3.rs
+++ b/halo2_gadgets/src/sha256/table16/message_schedule/subregion3.rs
@@ -48,7 +48,7 @@ impl Subregion3Word {
                     .iter()
                     .chain(c.iter())
                     .chain(d.iter())
-                    .chain(std::iter::repeat(&false).take(20))
+                    .chain(std::iter::repeat_n(&false, 20))
                     .copied()
                     .collect::<Vec<_>>();
 
@@ -168,13 +168,13 @@ impl MessageScheduleConfig {
 
             // Assign W_i, carry_i
             region.assign_advice(
-                || format!("W_{}", new_word_idx),
+                || format!("W_{new_word_idx}"),
                 a_5,
                 get_word_row(new_word_idx - 16) + 1,
                 || word.map(|word| pallas::Base::from(word as u64)),
             )?;
             region.assign_advice(
-                || format!("carry_{}", new_word_idx),
+                || format!("carry_{new_word_idx}"),
                 a_9,
                 get_word_row(new_word_idx - 16) + 1,
                 || carry.map(pallas::Base::from),

--- a/halo2_gadgets/src/sha256/table16/spread_table.rs
+++ b/halo2_gadgets/src/sha256/table16/spread_table.rs
@@ -443,7 +443,7 @@ mod tests {
 
         let prover = match MockProver::<Fp>::run(17, &circuit, vec![]) {
             Ok(prover) => prover,
-            Err(e) => panic!("{:?}", e),
+            Err(e) => panic!("{e:?}"),
         };
         assert_eq!(prover.verify(), Ok(()));
     }

--- a/halo2_gadgets/src/sinsemilla.rs
+++ b/halo2_gadgets/src/sinsemilla.rs
@@ -147,7 +147,7 @@ where
                 |(i, piece)| -> Result<MessagePiece<C, SinsemillaChip, K, MAX_WORDS>, Error> {
                     MessagePiece::from_bitstring(
                         chip.clone(),
-                        layouter.namespace(|| format!("message piece {}", i)),
+                        layouter.namespace(|| format!("message piece {i}")),
                         piece,
                     )
                 },

--- a/halo2_gadgets/src/sinsemilla/merkle.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle.rs
@@ -120,7 +120,7 @@ where
         leaf: MerkleChip::Var,
     ) -> Result<MerkleChip::Var, Error> {
         // Each chip processes `ceil(PATH_LENGTH / PAR)` layers.
-        let layers_per_chip = (PATH_LENGTH + PAR - 1) / PAR;
+        let layers_per_chip = PATH_LENGTH.div_ceil(PAR);
 
         // Assign each layer to a chip.
         let chips = (0..PATH_LENGTH).map(|i| self.chips[i / layers_per_chip].clone());
@@ -158,7 +158,7 @@ where
             // Compute the node in layer l from its children:
             //     M^l_i = MerkleCRH(l, M^{l+1}_{2i}, M^{l+1}_{2i+1})
             node = chip.hash_layer(
-                layouter.namespace(|| format!("MerkleCRH({}, left, right)", l)),
+                layouter.namespace(|| format!("MerkleCRH({l}, left, right)")),
                 Q,
                 l,
                 pair.0,

--- a/halo2_gadgets/src/sinsemilla/merkle/chip.rs
+++ b/halo2_gadgets/src/sinsemilla/merkle/chip.rs
@@ -320,7 +320,7 @@ where
         //
         // https://p.z.cash/proto:merkle-crh-orchard
         let (point, zs) = self.hash_to_point(
-            layouter.namespace(|| format!("hash at l = {}", l)),
+            layouter.namespace(|| format!("hash at l = {l}")),
             Q,
             vec![a.inner(), b.inner(), c.inner()].into(),
         )?;
@@ -347,7 +347,7 @@ where
                     // The layer with 2^n nodes is called "layer n".
                     config.q_decompose.enable(&mut region, 0)?;
                     region.assign_advice_from_constant(
-                        || format!("l {}", l),
+                        || format!("l {l}"),
                         config.advices[4],
                         1,
                         pallas::Base::from(l as u64),

--- a/halo2_gadgets/src/utilities.rs
+++ b/halo2_gadgets/src/utilities.rs
@@ -194,7 +194,7 @@ pub fn decompose_word<F: PrimeFieldBits>(
         .to_le_bits()
         .into_iter()
         .take(word_num_bits)
-        .chain(std::iter::repeat(false).take(padding))
+        .chain(std::iter::repeat_n(false, padding))
         .collect();
     assert_eq!(bits.len(), word_num_bits + padding);
 
@@ -337,6 +337,7 @@ mod tests {
 
     #[allow(clippy::assign_op_pattern)]
     #[allow(clippy::ptr_offset_with_cast)]
+    #[allow(clippy::manual_div_ceil)]
     #[test]
     fn test_bitrange_subset() {
         let rng = OsRng;

--- a/halo2_gadgets/src/utilities/lookup_range_check.rs
+++ b/halo2_gadgets/src/utilities/lookup_range_check.rs
@@ -129,7 +129,7 @@ pub trait LookupRangeCheck<F: PrimeFieldBits, const K: usize>: Eq + Copy + Debug
         strict: bool,
     ) -> Result<RunningSum<F>, Error> {
         layouter.assign_region(
-            || format!("{:?} words range check", num_words),
+            || format!("{num_words:?} words range check"),
             |mut region| {
                 // Copy `element` and initialize running sum `z_0 = element` to decompose it.
                 let z_0 =
@@ -253,7 +253,7 @@ pub trait LookupRangeCheck<F: PrimeFieldBits, const K: usize>: Eq + Copy + Debug
     ) -> Result<(), Error> {
         assert!(num_bits < K);
         layouter.assign_region(
-            || format!("Range check {:?} bits", num_bits),
+            || format!("Range check {num_bits:?} bits"),
             |mut region| {
                 // Copy `element` to use in the k-bit lookup.
                 let element =
@@ -276,7 +276,7 @@ pub trait LookupRangeCheck<F: PrimeFieldBits, const K: usize>: Eq + Copy + Debug
     ) -> Result<AssignedCell<F, F>, Error> {
         assert!(num_bits <= K);
         layouter.assign_region(
-            || format!("Range check {:?} bits", num_bits),
+            || format!("Range check {num_bits:?} bits"),
             |mut region| {
                 // Witness `element` to use in the k-bit lookup.
                 let element = region.assign_advice(
@@ -471,7 +471,7 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheck<F, K> for LookupRangeCh
         let shifted = element.value().into_field() * F::from(1 << (K - num_bits));
 
         region.assign_advice(
-            || format!("element * 2^({}-{})", K, num_bits),
+            || format!("element * 2^({K}-{num_bits})"),
             self.running_sum,
             1,
             || shifted,
@@ -480,7 +480,7 @@ impl<F: PrimeFieldBits, const K: usize> LookupRangeCheck<F, K> for LookupRangeCh
         // Assign 2^{-num_bits} from a fixed column.
         let inv_two_pow_s = F::from(1 << num_bits).invert().unwrap();
         region.assign_advice_from_constant(
-            || format!("2^(-{})", num_bits),
+            || format!("2^(-{num_bits})"),
             self.running_sum,
             2,
             inv_two_pow_s,

--- a/halo2_poseidon/CHANGELOG.md
+++ b/halo2_poseidon/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The minimum supported Rust version is now 1.88.
 
 ## [0.1.0] - 2024-12-16
 Initial release, extracted from `halo2_gadgets 0.3.0`. Includes minor changes

--- a/halo2_poseidon/Cargo.toml
+++ b/halo2_poseidon/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Ying Tong Lai",
 ]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.88"
 description = "The Poseidon algebraic hash function for Halo 2"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/zcash/halo2"

--- a/halo2_poseidon/README.md
+++ b/halo2_poseidon/README.md
@@ -1,6 +1,6 @@
 # halo2_poseidon [![Crates.io](https://img.shields.io/crates/v/halo2_poseidon.svg)](https://crates.io/crates/halo2_poseidon) #
 
-Requires Rust 1.60+.
+Requires Rust 1.88+.
 
 ## Documentation
 

--- a/halo2_poseidon/src/lib.rs
+++ b/halo2_poseidon/src/lib.rs
@@ -140,9 +140,18 @@ pub(crate) fn permute<F: Field, S: Spec<F, T, RATE>, const T: usize, const RATE:
     };
 
     iter::empty()
-        .chain(iter::repeat(&full_round as &dyn Fn(&mut State<F, T>, &[F; T])).take(r_f))
-        .chain(iter::repeat(&part_round as &dyn Fn(&mut State<F, T>, &[F; T])).take(r_p))
-        .chain(iter::repeat(&full_round as &dyn Fn(&mut State<F, T>, &[F; T])).take(r_f))
+        .chain(iter::repeat_n(
+            &full_round as &dyn Fn(&mut State<F, T>, &[F; T]),
+            r_f,
+        ))
+        .chain(iter::repeat_n(
+            &part_round as &dyn Fn(&mut State<F, T>, &[F; T]),
+            r_p,
+        ))
+        .chain(iter::repeat_n(
+            &full_round as &dyn Fn(&mut State<F, T>, &[F; T]),
+            r_f,
+        ))
         .zip(round_constants.iter())
         .fold(state, |state, (round, rcs)| {
             round(state, rcs);
@@ -392,7 +401,7 @@ impl<F: PrimeField, const RATE: usize, const L: usize> Domain<F, RATE> for Const
     type Padding = iter::Take<iter::Repeat<F>>;
 
     fn name() -> String {
-        format!("ConstantLength<{}>", L)
+        format!("ConstantLength<{L}>")
     }
 
     fn initial_capacity_element() -> F {
@@ -401,13 +410,16 @@ impl<F: PrimeField, const RATE: usize, const L: usize> Domain<F, RATE> for Const
         F::from_u128((L as u128) << 64)
     }
 
+    // `Self::Padding` is a public associated type, so it cannot be changed from
+    // `Take<Repeat<F>>` to `RepeatN<F>` without breaking the API of this crate.
+    #[allow(clippy::manual_repeat_n)]
     fn padding(input_len: usize) -> Self::Padding {
         assert_eq!(input_len, L);
         // For constant-input-length hashing, we pad the input with zeroes to a multiple
         // of RATE. On its own this would not be sponge-compliant padding, but the
         // Poseidon authors encode the constant length into the capacity element, ensuring
         // that inputs of different lengths do not share the same permutation.
-        let k = (L + RATE - 1) / RATE;
+        let k = L.div_ceil(RATE);
         iter::repeat(F::ZERO).take(k * RATE - L)
     }
 }

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to Rust's notion of
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The minimum supported Rust version is now 1.88.
 
 ## [0.3.5] - 2026-08-02
 ### Added

--- a/halo2_proofs/CHANGELOG.md
+++ b/halo2_proofs/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 ### Changed
+- `halo2_proofs::arithmetic::best_multiexp` now uses signed Booth recoding to
+  reduce its Pippenger bucket count. It computes each scalar's canonical
+  representation once per MSM rather than once per window, and derives its
+  window schedule from that representation instead of assuming a 256-bit
+  scalar.
 - The minimum supported Rust version is now 1.88.
 
 ## [0.3.5] - 2026-08-02

--- a/halo2_proofs/Cargo.toml
+++ b/halo2_proofs/Cargo.toml
@@ -8,7 +8,7 @@ authors = [
     "Jack Grigg <jack@electriccoin.co>",
 ]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.88"
 description = """
 Fast PLONK-based zero-knowledge proving system with no trusted setup
 """

--- a/halo2_proofs/README.md
+++ b/halo2_proofs/README.md
@@ -4,7 +4,7 @@
 
 ## Minimum Supported Rust Version
 
-Requires Rust **1.60** or higher.
+Requires Rust **1.88** or higher.
 
 Minimum supported Rust version can be changed in the future, but it will be done with a
 minor version bump.

--- a/halo2_proofs/benches/dev_lookup.rs
+++ b/halo2_proofs/benches/dev_lookup.rs
@@ -60,7 +60,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 |mut table| {
                     for row in 0u64..(1 << 8) {
                         table.assign_cell(
-                            || format!("row {}", row),
+                            || format!("row {row}"),
                             config.table,
                             row as usize,
                             || Value::known(F::from(row + 1)),
@@ -77,7 +77,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     for offset in 0u64..(1 << 10) {
                         config.selector.enable(&mut region, offset as usize)?;
                         region.assign_advice(
-                            || format!("offset {}", offset),
+                            || format!("offset {offset}"),
                             config.advice,
                             offset as usize,
                             || Value::known(F::from((offset % 256) + 1)),

--- a/halo2_proofs/examples/circuit-layout.rs
+++ b/halo2_proofs/examples/circuit-layout.rs
@@ -239,7 +239,7 @@ impl<F: Field> Circuit<F> for MyCircuit<F> {
 
         for i in 0..10 {
             layouter.assign_region(
-                || format!("region_{}", i),
+                || format!("region_{i}"),
                 |mut region| {
                     let a: Value<Assigned<_>> = self.a.into();
                     let mut a_squared = Value::unknown();

--- a/halo2_proofs/examples/cost-model.rs
+++ b/halo2_proofs/examples/cost-model.rs
@@ -171,7 +171,7 @@ impl Permutation {
 
         iter::empty()
             .chain(Some(product))
-            .chain(iter::repeat(poly).take(self.columns))
+            .chain(std::iter::repeat_n(poly, self.columns))
     }
 }
 
@@ -212,7 +212,7 @@ impl From<CostOptions> for Circuit {
             .cloned()
             .chain(opts.lookup.iter().flat_map(|l| l.queries()))
             .chain(opts.permutation.iter().flat_map(|p| p.queries()))
-            .chain(iter::repeat("0".parse().unwrap()).take(max_deg - 1))
+            .chain(std::iter::repeat_n("0".parse().unwrap(), max_deg - 1))
             .collect();
 
         let column_queries = queries.len();
@@ -294,7 +294,7 @@ impl Circuit {
 fn main() {
     let opts = CostOptions::parse_args_default_or_exit();
     let c = Circuit::from(opts);
-    println!("{:#?}", c);
+    println!("{c:#?}");
     println!("Proof size: {} bytes", c.proof_size());
     println!(
         "Verification: at least {}ms",

--- a/halo2_proofs/src/arithmetic.rs
+++ b/halo2_proofs/src/arithmetic.rs
@@ -71,10 +71,15 @@ impl<C: CurveAffine> Buckets<C> {
         }
     }
 
-    fn sum(&mut self, coeffs: &[C::Scalar], bases: &[C], i: usize) -> C::Curve {
+    fn sum(
+        &mut self,
+        coeffs: &[<C::Scalar as PrimeField>::Repr],
+        bases: &[C],
+        i: usize,
+    ) -> C::Curve {
         // get segmentation and add coeff to buckets content
         for (coeff, base) in coeffs.iter().zip(bases.iter()) {
-            let seg = self.get_at::<C::Scalar>(i, &coeff.to_repr());
+            let seg = self.get_at(i, coeff);
             if seg != 0 {
                 self.coeffs[seg - 1].add_assign(base);
             }
@@ -92,7 +97,7 @@ impl<C: CurveAffine> Buckets<C> {
         acc
     }
 
-    fn get_at<F: PrimeField>(&self, segment: usize, bytes: &F::Repr) -> usize {
+    fn get_at(&self, segment: usize, bytes: &<C::Scalar as PrimeField>::Repr) -> usize {
         let skip_bits = segment * self.c;
         let skip_bytes = skip_bits / 8;
 
@@ -143,6 +148,9 @@ pub fn small_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::C
 pub fn best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Curve {
     assert_eq!(coeffs.len(), bases.len());
 
+    // Convert to canonical representations once instead of once per window.
+    let coeffs = coeffs.iter().map(PrimeField::to_repr).collect::<Vec<_>>();
+
     let c = if bases.len() < 4 {
         1
     } else if bases.len() < 32 {
@@ -159,7 +167,7 @@ pub fn best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Cu
             .enumerate()
             .rev()
             .map(|(i, buckets)| {
-                let mut acc = buckets.sum(coeffs, bases, i);
+                let mut acc = buckets.sum(&coeffs, bases, i);
                 (0..c * i).for_each(|_| acc = acc.double());
                 acc
             })
@@ -170,7 +178,7 @@ pub fn best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Cu
             .iter_mut()
             .enumerate()
             .rev()
-            .map(|(i, buckets)| buckets.sum(coeffs, bases, i))
+            .map(|(i, buckets)| buckets.sum(&coeffs, bases, i))
             .fold(C::Curve::identity(), |mut sum, bucket| {
                 // restore original evaluation point
                 (0..c).for_each(|_| sum = sum.double());

--- a/halo2_proofs/src/arithmetic.rs
+++ b/halo2_proofs/src/arithmetic.rs
@@ -11,6 +11,8 @@ pub use pasta_curves::arithmetic::*;
 
 use crate::multicore::{self, TheBestReduce};
 
+const SCALAR_BITS: usize = 256;
+
 /// This represents an element of a group with basic operations that can be
 /// performed. This allows an FFT implementation (for example) to operate
 /// generically over either a field or elliptic curve group.
@@ -34,12 +36,12 @@ enum Bucket<C: CurveAffine> {
 }
 
 impl<C: CurveAffine> Bucket<C> {
-    fn add_assign(&mut self, other: &C) {
+    fn add_assign(&mut self, other: C) {
         *self = match *self {
-            Bucket::None => Bucket::Affine(*other),
-            Bucket::Affine(a) => Bucket::Projective(a + *other),
+            Bucket::None => Bucket::Affine(other),
+            Bucket::Affine(a) => Bucket::Projective(a + other),
             Bucket::Projective(mut a) => {
-                a += *other;
+                a += other;
                 Bucket::Projective(a)
             }
         }
@@ -57,17 +59,65 @@ impl<C: CurveAffine> Bucket<C> {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct BoothDigit {
+    magnitude: usize,
+    negative: bool,
+}
+
+fn booth_digit(bytes: &[u8], window_bits: usize, window: usize) -> BoothDigit {
+    debug_assert!(window_bits > 0);
+    debug_assert!(window_bits < u64::BITS as usize);
+
+    let window_start = window * window_bits;
+    let byte_start = window_start / 8;
+    let mut encoded = [0; 8];
+    if byte_start < bytes.len() {
+        for (slot, byte) in encoded.iter_mut().zip(&bytes[byte_start..]) {
+            *slot = *byte;
+        }
+    }
+
+    let bit_offset = window_start - byte_start * 8;
+    let radix = 1usize << window_bits;
+    let value = ((u64::from_le_bytes(encoded) >> bit_offset) as usize) & (radix - 1);
+    let overlap = if window_start == 0 {
+        0
+    } else {
+        let bit = window_start - 1;
+        bytes
+            .get(bit / 8)
+            .map_or(0, |byte| usize::from((byte >> (bit % 8)) & 1))
+    };
+
+    // The bit below each window is its carry-in, while the window's high bit
+    // is its carry-out. These terms cancel between adjacent windows, leaving
+    // a signed digit whose magnitude is at most half the radix.
+    if value < radix / 2 {
+        BoothDigit {
+            magnitude: value + overlap,
+            negative: false,
+        }
+    } else {
+        let magnitude = radix - value - overlap;
+        BoothDigit {
+            magnitude,
+            negative: magnitude != 0,
+        }
+    }
+}
+
 #[derive(Clone)]
-struct Buckets<C: CurveAffine> {
+struct BoothBuckets<C: CurveAffine> {
     c: usize,
     coeffs: Vec<Bucket<C>>,
 }
 
-impl<C: CurveAffine> Buckets<C> {
+impl<C: CurveAffine> BoothBuckets<C> {
     fn new(c: usize) -> Self {
         Self {
             c,
-            coeffs: vec![Bucket::None; (1 << c) - 1],
+            coeffs: vec![Bucket::None; 1 << (c - 1)],
         }
     }
 
@@ -77,11 +127,13 @@ impl<C: CurveAffine> Buckets<C> {
         bases: &[C],
         i: usize,
     ) -> C::Curve {
-        // get segmentation and add coeff to buckets content
+        // Recode each scalar window into a signed digit and add its base to
+        // the bucket for the digit's magnitude.
         for (coeff, base) in coeffs.iter().zip(bases.iter()) {
-            let seg = self.get_at(i, coeff);
-            if seg != 0 {
-                self.coeffs[seg - 1].add_assign(base);
+            let digit = booth_digit(coeff.as_ref(), self.c, i);
+            if digit.magnitude != 0 {
+                let base = if digit.negative { -*base } else { *base };
+                self.coeffs[digit.magnitude - 1].add_assign(base);
             }
         }
         // Summation by parts
@@ -95,24 +147,6 @@ impl<C: CurveAffine> Buckets<C> {
             acc += sum;
         });
         acc
-    }
-
-    fn get_at(&self, segment: usize, bytes: &<C::Scalar as PrimeField>::Repr) -> usize {
-        let skip_bits = segment * self.c;
-        let skip_bytes = skip_bits / 8;
-
-        if skip_bytes >= 32 {
-            0
-        } else {
-            let mut v = [0; 8];
-            for (v, o) in v.iter_mut().zip(bytes.as_ref()[skip_bytes..].iter()) {
-                *v = *o;
-            }
-
-            let mut tmp = u64::from_le_bytes(v);
-            tmp >>= skip_bits - (skip_bytes * 8);
-            (tmp % (1 << self.c)) as usize
-        }
     }
 }
 
@@ -159,7 +193,10 @@ pub fn best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Cu
         (f64::from(bases.len() as u32)).ln().ceil() as usize
     };
 
-    let mut multi_buckets: Vec<Buckets<C>> = vec![Buckets::new(c); (256 / c) + 1];
+    // The extra window captures a Booth carry above the scalar representation
+    // when `c` divides `SCALAR_BITS`.
+    let mut multi_buckets: Vec<BoothBuckets<C>> =
+        vec![BoothBuckets::new(c); (SCALAR_BITS / c) + 1];
     let num_threads = multicore::current_num_threads();
     if coeffs.len() > num_threads {
         multi_buckets
@@ -443,26 +480,105 @@ pub fn lagrange_interpolate<F: Field>(points: &[F], evals: &[F]) -> Vec<F> {
 use rand_core::OsRng;
 
 #[cfg(test)]
-use crate::pasta::{Eq, EqAffine, Fp};
+use crate::pasta::{Ep, EpAffine, Eq, EqAffine, Fp, Fq};
+
+#[cfg(test)]
+fn assert_multiexp_matches_naive<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) {
+    let expected = coeffs
+        .iter()
+        .zip(bases)
+        .map(|(coeff, base)| *base * coeff)
+        .fold(C::Curve::identity(), |acc, val| acc + val);
+
+    assert_eq!(best_multiexp(coeffs, bases), expected);
+}
 
 #[test]
 fn test_multiexp() {
     let rng = OsRng;
-    let k = 8;
+    for len in [0, 1, 2, 3, 4, 31, 32, 33, 255, 256, 257] {
+        let coeffs = (0..len).map(|_| Fp::random(rng)).collect::<Vec<_>>();
+        let bases = (0..len)
+            .map(|_| EqAffine::from(Eq::random(rng)))
+            .collect::<Vec<_>>();
 
-    let coeffs = (0..(1 << k)).map(|_| Fp::random(rng)).collect::<Vec<_>>();
-    let bases = (0..(1 << k))
+        assert_multiexp_matches_naive(&coeffs, &bases);
+    }
+}
+
+#[test]
+fn test_booth_digit_boundaries() {
+    let assert_digit = |bytes: &[u8], window_bits, window, magnitude, negative| {
+        assert_eq!(
+            booth_digit(bytes, window_bits, window),
+            BoothDigit {
+                magnitude,
+                negative,
+            }
+        );
+    };
+
+    let mut bytes = [0; SCALAR_BITS / 8];
+    assert_digit(&bytes, 3, 0, 0, false);
+
+    bytes[0] = 3;
+    assert_digit(&bytes, 3, 0, 3, false);
+
+    bytes[0] = 4;
+    assert_digit(&bytes, 3, 0, 4, true);
+    assert_digit(&bytes, 3, 1, 1, false);
+
+    bytes[0] = 7;
+    assert_digit(&bytes, 3, 0, 1, true);
+    assert_digit(&bytes, 3, 1, 1, false);
+
+    let bytes = [u8::MAX; SCALAR_BITS / 8];
+    assert_digit(&bytes, 8, 31, 0, false);
+    assert_digit(&bytes, 8, 32, 1, false);
+}
+
+#[test]
+fn test_multiexp_booth_boundaries() {
+    let rng = OsRng;
+    let mut fp_high_bit = Fp::ONE;
+    for _ in 0..254 {
+        fp_high_bit = fp_high_bit.double();
+    }
+    let fp_scalars = [
+        Fp::ZERO,
+        Fp::ONE,
+        -Fp::ONE,
+        Fp::from(3),
+        Fp::from(4),
+        Fp::from(7),
+        Fp::from(8),
+        fp_high_bit,
+    ];
+    let fp_coeffs = fp_scalars.into_iter().cycle().take(32).collect::<Vec<_>>();
+    let fp_bases = (0..fp_coeffs.len())
         .map(|_| EqAffine::from(Eq::random(rng)))
         .collect::<Vec<_>>();
+    assert_multiexp_matches_naive(&fp_coeffs, &fp_bases);
 
-    let expected = best_multiexp(&coeffs, &bases);
-    let actual = coeffs
-        .iter()
-        .zip(bases)
-        .map(|(coeff, base)| base * coeff)
-        .fold(Eq::identity(), |acc, val| acc + val);
-
-    assert_eq!(expected, actual);
+    let mut fq_high_bit = Fq::ONE;
+    for _ in 0..254 {
+        fq_high_bit = fq_high_bit.double();
+    }
+    let fq_scalars = [
+        Fq::ZERO,
+        Fq::ONE,
+        -Fq::ONE,
+        Fq::from(3),
+        Fq::from(4),
+        Fq::from(7),
+        Fq::from(8),
+        fq_high_bit,
+    ];
+    let fq_coeffs = fq_scalars.into_iter().cycle().take(32).collect::<Vec<_>>();
+    let fq_bases = (0..fq_coeffs.len())
+        .map(|_| EpAffine::from(Ep::random(rng)))
+        .collect::<Vec<_>>();
+    assert_multiexp_matches_naive(&fq_coeffs, &fq_bases);
 }
 
 #[test]

--- a/halo2_proofs/src/arithmetic.rs
+++ b/halo2_proofs/src/arithmetic.rs
@@ -11,8 +11,6 @@ pub use pasta_curves::arithmetic::*;
 
 use crate::multicore::{self, TheBestReduce};
 
-const SCALAR_BITS: usize = 256;
-
 /// This represents an element of a group with basic operations that can be
 /// performed. This allows an FFT implementation (for example) to operate
 /// generically over either a field or elliptic curve group.
@@ -107,6 +105,24 @@ fn booth_digit(bytes: &[u8], window_bits: usize, window: usize) -> BoothDigit {
     }
 }
 
+fn booth_window_count<R: AsRef<[u8]>>(reprs: &[R], window_bits: usize) -> usize {
+    debug_assert!(window_bits > 0);
+
+    let repr_bytes = reprs
+        .iter()
+        .map(|repr| repr.as_ref().len())
+        .max()
+        .unwrap_or(0);
+    let repr_bits = repr_bytes
+        .checked_mul(u8::BITS as usize)
+        .expect("scalar representation is too large");
+
+    // Integer division reserves an additional carry window exactly when the
+    // representation ends on a window boundary. Otherwise, the last partial
+    // window cannot produce a carry.
+    repr_bits / window_bits + 1
+}
+
 #[derive(Clone)]
 struct BoothBuckets<C: CurveAffine> {
     c: usize,
@@ -193,10 +209,8 @@ pub fn best_multiexp<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[C]) -> C::Cu
         (f64::from(bases.len() as u32)).ln().ceil() as usize
     };
 
-    // The extra window captures a Booth carry above the scalar representation
-    // when `c` divides `SCALAR_BITS`.
     let mut multi_buckets: Vec<BoothBuckets<C>> =
-        vec![BoothBuckets::new(c); (SCALAR_BITS / c) + 1];
+        vec![BoothBuckets::new(c); booth_window_count(&coeffs, c)];
     let num_threads = multicore::current_num_threads();
     if coeffs.len() > num_threads {
         multi_buckets
@@ -493,6 +507,39 @@ fn assert_multiexp_matches_naive<C: CurveAffine>(coeffs: &[C::Scalar], bases: &[
     assert_eq!(best_multiexp(coeffs, bases), expected);
 }
 
+#[cfg(test)]
+fn evaluate_le_bytes(bytes: &[u8]) -> Fp {
+    bytes.iter().rev().fold(Fp::ZERO, |mut acc, byte| {
+        for bit in (0..u8::BITS).rev() {
+            acc = acc.double();
+            if (byte >> bit) & 1 != 0 {
+                acc += Fp::ONE;
+            }
+        }
+        acc
+    })
+}
+
+#[cfg(test)]
+fn evaluate_booth_digits(bytes: &[u8], window_bits: usize) -> Fp {
+    (0..booth_window_count(&[bytes], window_bits))
+        .rev()
+        .fold(Fp::ZERO, |mut acc, window| {
+            for _ in 0..window_bits {
+                acc = acc.double();
+            }
+
+            let digit = booth_digit(bytes, window_bits, window);
+            let magnitude = Fp::from(digit.magnitude as u64);
+            if digit.negative {
+                acc -= magnitude;
+            } else {
+                acc += magnitude;
+            }
+            acc
+        })
+}
+
 #[test]
 fn test_multiexp() {
     let rng = OsRng;
@@ -518,7 +565,8 @@ fn test_booth_digit_boundaries() {
         );
     };
 
-    let mut bytes = [0; SCALAR_BITS / 8];
+    let repr_bytes = <Fp as PrimeField>::Repr::default().as_ref().len();
+    let mut bytes = vec![0; repr_bytes];
     assert_digit(&bytes, 3, 0, 0, false);
 
     bytes[0] = 3;
@@ -532,9 +580,77 @@ fn test_booth_digit_boundaries() {
     assert_digit(&bytes, 3, 0, 1, true);
     assert_digit(&bytes, 3, 1, 1, false);
 
-    let bytes = [u8::MAX; SCALAR_BITS / 8];
+    let bytes = vec![u8::MAX; repr_bytes];
     assert_digit(&bytes, 8, 31, 0, false);
     assert_digit(&bytes, 8, 32, 1, false);
+}
+
+#[test]
+fn test_booth_digit_wide_representation() {
+    const WIDE_REPR_BYTES: usize = 40;
+    const FIRST_WIDE_BYTE: usize = 32;
+    const WINDOW_BITS: usize = 8;
+    const HALF_RADIX: usize = 1 << (WINDOW_BITS - 1);
+
+    // A high-half value in the first byte above 256 bits produces a negative
+    // digit whose carry must be consumed by the following window.
+    let mut bytes = [0; WIDE_REPR_BYTES];
+    let short_bytes = [0; FIRST_WIDE_BYTE];
+    assert_eq!(
+        booth_window_count(&[short_bytes.as_slice(), bytes.as_slice()], WINDOW_BITS),
+        WIDE_REPR_BYTES + 1
+    );
+
+    bytes[FIRST_WIDE_BYTE] = HALF_RADIX as u8;
+    assert_eq!(
+        booth_digit(&bytes, WINDOW_BITS, FIRST_WIDE_BYTE),
+        BoothDigit {
+            magnitude: HALF_RADIX,
+            negative: true,
+        }
+    );
+    assert_eq!(
+        booth_digit(&bytes, WINDOW_BITS, FIRST_WIDE_BYTE + 1),
+        BoothDigit {
+            magnitude: 1,
+            negative: false,
+        }
+    );
+
+    // The final data window likewise has a following carry-only window.
+    bytes = [0; WIDE_REPR_BYTES];
+    bytes[WIDE_REPR_BYTES - 1] = HALF_RADIX as u8;
+    assert_eq!(
+        booth_digit(&bytes, WINDOW_BITS, WIDE_REPR_BYTES - 1),
+        BoothDigit {
+            magnitude: HALF_RADIX,
+            negative: true,
+        }
+    );
+    assert_eq!(
+        booth_digit(&bytes, WINDOW_BITS, WIDE_REPR_BYTES),
+        BoothDigit {
+            magnitude: 1,
+            negative: false,
+        }
+    );
+
+    let first_high_bit = {
+        let mut bytes = [0; WIDE_REPR_BYTES];
+        bytes[FIRST_WIDE_BYTE + 1] = 1;
+        bytes
+    };
+    let all_ones = [u8::MAX; WIDE_REPR_BYTES];
+    // Folding into `Fp` avoids a big-integer test dependency while exercising
+    // the complete 320-bit recoding schedule.
+    for bytes in [&bytes, &first_high_bit, &all_ones] {
+        for window_bits in [1, 3, 5, 8, 9] {
+            assert_eq!(
+                evaluate_booth_digits(bytes, window_bits),
+                evaluate_le_bytes(bytes)
+            );
+        }
+    }
 }
 
 #[test]

--- a/halo2_proofs/src/circuit.rs
+++ b/halo2_proofs/src/circuit.rs
@@ -557,7 +557,7 @@ impl<'a, F: Field, L: Layouter<F> + 'a> Drop for NamespacedLayouter<'a, F, L> {
                     if is_second_frame {
                         // Resolve this instruction pointer to a symbol name.
                         backtrace::resolve_frame(frame, |symbol| {
-                            gadget_name = symbol.name().map(|name| format!("{:#}", name));
+                            gadget_name = symbol.name().map(|name| format!("{name:#}"));
                         });
 
                         // We are done!

--- a/halo2_proofs/src/circuit/table_layouter.rs
+++ b/halo2_proofs/src/circuit/table_layouter.rs
@@ -101,7 +101,7 @@ impl<'r, 'a, F: Field, CS: Assignment<F> + 'a> TableLayouter<F>
                 return Err(Error::TableError(TableError::OverwriteDefault(
                     column,
                     format!("{:?}", entry.0.unwrap()),
-                    format!("{:?}", value),
+                    format!("{value:?}"),
                 )))
             }
             _ => (),

--- a/halo2_proofs/src/dev/cost.rs
+++ b/halo2_proofs/src/dev/cost.rs
@@ -340,7 +340,7 @@ impl<G: PrimeGroup, ConcreteCircuit: Circuit<G::Scalar>> CircuitCost<G, Concrete
 
     fn permutation_chunks(&self) -> usize {
         let chunk_size = self.max_deg - 2;
-        (self.permutation_cols + chunk_size - 1) / chunk_size
+        self.permutation_cols.div_ceil(chunk_size)
     }
 
     /// Returns the marginal proof size per instance of this circuit.

--- a/halo2_proofs/src/dev/failure.rs
+++ b/halo2_proofs/src/dev/failure.rs
@@ -36,9 +36,9 @@ pub enum FailureLocation {
 impl fmt::Display for FailureLocation {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InRegion { region, offset } => write!(f, "in {} at offset {}", region, offset),
+            Self::InRegion { region, offset } => write!(f, "in {region} at offset {offset}"),
             Self::OutsideRegion { row } => {
-                write!(f, "outside any region, on row {}", row)
+                write!(f, "outside any region, on row {row}")
             }
         }
     }
@@ -197,8 +197,7 @@ impl fmt::Display for VerifyFailure {
             } => {
                 write!(
                     f,
-                    "{} uses {} at offset {}, which requires cell in column {:?} at offset {} to be assigned.",
-                    region, gate, gate_offset, column, offset
+                    "{region} uses {gate} at offset {gate_offset}, which requires cell in column {column:?} at offset {offset} to be assigned."
                 )
             }
             Self::InstanceCellNotAssigned {
@@ -210,8 +209,7 @@ impl fmt::Display for VerifyFailure {
             } => {
                 write!(
                     f,
-                    "{} uses {} at offset {}, which requires cell in instance column {:?} at row {} to be assigned.",
-                    region, gate, gate_offset, column, row
+                    "{region} uses {gate} at offset {gate_offset}, which requires cell in instance column {column:?} at row {row} to be assigned."
                 )
             }
             Self::ConstraintNotSatisfied {
@@ -219,28 +217,26 @@ impl fmt::Display for VerifyFailure {
                 location,
                 cell_values,
             } => {
-                writeln!(f, "{} is not satisfied {}", constraint, location)?;
+                writeln!(f, "{constraint} is not satisfied {location}")?;
                 for (name, value) in cell_values {
-                    writeln!(f, "- {} = {}", name, value)?;
+                    writeln!(f, "- {name} = {value}")?;
                 }
                 Ok(())
             }
             Self::ConstraintPoisoned { constraint } => {
                 write!(
                     f,
-                    "{} is active on an unusable row - missing selector?",
-                    constraint
+                    "{constraint} is active on an unusable row - missing selector?"
                 )
             }
             Self::Lookup {
                 lookup_index,
                 location,
-            } => write!(f, "Lookup {} is not satisfied {}", lookup_index, location),
+            } => write!(f, "Lookup {lookup_index} is not satisfied {location}"),
             Self::Permutation { column, location } => {
                 write!(
                     f,
-                    "Equality constraint not satisfied by cell ({:?}, {})",
-                    column, location
+                    "Equality constraint not satisfied by cell ({column:?}, {location})"
                 )
             }
         }
@@ -284,7 +280,7 @@ fn render_cell_not_assigned<F: Field>(
                 if cell.column == column && gate_offset as i32 + cell.rotation.0 == offset as i32 {
                     "X".to_string()
                 } else {
-                    format!("x{}", i)
+                    format!("x{i}")
                 }
             });
     }
@@ -346,7 +342,7 @@ fn render_constraint_not_satisfied<F: Field>(
             .entry(cell.rotation)
             .or_default()
             .entry(cell.column)
-            .or_insert(format!("x{}", i));
+            .or_insert(format!("x{i}"));
     }
 
     eprintln!("error: constraint not satisfied");
@@ -371,7 +367,7 @@ fn render_constraint_not_satisfied<F: Field>(
     eprintln!();
     eprintln!("  Assigned cell values:");
     for (i, (_, value)) in cell_values.iter().enumerate() {
-        eprintln!("    x{} = {}", i, value);
+        eprintln!("    x{i} = {value}");
     }
 }
 
@@ -503,7 +499,7 @@ fn render_lookup<F: Field>(
                 .entry(cell.rotation)
                 .or_default()
                 .entry(cell.column)
-                .or_insert(format!("x{}", i));
+                .or_insert(format!("x{i}"));
         }
 
         if i != 0 {
@@ -525,7 +521,7 @@ fn render_lookup<F: Field>(
         eprintln!("    |");
         eprintln!("    | Assigned cell values:");
         for (i, (_, value)) in cell_values.iter().enumerate() {
-            eprintln!("    |   x{} = {}", i, value);
+            eprintln!("    |   x{i} = {value}");
         }
     }
 }
@@ -559,7 +555,7 @@ impl VerifyFailure {
                 lookup_index,
                 location,
             } => render_lookup(prover, *lookup_index, location),
-            _ => eprintln!("{}", self),
+            _ => eprintln!("{self}"),
         }
     }
 }

--- a/halo2_proofs/src/dev/failure/emitter.rs
+++ b/halo2_proofs/src/dev/failure/emitter.rs
@@ -1,5 +1,4 @@
 use std::collections::BTreeMap;
-use std::iter;
 
 use group::ff::Field;
 
@@ -13,9 +12,9 @@ fn padded(p: char, width: usize, text: &str) -> String {
     let pad = width - text.len();
     format!(
         "{}{}{}",
-        iter::repeat(p).take(pad - pad / 2).collect::<String>(),
+        std::iter::repeat_n(p, pad - pad / 2).collect::<String>(),
         text,
-        iter::repeat(p).take(pad / 2).collect::<String>(),
+        std::iter::repeat_n(p, pad / 2).collect::<String>(),
     )
 }
 
@@ -38,12 +37,12 @@ pub(super) fn render_cell_layout(
     let offset = match location {
         FailureLocation::InRegion { region, offset } => {
             eprintln!("{}Cell layout in region '{}':", prefix, region.name);
-            eprint!("{}  | Offset |", prefix);
+            eprint!("{prefix}  | Offset |");
             Some(*offset as i32)
         }
         FailureLocation::OutsideRegion { row } => {
-            eprintln!("{}Cell layout at row {}:", prefix, row);
-            eprint!("{}  |Rotation|", prefix);
+            eprintln!("{prefix}Cell layout at row {row}:");
+            eprint!("{prefix}  |Rotation|");
             None
         }
     };
@@ -69,7 +68,7 @@ pub(super) fn render_cell_layout(
         );
     }
     eprintln!();
-    eprint!("{}  +--------+", prefix);
+    eprint!("{prefix}  +--------+");
     for cells in columns.values() {
         eprint!("{}+", padded('-', col_width(*cells), ""));
     }
@@ -135,23 +134,23 @@ pub(super) fn expression_to_string<F: Field>(
         },
         &|a| {
             if a.contains(' ') {
-                format!("-({})", a)
+                format!("-({a})")
             } else {
-                format!("-{}", a)
+                format!("-{a}")
             }
         },
         &|a, b| {
             if let Some(b) = b.strip_prefix('-') {
-                format!("{} - {}", a, b)
+                format!("{a} - {b}")
             } else {
-                format!("{} + {}", a, b)
+                format!("{a} + {b}")
             }
         },
         &|a, b| match (a.contains(' '), b.contains(' ')) {
-            (false, false) => format!("{} * {}", a, b),
-            (false, true) => format!("{} * ({})", a, b),
-            (true, false) => format!("({}) * {}", a, b),
-            (true, true) => format!("({}) * ({})", a, b),
+            (false, false) => format!("{a} * {b}"),
+            (false, true) => format!("{a} * ({b})"),
+            (true, false) => format!("({a}) * {b}"),
+            (true, true) => format!("({a}) * ({b})"),
         },
         &|a, s| {
             if a.contains(' ') {

--- a/halo2_proofs/src/dev/gates.rs
+++ b/halo2_proofs/src/dev/gates.rs
@@ -124,23 +124,23 @@ impl CircuitGates {
                             &|query| format!("I{}@{}", query.column_index, query.rotation.0),
                             &|a| {
                                 if a.contains(' ') {
-                                    format!("-({})", a)
+                                    format!("-({a})")
                                 } else {
-                                    format!("-{}", a)
+                                    format!("-{a}")
                                 }
                             },
                             &|a, b| {
                                 if let Some(b) = b.strip_prefix('-') {
-                                    format!("{} - {}", a, b)
+                                    format!("{a} - {b}")
                                 } else {
-                                    format!("{} + {}", a, b)
+                                    format!("{a} + {b}")
                                 }
                             },
                             &|a, b| match (a.contains(' '), b.contains(' ')) {
-                                (false, false) => format!("{} * {}", a, b),
-                                (false, true) => format!("{} * ({})", a, b),
-                                (true, false) => format!("({}) * {}", a, b),
-                                (true, true) => format!("({}) * ({})", a, b),
+                                (false, false) => format!("{a} * {b}"),
+                                (false, true) => format!("{a} * ({b})"),
+                                (true, false) => format!("({a}) * {b}"),
+                                (true, true) => format!("({a}) * ({b})"),
                             },
                             &|a, s| {
                                 if a.contains(' ') {
@@ -228,7 +228,7 @@ impl CircuitGates {
         let mut ret = String::new();
         let w = &mut ret;
         for query in &queries {
-            write!(w, "{},", query).unwrap();
+            write!(w, "{query},").unwrap();
         }
         writeln!(w, "Name").unwrap();
 

--- a/halo2_proofs/src/dev/graph.rs
+++ b/halo2_proofs/src/dev/graph.rs
@@ -33,7 +33,7 @@ pub fn circuit_dot_graph<F: Field, ConcreteCircuit: Circuit<F>>(
         .into_iter()
         .map(|(name, gadget_name)| {
             if let Some(gadget_name) = gadget_name {
-                format!("[{}] {}", gadget_name, name)
+                format!("[{gadget_name}] {name}")
             } else {
                 name
             }

--- a/halo2_proofs/src/dev/graph/layout.rs
+++ b/halo2_proofs/src/dev/graph/layout.rs
@@ -309,7 +309,7 @@ impl CircuitLayout {
             root.draw(
                 &(EmptyElement::at((0, usable_rows))
                     + Text::new(
-                        format!("{} usable rows", usable_rows),
+                        format!("{usable_rows} usable rows"),
                         (10, 10),
                         ("sans-serif", 15.0).into_font(),
                     )),

--- a/halo2_proofs/src/dev/util.rs
+++ b/halo2_proofs/src/dev/util.rs
@@ -64,11 +64,11 @@ pub(super) fn format_value<F: Field>(v: F) -> String {
         "-1".into()
     } else {
         // Format value as hex.
-        let s = format!("{:?}", v);
+        let s = format!("{v:?}");
         // Remove leading zeroes.
         let s = s.strip_prefix("0x").unwrap();
         let s = s.trim_start_matches('0');
-        format!("0x{}", s)
+        format!("0x{s}")
     }
 }
 

--- a/halo2_proofs/src/helpers.rs
+++ b/halo2_proofs/src/helpers.rs
@@ -9,7 +9,7 @@ pub(crate) trait CurveRead: CurveAffine {
         let mut compressed = Self::Repr::default();
         reader.read_exact(compressed.as_mut())?;
         Option::from(Self::from_bytes(&compressed))
-            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "invalid point encoding in proof"))
+            .ok_or_else(|| io::Error::other("invalid point encoding in proof"))
     }
 }
 

--- a/halo2_proofs/src/multicore.rs
+++ b/halo2_proofs/src/multicore.rs
@@ -11,20 +11,24 @@ compile_error!(
     "The multicore feature flag is not supported on wasm32 architectures without atomics"
 );
 
-pub use maybe_rayon::{
-    iter::{IntoParallelIterator, ParallelIterator},
-    join, scope,
-};
+pub use maybe_rayon::{iter::IntoParallelIterator, join, scope};
 
 #[cfg(feature = "multicore")]
-pub use maybe_rayon::{current_num_threads, iter::IndexedParallelIterator};
+pub use maybe_rayon::{
+    current_num_threads,
+    iter::{IndexedParallelIterator, ParallelIterator},
+};
 
 #[cfg(not(feature = "multicore"))]
 pub fn current_num_threads() -> usize {
     1
 }
 
+// Mirrors the `multicore` re-export above so both configurations expose the same
+// name. Its only consumer is `plonk::verifier::batch`, whose import of it is
+// itself gated on `multicore`, so nothing references it in this configuration.
 #[cfg(not(feature = "multicore"))]
+#[allow(dead_code)]
 pub trait IndexedParallelIterator: std::iter::Iterator {}
 
 pub trait TryFoldAndReduce<T, E> {

--- a/halo2_proofs/src/plonk/error.rs
+++ b/halo2_proofs/src/plonk/error.rs
@@ -66,11 +66,10 @@ impl fmt::Display for Error {
             Error::ConstraintSystemFailure => write!(f, "The constraint system is not satisfied"),
             Error::BoundsFailure => write!(f, "An out-of-bounds index was passed to the backend"),
             Error::Opening => write!(f, "Multi-opening proof was invalid"),
-            Error::Transcript(e) => write!(f, "Transcript error: {}", e),
+            Error::Transcript(e) => write!(f, "Transcript error: {e}"),
             Error::NotEnoughRowsAvailable { current_k } => write!(
                 f,
-                "k = {} is too small for the given circuit. Try using a larger value of k",
-                current_k,
+                "k = {current_k} is too small for the given circuit. Try using a larger value of k",
             ),
             Error::InstanceTooLarge => write!(f, "Instance vectors are larger than the circuit"),
             Error::NotEnoughColumnsForConstants => {
@@ -81,10 +80,9 @@ impl fmt::Display for Error {
             }
             Error::ColumnNotInPermutation(column) => write!(
                 f,
-                "Column {:?} must be included in the permutation. Help: try applying `meta.enable_equalty` on the column",
-                column
+                "Column {column:?} must be included in the permutation. Help: try applying `meta.enable_equalty` on the column"
             ),
-            Error::TableError(error) => write!(f, "{}", error),
+            Error::TableError(error) => write!(f, "{error}"),
             Error::IllegalHashFromPrivatePoint =>  write!(
                 f,
                 "Hashing from private point is disabled"
@@ -121,23 +119,20 @@ impl fmt::Display for TableError {
             TableError::ColumnNotAssigned(col) => {
                 write!(
                     f,
-                    "{:?} not fully assigned. Help: assign a value at offset 0.",
-                    col
+                    "{col:?} not fully assigned. Help: assign a value at offset 0."
                 )
             }
             TableError::UnevenColumnLengths((col, col_len), (table, table_len)) => write!(
                 f,
-                "{:?} has length {} while {:?} has length {}",
-                col, col_len, table, table_len
+                "{col:?} has length {col_len} while {table:?} has length {table_len}"
             ),
             TableError::UsedColumn(col) => {
-                write!(f, "{:?} has already been used", col)
+                write!(f, "{col:?} has already been used")
             }
             TableError::OverwriteDefault(col, default, val) => {
                 write!(
                     f,
-                    "Attempted to overwrite default value {} with {} in {:?}",
-                    default, val, col
+                    "Attempted to overwrite default value {default} with {val} in {col:?}"
                 )
             }
         }

--- a/halo2_proofs/src/plonk/fingerprint/vesta_lean.rs
+++ b/halo2_proofs/src/plonk/fingerprint/vesta_lean.rs
@@ -194,9 +194,9 @@ fn expr_to_lean(e: &Expression<Fp>) -> String {
         &|q| format!("(.fixed {})", q.index),
         &|q| format!("(.advice {})", q.index),
         &|q| format!("(.instance {})", q.index),
-        &|a: String| format!("(.negated {})", a),
-        &|a: String, b: String| format!("(.sum {} {})", a, b),
-        &|a: String, b: String| format!("(.product {} {})", a, b),
+        &|a: String| format!("(.negated {a})"),
+        &|a: String, b: String| format!("(.sum {a} {b})"),
+        &|a: String, b: String| format!("(.product {a} {b})"),
         &|a: String, c| format!("(.scaled {} {})", a, fp(c)),
     )
 }
@@ -769,16 +769,14 @@ impl VerifyingKey<EqAffine> {
 
         // ---- Shape ----
         out.push_str(&format!(
-            "def shape : Shape := {{ k := {}, numProofs := {}, numAdviceColumns := {}, numLookups := {}, numPermutationSets := {}, numPermutationColumns := {}, numQuotientPieces := {}, numInstanceColumns := {}, numInstanceQueries := {}, numAdviceQueries := {}, numFixedQueries := {}, numPointSets := {} }}\n\n",
-            k, num_proofs, n_advice, n_lookups, n_perm_sets, n_perm_cols, n_quotient, n_inst_cols, n_inst_q, n_adv_q, n_fixed_q, n_point_sets,
+            "def shape : Shape := {{ k := {k}, numProofs := {num_proofs}, numAdviceColumns := {n_advice}, numLookups := {n_lookups}, numPermutationSets := {n_perm_sets}, numPermutationColumns := {n_perm_cols}, numQuotientPieces := {n_quotient}, numInstanceColumns := {n_inst_cols}, numInstanceQueries := {n_inst_q}, numAdviceQueries := {n_adv_q}, numFixedQueries := {n_fixed_q}, numPointSets := {n_point_sets} }}\n\n",
         ));
         out.push_str(&format!(
             "def capturedUrsG : List G := [{}]\n\n",
             urs_g.join(", ")
         ));
         out.push_str(&format!(
-            "def capturedURS : URS G := {{ k := {}, g := fun i => capturedUrsG.getD i.val 0, w := {}, u := {} }}\n\n",
-            k, urs_w, urs_u
+            "def capturedURS : URS G := {{ k := {k}, g := fun i => capturedUrsG.getD i.val 0, w := {urs_w}, u := {urs_u} }}\n\n"
         ));
         // `capturedURS.g` indexes `capturedUrsG` with `getD`, which silently yields the identity for
         // any index past the list's end; pin the length so a truncated URS cannot pass unnoticed.
@@ -825,11 +823,11 @@ impl VerifyingKey<EqAffine> {
             for col in chunk {
                 let qi = cs.get_any_query_index(*col);
                 let cref = match col.column_type() {
-                    Any::Advice => format!("(.advice {})", qi),
-                    Any::Fixed => format!("(.fixed {})", qi),
-                    Any::Instance => format!("(.instance {})", qi),
+                    Any::Advice => format!("(.advice {qi})"),
+                    Any::Fixed => format!("(.fixed {qi})"),
+                    Any::Instance => format!("(.instance {qi})"),
                 };
-                entries.push(format!("({}, {})", cref, gidx));
+                entries.push(format!("({cref}, {gidx})"));
                 gidx += 1;
             }
             chunks.push(format!("[{}]", entries.join(", ")));
@@ -963,10 +961,10 @@ impl VerifyingKey<EqAffine> {
         );
         out.push_str("def vk : VerifyingKey shape Fp G := {\n");
         out.push_str(&format!("  omega := {},\n", fp(self.domain.get_omega())));
-        out.push_str(&format!("  n := {},\n", n));
-        out.push_str(&format!("  blindingFactors := {},\n", blinding));
+        out.push_str(&format!("  n := {n},\n"));
+        out.push_str(&format!("  blindingFactors := {blinding},\n"));
         out.push_str(&format!("  delta := {},\n", fp(Fp::DELTA)));
-        out.push_str(&format!("  chunkLen := {},\n", chunk_len));
+        out.push_str(&format!("  chunkLen := {chunk_len},\n"));
         out.push_str(&format!("  gates := [{}],\n", gates.join(", ")));
         out.push_str(&format!(
             "  instanceQueryLayout := [{}],\n",
@@ -1109,26 +1107,22 @@ impl VerifyingKey<EqAffine> {
         ));
 
         out.push_str("def ps : ProofString shape Fp G := {\n");
-        out.push_str(&format!("  adviceCommitments := fun p c => capturedAdviceCommitments.getD (p.val * {} + c.val) 0,\n", n_advice));
-        out.push_str(&format!("  lookupPermutedInput := fun p l => capturedLookupPermutedInput.getD (p.val * {} + l.val) 0,\n", n_lookups));
-        out.push_str(&format!("  lookupPermutedTable := fun p l => capturedLookupPermutedTable.getD (p.val * {} + l.val) 0,\n", n_lookups));
-        out.push_str(&format!("  permutationProduct := fun p s => capturedPermutationProducts.getD (p.val * {} + s.val) 0,\n", n_perm_sets));
+        out.push_str(&format!("  adviceCommitments := fun p c => capturedAdviceCommitments.getD (p.val * {n_advice} + c.val) 0,\n"));
+        out.push_str(&format!("  lookupPermutedInput := fun p l => capturedLookupPermutedInput.getD (p.val * {n_lookups} + l.val) 0,\n"));
+        out.push_str(&format!("  lookupPermutedTable := fun p l => capturedLookupPermutedTable.getD (p.val * {n_lookups} + l.val) 0,\n"));
+        out.push_str(&format!("  permutationProduct := fun p s => capturedPermutationProducts.getD (p.val * {n_perm_sets} + s.val) 0,\n"));
         out.push_str(&format!(
-            "  lookupProduct := fun p l => capturedLookupProducts.getD (p.val * {} + l.val) 0,\n",
-            n_lookups
+            "  lookupProduct := fun p l => capturedLookupProducts.getD (p.val * {n_lookups} + l.val) 0,\n"
         ));
         out.push_str(&format!(
-            "  vanishingRandom := {},\n",
-            vanishing_random_point
+            "  vanishingRandom := {vanishing_random_point},\n"
         ));
         out.push_str("  hPieces := fun i => capturedHPieces.getD i.val 0,\n");
         out.push_str(&format!(
-            "  instanceEvals := fun p q => capturedInstanceEvals.getD (p.val * {} + q.val) 0,\n",
-            n_inst_q
+            "  instanceEvals := fun p q => capturedInstanceEvals.getD (p.val * {n_inst_q} + q.val) 0,\n"
         ));
         out.push_str(&format!(
-            "  adviceEvals := fun p q => capturedAdviceEvals.getD (p.val * {} + q.val) 0,\n",
-            n_adv_q
+            "  adviceEvals := fun p q => capturedAdviceEvals.getD (p.val * {n_adv_q} + q.val) 0,\n"
         ));
         out.push_str("  fixedEvals := fun q => capturedFixedEvals.getD q.val 0,\n");
         out.push_str(&format!(
@@ -1138,11 +1132,11 @@ impl VerifyingKey<EqAffine> {
         out.push_str(
             "  permutationCommonEvals := fun i => capturedPermutationCommonEvals.getD i.val 0,\n",
         );
-        out.push_str(&format!("  permutationSetEvals := fun p s => capturedPermutationSetEvals.getD (p.val * {} + s.val) {{ eval := 0, nextEval := 0, lastEval := none }},\n", n_perm_sets));
-        out.push_str(&format!("  lookupEvals := fun p l => capturedLookupEvals.getD (p.val * {} + l.val) {{ productEval := 0, productNextEval := 0, permutedInputEval := 0, permutedInputInvEval := 0, permutedTableEval := 0 }},\n", n_lookups));
-        out.push_str(&format!("  multiopenQPrime := {},\n", q_prime_point));
+        out.push_str(&format!("  permutationSetEvals := fun p s => capturedPermutationSetEvals.getD (p.val * {n_perm_sets} + s.val) {{ eval := 0, nextEval := 0, lastEval := none }},\n"));
+        out.push_str(&format!("  lookupEvals := fun p l => capturedLookupEvals.getD (p.val * {n_lookups} + l.val) {{ productEval := 0, productNextEval := 0, permutedInputEval := 0, permutedInputInvEval := 0, permutedTableEval := 0 }},\n"));
+        out.push_str(&format!("  multiopenQPrime := {q_prime_point},\n"));
         out.push_str("  multiopenU := fun s => capturedMultiopenU.getD s.val 0,\n");
-        out.push_str(&format!("  ipaS := {},\n", ipa_s_point));
+        out.push_str(&format!("  ipaS := {ipa_s_point},\n"));
         out.push_str("  ipaRounds := fun j => capturedIpaRounds.getD j.val (0, 0),\n");
         out.push_str(&format!("  ipaC := {},\n", fp(ipa_c)));
         out.push_str(&format!("  ipaF := {} }}\n\n", fp(ipa_f)));
@@ -1253,7 +1247,7 @@ impl VerifyingKey<EqAffine> {
                 out.push_str("theorem capturedMsm_evalNat_ne_zero : capturedMsm.evalNat capturedURS ≠ 0 := by native_decide\n\n");
             }
         }
-        out.push_str(&format!("end {}\n", lean_namespace));
+        out.push_str(&format!("end {lean_namespace}\n"));
 
         let body = out;
         let point_coordinates = points.coordinate_literals();
@@ -1281,8 +1275,7 @@ impl VerifyingKey<EqAffine> {
         // g-scalar arrays, point-coordinate validation, and gate Expr trees) that `native_decide`
         // compiles.
         out.push_str(&format!(
-            "import Zcash.Snark\n\nset_option maxRecDepth 1000000\n\nnamespace {}\n\nopen Zcash.Snark\nopen CompElliptic.CurveForms.ShortWeierstrass\nopen CompElliptic.Curves.Pasta\nopen CompElliptic.Fields.Pasta\n\n",
-            lean_namespace
+            "import Zcash.Snark\n\nset_option maxRecDepth 1000000\n\nnamespace {lean_namespace}\n\nopen Zcash.Snark\nopen CompElliptic.CurveForms.ShortWeierstrass\nopen CompElliptic.Curves.Pasta\nopen CompElliptic.Fields.Pasta\n\n"
         ));
         out.push_str("/-- Scalar field element from four little-endian u64 limbs. -/\n");
         out.push_str("def mkFp (a b c d : ℕ) : Fp := (a : Fp) + (b : Fp) * (2 : Fp) ^ 64 + (c : Fp) * (2 : Fp) ^ 128 + (d : Fp) * (2 : Fp) ^ 192\n\n");
@@ -1292,8 +1285,7 @@ impl VerifyingKey<EqAffine> {
         out.push_str("abbrev G := VestaG\n\n");
         out.push_str("instance : Inhabited G := ⟨0⟩\n\n");
         out.push_str(&format!(
-            "def capturedCircuitId : String := {:?}\n\n",
-            circuit_id
+            "def capturedCircuitId : String := {circuit_id:?}\n\n"
         ));
         out.push_str("/-- Canonical affine coordinates for every distinct Vesta point used by this fixture. -/\n");
         out.push_str(&format!(

--- a/halo2_proofs/src/plonk/fingerprint/vesta_lean.rs
+++ b/halo2_proofs/src/plonk/fingerprint/vesta_lean.rs
@@ -1114,9 +1114,7 @@ impl VerifyingKey<EqAffine> {
         out.push_str(&format!(
             "  lookupProduct := fun p l => capturedLookupProducts.getD (p.val * {n_lookups} + l.val) 0,\n"
         ));
-        out.push_str(&format!(
-            "  vanishingRandom := {vanishing_random_point},\n"
-        ));
+        out.push_str(&format!("  vanishingRandom := {vanishing_random_point},\n"));
         out.push_str("  hPieces := fun i => capturedHPieces.getD i.val 0,\n");
         out.push_str(&format!(
             "  instanceEvals := fun p q => capturedInstanceEvals.getD (p.val * {n_inst_q} + q.val) 0,\n"

--- a/halo2_proofs/src/poly/evaluator.rs
+++ b/halo2_proofs/src/poly/evaluator.rs
@@ -26,10 +26,10 @@ fn get_chunk_params(poly_len: usize) -> (usize, usize) {
     // Calculate the ideal chunk size for the desired throughput. We use ceiling
     // division to ensure the minimum chunk size is 1.
     //     chunk_size = ceil(poly_len / num_chunks)
-    let chunk_size = (poly_len + num_chunks - 1) / num_chunks;
+    let chunk_size = poly_len.div_ceil(num_chunks);
     // Now re-calculate num_chunks from the actual chunk size.
     //     num_chunks = ceil(poly_len / chunk_size)
-    let num_chunks = (poly_len + chunk_size - 1) / chunk_size;
+    let num_chunks = poly_len.div_ceil(chunk_size);
 
     (chunk_size, num_chunks)
 }
@@ -641,7 +641,7 @@ mod tests {
                 return;
             }
         };
-        eprintln!("Testing short-chunk regression with k = {}", k);
+        eprintln!("Testing short-chunk regression with k = {k}");
 
         fn test_case<E: Copy + Send + Sync, B: BasisOps>(
             k: u32,

--- a/halo2_proofs/src/transcript.rs
+++ b/halo2_proofs/src/transcript.rs
@@ -92,7 +92,7 @@ where
         let mut compressed = C::Repr::default();
         self.reader.read_exact(compressed.as_mut())?;
         let point: C = Option::from(C::from_bytes(&compressed)).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::Other, "invalid point encoding in proof")
+            io::Error::other("invalid point encoding in proof")
         })?;
         self.common_point(point)?;
 
@@ -103,8 +103,7 @@ where
         let mut data = <C::Scalar as PrimeField>::Repr::default();
         self.reader.read_exact(data.as_mut())?;
         let scalar: C::Scalar = Option::from(C::Scalar::from_repr(data)).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 "invalid field element encoding in proof",
             )
         })?;
@@ -128,8 +127,7 @@ where
     fn common_point(&mut self, point: C) -> io::Result<()> {
         self.state.update(&[BLAKE2B_PREFIX_POINT]);
         let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 "cannot write points at infinity to the transcript",
             )
         })?;
@@ -207,8 +205,7 @@ where
     fn common_point(&mut self, point: C) -> io::Result<()> {
         self.state.update(&[BLAKE2B_PREFIX_POINT]);
         let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::Other,
+            io::Error::other(
                 "cannot write points at infinity to the transcript",
             )
         })?;

--- a/halo2_proofs/src/transcript.rs
+++ b/halo2_proofs/src/transcript.rs
@@ -91,9 +91,8 @@ where
     fn read_point(&mut self) -> io::Result<C> {
         let mut compressed = C::Repr::default();
         self.reader.read_exact(compressed.as_mut())?;
-        let point: C = Option::from(C::from_bytes(&compressed)).ok_or_else(|| {
-            io::Error::other("invalid point encoding in proof")
-        })?;
+        let point: C = Option::from(C::from_bytes(&compressed))
+            .ok_or_else(|| io::Error::other("invalid point encoding in proof"))?;
         self.common_point(point)?;
 
         Ok(point)
@@ -102,11 +101,8 @@ where
     fn read_scalar(&mut self) -> io::Result<C::Scalar> {
         let mut data = <C::Scalar as PrimeField>::Repr::default();
         self.reader.read_exact(data.as_mut())?;
-        let scalar: C::Scalar = Option::from(C::Scalar::from_repr(data)).ok_or_else(|| {
-            io::Error::other(
-                "invalid field element encoding in proof",
-            )
-        })?;
+        let scalar: C::Scalar = Option::from(C::Scalar::from_repr(data))
+            .ok_or_else(|| io::Error::other("invalid field element encoding in proof"))?;
         self.common_scalar(scalar)?;
 
         Ok(scalar)
@@ -126,11 +122,8 @@ where
 
     fn common_point(&mut self, point: C) -> io::Result<()> {
         self.state.update(&[BLAKE2B_PREFIX_POINT]);
-        let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
-            io::Error::other(
-                "cannot write points at infinity to the transcript",
-            )
-        })?;
+        let coords: Coordinates<C> = Option::from(point.coordinates())
+            .ok_or_else(|| io::Error::other("cannot write points at infinity to the transcript"))?;
         self.state.update(coords.x().to_repr().as_ref());
         self.state.update(coords.y().to_repr().as_ref());
 
@@ -204,11 +197,8 @@ where
 
     fn common_point(&mut self, point: C) -> io::Result<()> {
         self.state.update(&[BLAKE2B_PREFIX_POINT]);
-        let coords: Coordinates<C> = Option::from(point.coordinates()).ok_or_else(|| {
-            io::Error::other(
-                "cannot write points at infinity to the transcript",
-            )
-        })?;
+        let coords: Coordinates<C> = Option::from(point.coordinates())
+            .ok_or_else(|| io::Error::other("cannot write points at infinity to the transcript"))?;
         self.state.update(coords.x().to_repr().as_ref());
         self.state.update(coords.y().to_repr().as_ref());
 

--- a/halo2_proofs/tests/fingerprint_export.rs
+++ b/halo2_proofs/tests/fingerprint_export.rs
@@ -170,7 +170,7 @@ fn prove() -> (
 #[test]
 fn exports_accepting_fixture() {
     let (params, pk, product, proof) = prove();
-    let pubinputs = vec![product];
+    let pubinputs = [product];
 
     // The proof verifies, so the captured fingerprint is the group identity.
     let strategy = SingleVerifier::new(&params);
@@ -273,7 +273,7 @@ fn exports_accepting_fixture() {
 #[test]
 fn rejects_non_identity_capture() {
     let (params, pk, product, proof) = prove();
-    let wrong_pubinputs = vec![product + Fp::ONE];
+    let wrong_pubinputs = [product + Fp::ONE];
 
     let mut transcript = ChallengeRecorder::<_, _, Challenge255<_>>::init(&proof[..]);
     let msm = capture_proof_fingerprint(
@@ -324,7 +324,7 @@ fn rejects_non_identity_capture() {
 #[test]
 fn exports_match_only_fixture_for_non_identity_capture() {
     let (params, pk, product, proof) = prove();
-    let wrong_pubinputs = vec![product + Fp::ONE];
+    let wrong_pubinputs = [product + Fp::ONE];
 
     let mut transcript = ChallengeRecorder::<_, _, Challenge255<_>>::init(&proof[..]);
     let msm = capture_proof_fingerprint(
@@ -401,7 +401,7 @@ fn exports_match_only_fixture_for_non_identity_capture() {
 #[test]
 fn match_only_export_rejects_identity_capture() {
     let (params, pk, product, proof) = prove();
-    let pubinputs = vec![product];
+    let pubinputs = [product];
 
     let mut transcript = ChallengeRecorder::<_, _, Challenge255<_>>::init(&proof[..]);
     let msm =

--- a/halo2_proofs/tests/plonk_api.rs
+++ b/halo2_proofs/tests/plonk_api.rs
@@ -435,7 +435,7 @@ fn plonk_api() {
     // Check this circuit is satisfied.
     let prover = match MockProver::run(K, &circuit, vec![pubinputs.clone()]) {
         Ok(prover) => prover,
-        Err(e) => panic!("{:?}", e),
+        Err(e) => panic!("{e:?}"),
     };
     assert_eq!(prover.verify(), Ok(()));
 
@@ -626,7 +626,7 @@ fn plonk_api() {
             // A rejecting capture is checked only in Rust (it is never exported to Lean): verify the
             // same proof bytes against the wrong public inputs. Every read still parses (the proof is
             // unchanged), so capture succeeds, but the assembled MSM is non-identity.
-            let wrong_pubinputs = vec![instance + Fp::ONE];
+            let wrong_pubinputs = [instance + Fp::ONE];
             let mut reject_transcript =
                 ChallengeRecorder::<_, _, Challenge255<_>>::init(&proof[..]);
             let reject_msm = capture_proof_fingerprint(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.60.0"
+channel = "1.88.0"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Upstreams signed Booth recoding for the multiexponentiation, from
https://github.com/zakura-core/libraries.

> **Stacked on #936.** The base is `dw/msrv-1.88`, not `main`. Review and merge
> #936 first; GitHub then retargets this to `main`.

`best_multiexp` currently recodes each scalar per window with unsigned digits.
This switches it to SIGNED BOOTH recoding, which roughly halves the number of
nonzero digits and so the number of bucket additions; computes each scalar's
canonical representation ONCE per MSM instead of once per window; and derives
the window schedule from that representation instead of assuming a 256-bit
scalar.

Everything is confined to one source file, `halo2_proofs/src/arithmetic.rs`.

Three of the four commits are ports and keep their original author, date and
message, with an upstreaming block appended carrying the `format-patch`
command that reproduces each one and its `Source-Commit:` trailer. The fourth
is the CHANGELOG entry.

## What a reviewer should look at

**1. Correctness of the recoding, which is the whole risk here.** A wrong digit
table produces a wrong MSM, and an MSM is used everywhere in proving and
verification. The commits bring their own guard rather than relying on the
existing `test_multiexp`: `assert_multiexp_matches_naive` compares
`best_multiexp` against the naive per-term sum,

```rust
coeffs.iter().zip(bases)
    .map(|(coeff, base)| *base * coeff)
    .fold(C::Curve::identity(), |acc, val| acc + val)
```

and three new tests drive it plus the digit function directly:
`test_booth_digit_boundaries`, `test_booth_digit_wide_representation` and
`test_multiexp_booth_boundaries`. All four multiexp tests pass.

**2. The extra window.** The bucket vector is sized `(SCALAR_BITS / c) + 1`
before the last commit and `booth_window_count(&coeffs, c)` after. The `+ 1`
captures a Booth carry above the scalar representation when `c` divides
`SCALAR_BITS`; the final form derives it instead. Worth confirming the derived
count is never short.

**3. One hunk, re-sited twice.** See below; it is the only place the port
deviates from its source.

## Provenance

Each port was checked against the `format-patch` output of its source commit:

| commit | source | result |
| --- | --- | --- |
| Precompute MSM scalar representations | `1a3f293` | identical |
| Use signed Booth recoding for multiexp | `d974e1d` | one hunk re-sited |
| Size Booth windows from scalar representations | `4bda24e` | the same hunk, re-sited again |

Both re-sites are at the same line, and for the same reason: the patch context
expects `should_parallelize_multiexp(coeffs.len(), num_threads)`, a helper
introduced by a commit outside this series. This crate still reads
`coeffs.len() > num_threads`. Only the `multi_buckets` binding was carried
over in each case; the parallelisation predicate is left exactly as it is on
this branch. The binding is also wrapped over two lines to stay within the line
width, which accounts for the rest of the difference.

## Verification

- `cargo build -p halo2_proofs`, `cargo test -p halo2_proofs`,
  `cargo clippy -p halo2_proofs --all-targets -- -D warnings`, `cargo fmt
  --check`: all clean.
- `cargo build --workspace` and `cargo test --workspace --release`: 10 suites,
  90 tests, 0 failures. The workspace suite matters here because
  `halo2_gadgets` proves real circuits through this code path.
- The four multiexp tests were run by exact name and confirmed to pass, so the
  new differential guard is known to execute rather than merely compile.
